### PR TITLE
Bugfix/infinite loop in file system copy dir

### DIFF
--- a/src/Util/FileSystem.php
+++ b/src/Util/FileSystem.php
@@ -18,21 +18,17 @@ class FileSystem extends SfFilesystem
 
         foreach ($iterator as $path) {
             if ($path->isDir()) {
-                $dir = (string) $path;
+                $dir = (string)$path;
                 if (basename($dir) === '.' || basename($dir) === '..') {
                     continue;
                 }
                 $this->remove($dir);
             } else {
                 $file = (string)$path;
-                if (basename($file) === '.gitignore') {
+                if (basename($file) === '.gitignore' || basename($file) === '.gitkeep') {
                     continue;
                 }
-                if (basename($file) === '.gitkeep') {
-                    continue;
-                }
-
-                $this->remove($path->__toString());
+                $this->remove($file);
             }
         }
     }
@@ -49,13 +45,14 @@ class FileSystem extends SfFilesystem
             throw new TaskException(__CLASS__, "Cannot open source directory '" . $src . "'");
         }
         @mkdir($dst);
-        while(false !== ( $file = readdir($dir)) ) {
-            if (( $file != '.' ) && ( $file != '..' )) {
-                if ( is_dir($src . '/' . $file) ) {
-                    self::copyDir($src . '/' . $file,$dst . '/' . $file);
-                }
-                else {
-                    copy($src . '/' . $file,$dst . '/' . $file);
+        while (false !== ($file = readdir($dir))) {
+            if (($file !== '.') && ($file !== '..')) {
+                $srcFile = $src . '/' . $file;
+                $destFile = $dst . '/' . $file;
+                if (is_dir($srcFile)) {
+                    self::copyDir($srcFile, $destFile);
+                } else {
+                    copy($srcFile, $destFile);
                 }
             }
         }


### PR DESCRIPTION
This came up since our Robo tasks are used in multiple projects.
One project did not have one of the directories to be copied.
The while loop never ended and killed our CI server with "no space left on device" ;)

From my perspective, throwing an Exception is reasonable (instead of simply emit a warning and go on), since if you want to copy a directory in a Task and it cannot be opened (whether it be because the directory does not exist or access rights problems), this denotes a problem.

In our generic tasks, we will check for the existance of the directory ourselves.

(the second commit makes the code PSR-2 compliant).
