### PR TITLE
Use PHP_WINDOWS_VERSION_BUILD to check for Windows in test tasks

### DIFF
--- a/src/Task/Codeception.php
+++ b/src/Task/Codeception.php
@@ -42,6 +42,9 @@ class CodeceptionTask implements TaskInterface, CommandInterface{
             $this->command = "$pathToCodeception run";
         } elseif (file_exists('vendor/bin/codecept')) {
             $this->command = 'vendor/bin/codecept run';
+            if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+                $this->command = 'call ' . $this->command;
+            }
         } elseif (file_exists('codecept.phar')) {
             $this->command = 'php codecept.phar run';
 		} else {

--- a/src/Task/PHPUnit.php
+++ b/src/Task/PHPUnit.php
@@ -39,8 +39,9 @@ class PHPUnitTask implements TaskInterface, CommandInterface
             $this->command = $pathToPhpUnit;
         } elseif (file_exists('vendor/bin/phpunit')) {
             $this->command = 'vendor/bin/phpunit';
-        } elseif (!empty($_SERVER['windir'])) {
-            $this->command = 'call ' . $this->command;
+            if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+                $this->command = 'call ' . $this->command;
+            }
         } elseif (file_exists('phpunit.phar')) {
             $this->command = 'php phpunit.phar';
         } elseif (is_executable('/usr/bin/phpunit')) {


### PR DESCRIPTION
Symfony Process also does it like that (which is used to execute the command).

`!empty($_SERVER['windir'])` did not work for me.
Tested it with normal CMD and Git Bash.

(This also fixes the bug introduced in https://github.com/Codegyre/Robo/commit/b53fe4cf44f784c9bf6d8a88d8b631784e8e0d2b#diff-f2bf6c27b538bfc61de4fb46d65d0f9dR41)
