### PR TITLE
If no value for an option is provided, assume it's a VALUE_NONE option.

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -123,7 +123,11 @@ class Runner {
         }
         $opts = $taskInfo->getOptions();
         foreach ($opts as $name => $val) {
-            $task->addOption($name, '', InputOption::VALUE_OPTIONAL, '', $val);
+            if (empty($val)) {
+                $task->addOption($name, '', InputOption::VALUE_NONE, '');
+            } else {
+                $task->addOption($name, '', InputOption::VALUE_OPTIONAL, '', $val);
+            }
         }
 
         return $task;


### PR DESCRIPTION
Very quickly knocked this together and it's very untested, but I was curious why options without values (e.g.) `--silent` didn't work as I expected:

```
$ robo drupal:magic /my/path
array(8) {
  ["nuke"]=>
  bool(false)
  ...
```

```
robo drupal:magic /my/path --nuke
array(8) {
  ["nuke"]=>
  bool(false)
  ...
```

```
robo drupal:magic /my/path --nuke=true
array(8) {
  ["nuke"]=>
  string(4) "true"
  ...
```

There is no checking to see if the option _should_ have a value and has been accidentally omitted (an obvious improvement to this PR), but this change makes no-value options (i.e. booleans) work as expected, IMO:

```
$ robo drupal:magic /my/path
array(8) {
  ["nuke"]=>
  bool(false)
  ...
```

```
robo drupal:magic /my/path --nuke
array(8) {
  ["nuke"]=>
  bool(true)
  ...
```

```
robo drupal:magic /my/path --nuke=true
[RuntimeException]
  The "--nonuke" option does not accept a value."
```

Note that we can still do `robo drupal:magic --anotheroption="that"`, if the option's default is a non-boolean:

``` php
public function drupalMagic($path, $opts = ['nuke' => false, 'anotheroption' => 'this'])
{ ...
```

Any thoughts?
