### PR TITLE
Backs out #396: Remove --supress-messages.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -21,10 +21,6 @@ class Application extends SymfonyApplication
             ->addOption(
                 new InputOption('--progress-delay', null, InputOption::VALUE_REQUIRED, 'Number of seconds before progress bar is displayed in long-running task collections. Default: 2s.', Config::DEFAULT_PROGRESS_DELAY)
             );
-        $this->getDefinition()
-            ->addOption(
-                new InputOption('--supress-messages', null, InputOption::VALUE_NONE, 'Supress all Robo TaskIO messages.')
-            );
     }
 
     public function addInitRoboFileCommand($roboFile, $roboClass)

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -114,7 +114,7 @@ trait TaskIO
     protected function printTaskOutput($level, $text, $context)
     {
         $logger = $this->logger();
-        if (($this->getConfig() && $this->getConfig()->isSupressed()) || !$logger) {
+        if (!$logger) {
             return;
         }
         // Hide the progress indicator, if it is visible.

--- a/src/Config.php
+++ b/src/Config.php
@@ -6,7 +6,6 @@ class Config
     const PROGRESS_BAR_AUTO_DISPLAY_INTERVAL = 'progress-delay';
     const DEFAULT_PROGRESS_DELAY = 2;
     const SIMULATE = 'simulate';
-    const SUPRESS_MESSAGES = 'supress-messages';
     const DECORATED = 'decorated';
 
     protected $config = [];
@@ -48,7 +47,6 @@ class Config
         [
             self::PROGRESS_BAR_AUTO_DISPLAY_INTERVAL => self::DEFAULT_PROGRESS_DELAY,
             self::SIMULATE => false,
-            self::SUPRESS_MESSAGES => false,
         ];
 
         return $globalOptions;
@@ -84,16 +82,6 @@ class Config
     public function setDecorated($decorated = true)
     {
         return $this->set(self::DECORATED, $decorated);
-    }
-
-    public function isSupressed()
-    {
-        return $this->get(self::SUPRESS_MESSAGES);
-    }
-
-    public function setSupressed($supressed = true)
-    {
-        return $this->set(self::SUPRESS_MESSAGES, $supressed);
     }
 
     public function setProgressBarAutoDisplayInterval($interval)


### PR DESCRIPTION
For the casual Robo user, this option is not sufficiently different than --quiet. Applications that wish to alter the way that Robo handles status messages should override Robo's default container as described in docs/framework.md.