### PR TITLE
Fix error triggered in E_STRICT mode.

### DIFF
--- a/src/Task/Codeception.php
+++ b/src/Task/Codeception.php
@@ -33,7 +33,6 @@ class CodeceptionTask implements TaskInterface, CommandInterface{
 
     protected $suite = '';
     protected $test = '';
-    protected $arguments = '';
     protected $command;
 
 

--- a/src/Task/Composer.php
+++ b/src/Task/Composer.php
@@ -43,7 +43,6 @@ abstract class BaseComposerTask
     protected $prefer;
     protected $dev;
     protected $optimizeAutoloader;
-    protected $arguments;
 
     /**
      * adds `prefer-dist` option to composer


### PR DESCRIPTION
- Robo\Task\BaseComposerTask and Robo\Task\Shared\Executable define the
  same property ($arguments) in the composition of Robo\Task\BaseComposerTask.
- Robo\Task\Codeception and Robo\Task\Shared\Executable define the same
  property ($arguments) in the composition of Robo\Task\Codeception.
