### PR TITLE
Fix PHP error in Minify

### DIFF
--- a/src/Task/Assets/Minify.php
+++ b/src/Task/Assets/Minify.php
@@ -266,7 +266,7 @@ class Minify extends BaseTask
         $size_after = strlen($minified);
 
         // Minification did not reduce file size, so use original file.
-        if($size_after > $size_before) {
+        if ($size_after > $size_before) {
             $minified = $this->text;
             $size_after = $size_before;
         }

--- a/src/Task/Assets/Minify.php
+++ b/src/Task/Assets/Minify.php
@@ -263,7 +263,14 @@ class Minify extends BaseTask
             return Result::error($this, 'Minification failed.');
         }
 
-        $size_after = min($size_before, strlen($minified));
+        $size_after = strlen($minified);
+
+        // Minification did not reduce file size, so use original file.
+        if($size_after > $size_before) {
+            $minified = $this->text;
+            $size_after = $size_before;
+        }
+
         $dst = $this->dst . '.part';
         $write_result = file_put_contents($dst, $minified);
 

--- a/src/Task/Assets/Minify.php
+++ b/src/Task/Assets/Minify.php
@@ -263,7 +263,6 @@ class Minify extends BaseTask
             return Result::error($this, 'Minification failed.');
         }
 
-        $size_after = strlen($minified);
         $dst = $this->dst . '.part';
         $write_result = file_put_contents($dst, $minified);
 

--- a/src/Task/Assets/Minify.php
+++ b/src/Task/Assets/Minify.php
@@ -263,6 +263,7 @@ class Minify extends BaseTask
             return Result::error($this, 'Minification failed.');
         }
 
+        $size_after = min($size_before, strlen($minified));
         $dst = $this->dst . '.part';
         $write_result = file_put_contents($dst, $minified);
 


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Needs tests

### Summary

Fixes #254.

### Description

If the minified size of a file was greater than the original size a PHP
error would be thrown. This would happen if you tried to minifed files
that had already been minifed.
This fix stops the minifed size being greater than the original size.