### PR TITLE
WriteToFileTask should use DynamicConfig trait

### DIFF
--- a/src/Task/FileSystem.php
+++ b/src/Task/FileSystem.php
@@ -213,6 +213,8 @@ class ReplaceInFileTask implements TaskInterface
 class WriteToFileTask implements TaskInterface
 {
     use Output;
+    use DynamicConfig;
+
     protected $filename;
     protected $body = "";
     protected $append = false;


### PR DESCRIPTION
Robo\Task\WriteToFileTask should use DynamicConfig trait in order to provide access to protected $append property via _call() magic method.

See https://github.com/Codegyre/Robo/issues/10
