### PR TITLE
Ensure that php code sniffer is not included in robo.phar. Allow Rsyn…

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -270,23 +270,16 @@ class RoboFile extends \Robo\Tasks
             ->taskFilesystemStack()
                 ->mkdir($workDir)
             ->taskRsync()
-                ->fromPath(__DIR__ . '/')
-                ->toPath($roboBuildDir)
-                ->recursive()
-                ->exclude(
+                ->fromPath(
                     [
-                        'vendor/',
-                        '.idea/',
-                        'build',
-                        'site/',
-                        'robotheme/',
-                        'tests/_log',
-                        'tests/_helpers/_generated',
-                        'composer.phar',
-                        'composer.lock',
-                        'robo.phar',
+                        __DIR__ . '/composer.json',
+                        __DIR__ . '/scripts',
+                        __DIR__ . '/src',
+                        __DIR__ . '/data'
                     ]
                 )
+                ->toPath($roboBuildDir)
+                ->recursive()
                 ->progress()
                 ->stats()
             ->taskComposerRemove()

--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "44a17ce3e707f5df1cb0dea6bdddd1ba0291aab4"
+                "reference": "0bcb15e86b8bfbb1972fc6bc31b7d9c3fa40285d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/44a17ce3e707f5df1cb0dea6bdddd1ba0291aab4",
-                "reference": "44a17ce3e707f5df1cb0dea6bdddd1ba0291aab4",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/0bcb15e86b8bfbb1972fc6bc31b7d9c3fa40285d",
+                "reference": "0bcb15e86b8bfbb1972fc6bc31b7d9c3fa40285d",
                 "shasum": ""
             },
             "require": {
@@ -26,14 +26,14 @@
                 "php": ">=5.4.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "psr/log": "~1",
-                "squizlabs/php_codesniffer": "^2.7",
                 "symfony/console": "^2.8|~3",
                 "symfony/event-dispatcher": "^2.5|~3",
                 "symfony/finder": "^2.5|~3"
             },
             "require-dev": {
                 "phpunit/phpunit": "4.*",
-                "satooshi/php-coveralls": "^1.0"
+                "satooshi/php-coveralls": "^1.0",
+                "squizlabs/php_codesniffer": "^2.7"
             },
             "type": "library",
             "extra": {
@@ -57,7 +57,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2016-11-14 18:47:37"
+            "time": "2016-11-14 23:51:12"
         },
         {
             "name": "consolidation/log",
@@ -438,84 +438,6 @@
                 "psr-3"
             ],
             "time": "2016-10-10 12:19:37"
-        },
-        {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
-                "shasum": ""
-            },
-            "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
-                }
-            ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
-            "keywords": [
-                "phpcs",
-                "standards"
-            ],
-            "time": "2016-09-01 23:53:02"
         },
         {
             "name": "symfony/console",
@@ -3187,6 +3109,84 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-02-04 12:56:52"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
+                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2016-09-01 23:53:02"
         },
         {
             "name": "symfony/browser-kit",

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -106,7 +106,7 @@ class Rsync extends BaseTask implements CommandInterface
      * This can either be a full rsync path spec (user@host:path) or just a path.
      * In case of the former do not specify host and user.
      *
-     * @param string $path
+     * @param string|array $path
      *
      * @return $this
      */
@@ -445,8 +445,10 @@ class Rsync extends BaseTask implements CommandInterface
      */
     public function getCommand()
     {
-        $this->option(null, $this->getFromPathSpec())
-            ->option(null, $this->getToPathSpec());
+        foreach ((array)$this->fromPath as $from) {
+            $this->option(null, $this->getFromPathSpec($from));
+        }
+        $this->option(null, $this->getToPathSpec());
 
         return $this->command . $this->arguments;
     }
@@ -454,9 +456,9 @@ class Rsync extends BaseTask implements CommandInterface
     /**
      * @return string
      */
-    protected function getFromPathSpec()
+    protected function getFromPathSpec($from)
     {
-        return $this->getPathSpec($this->fromHost, $this->fromUser, $this->fromPath);
+        return $this->getPathSpec($this->fromHost, $this->fromUser, $from);
     }
 
     /**

--- a/tests/unit/Task/RsyncTest.php
+++ b/tests/unit/Task/RsyncTest.php
@@ -32,6 +32,7 @@ class RsyncTest extends \Codeception\TestCase\Test
                 'rsync --recursive --exclude .git --exclude .svn --exclude .hg --checksum --whole-file --verbose --progress --human-readable --stats src/ \'dev@localhost:/var/www/html/app/\''
         );
 
+        // From the folder 'foo bar' (with space) in 'src' directory
         verify(
             (new \Robo\Task\Remote\Rsync())
                 ->fromPath('src/foo bar/baz')
@@ -41,6 +42,18 @@ class RsyncTest extends \Codeception\TestCase\Test
                 ->getCommand()
         )->equals(
                 'rsync \'src/foo bar/baz\' \'dev@localhost:/var/path/with/a space\''
+        );
+
+        // Copy two folders, 'src/foo' and 'src/bar'
+        verify(
+            (new \Robo\Task\Remote\Rsync())
+                ->fromPath(['src/foo', 'src/bar'])
+                ->toHost('localhost')
+                ->toUser('dev')
+                ->toPath('/var/path/with/a space')
+                ->getCommand()
+        )->equals(
+                'rsync src/foo src/bar \'dev@localhost:/var/path/with/a space\''
         );
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Needs tests

### Summary
Ensure that size of phar remains reasonable (2.2M needed, rather than >4M)

### Description
The php code sniffer was being included in the phar.  This PR fixes that, and also improves the Rsync task so that the phar:build command can copy via a whitelist instead of a blacklist.