### PR TITLE
Autoload path fix

### DIFF
--- a/robo
+++ b/robo
@@ -1,6 +1,6 @@
 #!/usr/bin/env php
 <?php
-require_once __DIR__.'/vendor/autoload.php';
+require_once __DIR__.'/../../autoload.php';
 
 $runner = new \Robo\Runner();
 $runner->execute();


### PR DESCRIPTION
It was causing `PHP Warning:  require_once(/var/www/<my-path>/vendor/codegyre/robo/vendor/autoload.php): failed to open stream: No such file or directory in...`  while calling it from project dir `ijack@ijack:/var/www/<my-path>$ ./vendor/bin/robo`
