### PR TITLE
Add PHP requirements to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "bin":["robo"],
     "require": {
         "symfony/console": "*",
+        "php": ">=5.4.0",
         "henrikbjorn/lurker" : "1.0.*@dev"
     },
     "require-dev": {


### PR DESCRIPTION
Since this project uses traits, it's restricted to 5.4+.
