### PR TITLE
Equalized Filesystem defaults

### DIFF
--- a/src/Task/FileSystem.php
+++ b/src/Task/FileSystem.php
@@ -403,7 +403,7 @@ class FileSystemStackTask implements TaskInterface
         return $this;
     }
 
-    public function chmod($file, $permissions, $umask = 0000, $recursive = true)
+    public function chmod($file, $permissions, $umask = 0000, $recursive = false)
     {
         $this->stack[] = array_merge([__FUNCTION__], func_get_args());
         return $this;


### PR DESCRIPTION
Reverted default arguments handling and equalized defaults to those of Symfony Filesystem for simplicity.

See #78
