### PR TITLE
Handle option shortcuts

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -126,10 +126,17 @@ class Runner {
         $opts = $taskInfo->getOptions();
         foreach ($opts as $name => $val) {
             $description = $taskInfo->getOptionDescription($name);
+
+            $fullname = $name;
+            $shortcut = '';
+            if (strpos($name, '|')) {
+              list($fullname, $shortcut) = explode('|', $name, 2);
+            }
+
             if (is_bool($val)) {
-                $task->addOption($name, '', InputOption::VALUE_NONE, $description);
+                $task->addOption($fullname, $shortcut, InputOption::VALUE_NONE, $description);
             } else {
-                $task->addOption($name, '', InputOption::VALUE_OPTIONAL, $description, $val);
+                $task->addOption($fullname, $shortcut, InputOption::VALUE_OPTIONAL, $description, $val);
             }
         }
 


### PR DESCRIPTION
Robo doesn't provide a way specify option shortcuts, though Symfony's addOption() accepts one as the second argument.  Consider this an idea of how it might be implemented, if it's not on the roadmap already.  If the idea needs more work please let me know, feedback is appreciated.

If the option name is in the form "foo|f", then \Robo\Runner::createCommand() would call $task->addOption('foo', 'f', ...).
