### PR TITLE
Work-in-progress: use ProcessBuilder API with Exec chained initializers.

### DIFF
--- a/src/Common/CommandArguments.php
+++ b/src/Common/CommandArguments.php
@@ -1,12 +1,53 @@
 <?php
 namespace Robo\Common;
 
+use Symfony\Component\Process\ProcessBuilder;
+
 /**
  * Use this to add arguments and options to the $arguments property.
  */
 trait CommandArguments
 {
-    protected $arguments = '';
+    private $processBuilder;
+    private $preEscapedCommand;
+    private $workingDirectory;
+
+    public function hasProcessBuilder()
+    {
+        return isset($this->processBuilder);
+    }
+
+    /**
+     * Provides direct access to the process builder to set up
+     * args, options, redirection, etc. for the command.
+     */
+    protected function getProcessBuilder()
+    {
+        if (!$this->hasProcessBuilder()) {
+            $this->processBuilder = new ProcessBuilder();
+        }
+        return $this->processBuilder;
+    }
+
+    /**
+     * Tasks can override getCommand to alter the process builder
+     * once the  command has been set up.  Alterations should be
+     * idempotent.
+     */
+    public function getCommand()
+    {
+        if (!empty($this->preEscapedCommand)) {
+            $result = $this->preEscapedCommand;
+            if ($this->hasProcessBuilder()) {
+                $result = trim($result . ' ' . $this->getProcessBuilder()->getProcess()->getCommandLine());
+            }
+            return $result;
+        }
+        if (!$this->hasProcessBuilder()) {
+            throw new TaskException($this, 'Please define a command');
+        }
+        return $this->getProcessBuilder();
+    }
 
     /**
      * Pass argument to executable
@@ -16,7 +57,8 @@ trait CommandArguments
      */
     public function arg($arg)
     {
-        return $this->args($arg);
+        $this->args($arg);
+        return $this;
     }
 
     /**
@@ -30,7 +72,9 @@ trait CommandArguments
         if (!is_array($args)) {
             $args = func_get_args();
         }
-        $this->arguments .= " ".implode(' ', $args);
+        foreach ($args as $arg) {
+            $this->getProcessBuilder()->add($arg);
+        }
         return $this;
     }
 
@@ -42,38 +86,139 @@ trait CommandArguments
      *
      * @param $option
      * @param string $value
+     * $param string $sep ' ' or '='
      * @return $this
      */
-    public function option($option, $value = null)
+    public function option($option, $value = null, $sep = ' ')
     {
         if ($option !== null and strpos($option, '-') !== 0) {
             $option = "--$option";
         }
-        $this->arguments .= null == $option ? '' : " " . $option;
-        $this->arguments .= null == $value ? '' : " " . $value;
+        if (isset($value)) {
+            $option .= $sep . $value;
+        }
+        $this->arg($option);
         return $this;
     }
 
     /**
      * Pass multiple options to executable. Value can be a string or array.
      *
-     * Option values should be provided in raw, unescaped form; they are always
-     * escaped via escapeshellarg in this function.
+     * Option values should be provided in raw, unescaped form. They will be
+     * escaped.
      *
      * @param $option
      * @param string|array $value
      * @return $this
      */
-    public function optionList($option, $value = array())
+    public function optionList($option, $value = array(), $sep = ' ')
     {
         if (is_array($value)) {
             foreach ($value as $item) {
-                $this->optionList($option, $item);
+                $this->optionList($option, $item, $sep);
             }
         } else {
-            $this->option($option, escapeshellarg($value));
+            $this->option($option, $value, $sep);
         }
 
+        return $this;
+    }
+
+    /**
+     * Some tasks allow an entire pre-escaped commandline to
+     * be passed in via the task constructor as an alternative
+     * to using chained initializer methods.  This is generally
+     * not recommended, save for simple commands that require
+     * no escaping, as escaping rules are platform-specific.
+     *
+     * @param string $command Commandline to execute, already escaped.
+     */
+    public function setPreEscapedCommand($command)
+    {
+        $this->preEscapedCommand = $command;
+    }
+
+    public function setExecutableCommand($prefix)
+    {
+        $this->getProcessBuilder()->setPrefix($prefix);
+        $this->preEscapedCommand = null;
+        return $this;
+    }
+
+    public function dir($cwd)
+    {
+        $this->workingDirectory = $cwd;
+        $this->getProcessBuilder()->setWorkingDirectory($cwd);
+        return $this;
+    }
+
+    public function hasWorkingDirectory()
+    {
+        return isset($this->workingDirectory);
+    }
+
+    public function getWorkingDirectory()
+    {
+        return $this->workingDirectory;
+    }
+
+    public function inheritEnvironmentVariables($inheritEnv = true)
+    {
+        $this->getProcessBuilder()->inheritEnvironmentVariables($inheritEnv);
+        return $this;
+    }
+
+    /**
+     * Sets the environment variables for the command
+     *
+     * @param $env
+     * @return $this
+     */
+    public function env(array $env)
+    {
+        $this->getProcessBuilder()->addEnvironmentVariables($env);
+        return $this;
+    }
+
+    public function setEnv($name, $value)
+    {
+        $this->getProcessBuilder()->setEnv($name, $value);
+        return $this;
+    }
+
+    public function setInput($input)
+    {
+        $this->getProcessBuilder()->setInput($input);
+        return $this;
+    }
+
+    public function timeout($timeout)
+    {
+        $this->getProcessBuilder()->setTimeout($timeout);
+        return $this;
+    }
+
+    public function idleTimeout($timeout)
+    {
+        $this->getProcessBuilder()->setIdleTimeout($timeout);
+        return $this;
+    }
+
+    public function setProcOpenOption($name, $value)
+    {
+        $this->getProcessBuilder()->setOption($name, $value);
+        return $this;
+    }
+
+    public function disableOutput()
+    {
+        $this->getProcessBuilder()->disableOutput();
+        return $this;
+    }
+
+    public function enableOutput()
+    {
+        $this->getProcessBuilder()->enableOutput();
         return $this;
     }
 }

--- a/src/Common/CommandReceiver.php
+++ b/src/Common/CommandReceiver.php
@@ -3,26 +3,41 @@ namespace Robo\Common;
 
 use Robo\Contract\CommandInterface;
 use Robo\Exception\TaskException;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * This task can receive commands from task implementing CommandInterface.
+ * It is also permissible to pass in a prepared command string, a
+ * Symfony\Component\Process\ProcessBuilder object, or a constructed
+ * Symfony\Component\Process\Process object.
  */
 trait CommandReceiver
 {
     /**
      * @param $command
      * @throws \Robo\Exception\TaskException
-     * @return string $command
+     * @return Symfony\Component\Process\Process
      */
     protected function receiveCommand($command)
     {
-        if (!is_object($command)) {
-            return $command;
-        }
         if ($command instanceof CommandInterface) {
-            return $command->getCommand();
-        } else {
+            $command = $command->getCommand();
+        }
+        if (is_string($command)) {
+            $command = new Process(trim($command));
+        }
+        if (is_array($command)) {
+            $command = new ProcessBuilder(array_filter($command));
+        }
+        if ($command instanceof ProcessBuilder) {
+            $command = $command->getProcess();
+        }
+
+        if (!$command instanceof Process) {
             throw new TaskException($this, get_class($command) . " does not implement CommandInterface, so can't be passed into this task");
         }
+
+        return $command;
     }
 }

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Process\Process;
 trait ExecCommand
 {
     protected $isPrinted = true;
-    protected $workingDirectory;
     protected $execTimer;
 
     protected function getExecTimer()
@@ -31,18 +30,6 @@ trait ExecCommand
     {
         return $this->isPrinted;
     }
-
-    /**
-     * changes working directory of command
-     * @param $dir
-     * @return $this
-     */
-    public function dir($dir)
-    {
-        $this->workingDirectory = $dir;
-        return $this;
-    }
-
 
     /**
      * Should command output be printed
@@ -110,10 +97,10 @@ trait ExecCommand
      */
     protected function executeCommand($command)
     {
-        $process = new Process($command);
-        $process->setTimeout(null);
-        if ($this->workingDirectory) {
-            $process->setWorkingDirectory($this->workingDirectory);
+        $process = $command;
+        if (!$command instanceof Process) {
+            $process = new Process($command);
+            $process->setTimeout(null);
         }
         $this->getExecTimer()->start();
         if ($this->isPrinted) {

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -9,6 +9,7 @@ use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Robo\Contract\ProgressIndicatorAwareInterface;
+use Symfony\Component\Process\Process;
 
 /**
  * Task input/output methods.  TaskIO is 'used' in BaseTask, so any
@@ -182,6 +183,9 @@ trait TaskIO
         }
         if (!array_key_exists('task', $context)) {
             $context['task'] = $this;
+        }
+        if (array_key_exists('command', $context) && ($context['command'] instanceof Process)) {
+            $context['command'] = $context['command']->getCommandLine();
         }
 
         return $context + TaskInfo::getTaskContext($context['task']);

--- a/src/Contract/CommandInterface.php
+++ b/src/Contract/CommandInterface.php
@@ -14,7 +14,7 @@ interface CommandInterface
      * Returns command that can be executed.
      * This method is used to pass generated command from one task to another.
      *
-     * @return string
+     * @return string|Symfony\Component\Process\ProcessBuilder|Symfony\Component\Process\Process
      */
     public function getCommand();
 }

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -49,7 +49,7 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
 
     public function process($command)
     {
-        $this->processes[] = new Process($this->receiveCommand($command));
+        $this->processes[] = $this->receiveCommand($command);
         return $this;
     }
 

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -54,7 +54,7 @@ class Rsync extends BaseTask implements CommandInterface
 {
     use \Robo\Common\ExecOneCommand;
 
-    protected $command;
+    protected $pathspecsAdded;
 
     protected $fromUser;
 
@@ -75,7 +75,7 @@ class Rsync extends BaseTask implements CommandInterface
 
     public function __construct()
     {
-        $this->command = 'rsync';
+        $this->setExecutableCommand('rsync');
     }
 
     /**
@@ -291,7 +291,7 @@ class Rsync extends BaseTask implements CommandInterface
 
     public function remoteShell($command)
     {
-        $this->option('rsh', "'$command'");
+        $this->option('rsh', $command);
 
         return $this;
     }
@@ -303,7 +303,6 @@ class Rsync extends BaseTask implements CommandInterface
     {
         $command = $this->getCommand();
         $this->printTaskInfo("Running {command}", ['command' => $command]);
-
         return $this->executeCommand($command);
     }
 
@@ -315,10 +314,16 @@ class Rsync extends BaseTask implements CommandInterface
      */
     public function getCommand()
     {
-        $this->option(null, escapeshellarg($this->getFromPathSpec()))
-            ->option(null, escapeshellarg($this->getToPathSpec()));
+        $this->addPathSpecs();
+        return parent::getCommand();
+    }
 
-        return $this->command . $this->arguments;
+    protected function addPathSpecs()
+    {
+        if (!$this->pathspecsAdded) {
+            $this->args($this->getFromPathSpec(), $this->getToPathSpec());
+            $this->pathspecsAdded = true;
+        }
     }
 
     protected function getFromPathSpec()

--- a/tests/unit/Task/ExecTaskTest.php
+++ b/tests/unit/Task/ExecTaskTest.php
@@ -42,7 +42,7 @@ class ExecTaskTest extends \Codeception\TestCase\Test
 
     public function testGetCommand()
     {
-        verify($this->container->get('taskExec', ['ls'])->getCommand())->equals('ls');
+        verify($this->container->get('taskExec', ['ls'])->getCommand()->getCommandLine())->equals('ls');
     }
 
     public function testExecStack()


### PR DESCRIPTION
Not all of the code has been updated to use the changes introduced in this PR -- hence the failing tests.

This might be best saved for the Robo 2.x branch; however, I do think it will be important to escape the parameters to `arg()` and `option()` in Exec chained initializers.