### PR TITLE
Fix a bug in PHPUnit task: specifying a directory caused infinite loop.

### DIFF
--- a/src/Task/Testing/PHPUnit.php
+++ b/src/Task/Testing/PHPUnit.php
@@ -20,7 +20,9 @@ use Robo\Task\BaseTask;
  */
 class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
 {
-    use \Robo\Common\ExecOneCommand;
+    use \Robo\Common\ExecOneCommand {
+        dir as execOneCommandDir;
+    }
 
     /**
      * @var string
@@ -189,7 +191,7 @@ class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
      */
     public function dir($dir)
     {
-        return $this->dir($dir);
+        return $this->execOneCommandDir($dir);
     }
 
     /**

--- a/src/Task/Testing/PHPUnit.php
+++ b/src/Task/Testing/PHPUnit.php
@@ -20,9 +20,7 @@ use Robo\Task\BaseTask;
  */
 class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
 {
-    use \Robo\Common\ExecOneCommand {
-        dir as execOneCommandDir;
-    }
+    use \Robo\Common\ExecOneCommand;
 
     /**
      * @var string
@@ -180,18 +178,6 @@ class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
     public function file($file)
     {
         return $this->files($file);
-    }
-
-    /**
-     * Test all of the files in the provided directory.
-     *
-     * @param string $dir path to directory to test
-     *
-     * @return $this
-     */
-    public function dir($dir)
-    {
-        return $this->execOneCommandDir($dir);
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [x] Needs tests
- [ ] Breaks backwards compatibility

### Summary
Fix a bug in PHPUnit task: specifying a directory caused infinite loop.

### Description
The dir function is currently only calling itself, causing an infinite loop. I'm assuming the intention was to call ExecOneCommand::dir instead. 

This fix relieves the method naming conflict and calls the aliased method.