### PR TITLE
add Exec::getProcess() which returns the internal Symfony Process instance

### DIFF
--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -154,6 +154,17 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface
         return Result::success($this);
     }
 
+    /**
+     * Returns the Symfony process instance.
+     * If `run()` has not been called before, NULL is returned.
+     *
+     * @return Process
+     */
+    public function getProcess()
+    {
+        return $this->process;
+    }
+
     static function stopRunningJobs()
     {
         foreach (self::$instances as $instance) {

--- a/tests/unit/Task/ExecTaskTest.php
+++ b/tests/unit/Task/ExecTaskTest.php
@@ -41,6 +41,21 @@ class ExecTaskTest extends \Codeception\TestCase\Test
         verify($this->taskExec('ls')->getCommand())->equals('ls');
     }
 
+    public function testGetProcessReturnsNullIfNotStarted()
+    {
+        verify($this->taskExec('ls')->getProcess())->equals(null);
+    }
+
+    public function testGetProcessReturnsProcessInstanceIfStarted()
+    {
+        $result = $this->taskExec('ls')->run();
+
+        /** @var \Robo\Task\Base\Exec $task */
+        $task = $result->getTask();
+        $process = $task->getProcess();
+        $this->assertInstanceOf('Symfony\Component\Process\Process', $process);
+    }
+
     public function testExecStack()
     {
         $this->taskExecStack()


### PR DESCRIPTION
The easy, versatile and future-proof way was to just return the Process instance itself (and e.g. not give the Result object another parameter for error output).

This fixes #286