### PR TITLE
Fix broken options when using '--no-dev'.

### DIFF
--- a/src/Task/Composer.php
+++ b/src/Task/Composer.php
@@ -125,7 +125,7 @@ class ComposerUpdateTask extends BaseComposerTask implements TaskInterface {
     public function run()
     {
         $options = $this->prefer;
-        $this->dev ?: $options.= "--no-dev";
+        $this->dev ?: $options.= " --no-dev";
         $this->printTaskInfo('Updating Packages: '.$options);
         $line = system($this->command.' update '.$options, $code);
         return new Result($this, $code, $line);


### PR DESCRIPTION
When using '--no-dev', the command's options where being concatenated like so: '--prefer-dist--no-dev'.
