### PR TITLE
continue on fail for command stack

### DIFF
--- a/src/Task/Base/ExecStack.php
+++ b/src/Task/Base/ExecStack.php
@@ -24,10 +24,4 @@ use Robo\Task\Base;
  */
 class ExecStack extends CommandStack
 {
-
-  public function getCommand()
-  {
-    return implode($this->stopOnFail ? ' && ' : ' ; ', $this->exec);
-  }
-
 }

--- a/src/Task/Base/ExecStack.php
+++ b/src/Task/Base/ExecStack.php
@@ -24,4 +24,10 @@ use Robo\Task\Base;
  */
 class ExecStack extends CommandStack
 {
+
+  public function getCommand()
+  {
+    return implode($this->stopOnFail ? ' && ' : ' ; ', $this->exec);
+  }
+
 }

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -21,7 +21,7 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
 
     public function getCommand()
     {
-        return implode(' && ', $this->exec);
+      return implode($this->stopOnFail ? ' && ' : ' ; ', $this->exec);
     }
 
     public function exec($command)

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -21,7 +21,7 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
 
     public function getCommand()
     {
-        return implode(' && ', $this->exec);
+        return implode(' ; ', $this->exec);
     }
 
     public function exec($command)

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -21,7 +21,7 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
 
     public function getCommand()
     {
-        return implode(' ; ', $this->exec);
+        return implode(' && ', $this->exec);
     }
 
     public function exec($command)

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -17,7 +17,7 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
     protected $executable;
     protected $result;
     protected $exec = [];
-    protected $stopOnFail = false;
+    protected $stopOnFail = true;
 
     public function getCommand()
     {

--- a/src/Task/Vcs/SvnStack.php
+++ b/src/Task/Vcs/SvnStack.php
@@ -28,7 +28,7 @@ use Robo\Task\CommandStack;
  */
 class SvnStack extends CommandStack implements CommandInterface
 {
-    protected $stopOnFail = false;
+    protected $stopOnFail = true;
     protected $result;
 
     public function __construct($username='', $password='', $pathToSvn = 'svn')

--- a/tests/unit/ExecTaskTest.php
+++ b/tests/unit/ExecTaskTest.php
@@ -58,6 +58,6 @@ class ExecTaskTest extends \Codeception\TestCase\Test
             ->exec('cd /')
             ->exec('cd home')
             ->getCommand()
-        )->equals('ls && cd / && cd home');
+        )->equals('ls ; cd / ; cd home');
     }
 };

--- a/tests/unit/ExecTaskTest.php
+++ b/tests/unit/ExecTaskTest.php
@@ -58,6 +58,6 @@ class ExecTaskTest extends \Codeception\TestCase\Test
             ->exec('cd /')
             ->exec('cd home')
             ->getCommand()
-        )->equals('ls ; cd / ; cd home');
+        )->equals('ls && cd / && cd home');
     }
 };

--- a/tests/unit/GitTest.php
+++ b/tests/unit/GitTest.php
@@ -25,7 +25,7 @@ class GitTest extends \Codeception\TestCase\Test
         $this->git->verifyInvoked('executeCommand', ['git pull']);
 
         $this->taskGitStack('git')->add('-A')->pull()->run();
-        $this->git->verifyInvoked('executeCommand', ['git add -A && git pull']);
+        $this->git->verifyInvoked('executeCommand', ['git add -A ; git pull']);
     }
 
     public function testGitStackCommands()


### PR DESCRIPTION
Fix for the following so COMMAND2 runs if COMMAND1 fails.

$this->taskExecStack()
  ->stopOnFail(FALSE)
  ->exec("COMMAND1")
  ->exec("COMMAND2")
  ->run();

currently executes "COMMAND1 && COMMAND2" which if COMMAND1 fails COMMAND2 is never executed.

This pull request changes it so executes "COMMAND1 ; COMMAND2" so COMMAND2 is executed even if COMMAND1 fails.