### PR TITLE
Added missing umask argument to chmod() method of FileSystemStack

### DIFF
--- a/src/Task/FileSystem.php
+++ b/src/Task/FileSystem.php
@@ -399,13 +399,13 @@ class FileSystemStackTask implements TaskInterface
 
     public function copy($from, $to, $force = false)
     {
-        $this->stack[] = array_merge([__FUNCTION__], func_get_args());
+        $this->stack[] = array_merge([__FUNCTION__], compact('from', 'to', 'force'));
         return $this;
     }
 
     public function chmod($file, $permissions, $umask = 0000, $recursive = true)
     {
-        $this->stack[] = array_merge([__FUNCTION__], func_get_args());
+        $this->stack[] = array_merge([__FUNCTION__], compact('file', 'permissions', 'umask', 'recursive'));
         return $this;
     }
 


### PR DESCRIPTION
Fixes "ERROR: Unsupported operand types" when providing more than two arguments.
