### PR TITLE
Remove the prefix char when running command

### DIFF
--- a/src/Task/Exec.php
+++ b/src/Task/Exec.php
@@ -134,7 +134,7 @@ class ExecTask implements TaskInterface, CommandInterface{
 
         if (!$this->background and $this->isPrinted) {
             $this->process->run(function ($type, $buffer) {
-                Process::ERR === $type ? print('ER» '.$buffer) : print('» '.$buffer);
+                Process::ERR === $type ? print('ER» '.$buffer) : print($buffer);
             });
             return new Result($this, $this->process->getExitCode(), $this->process->getOutput());
         }


### PR DESCRIPTION
Many commands have an output well format. And this prefix char will be a mess .
It is quit annoying.
