### PR TITLE
Improve Robo version management

### DIFF
--- a/src/Robo.php
+++ b/src/Robo.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Application as SymfonyApplication;
 class Robo
 {
     const APPLICATION_NAME = 'Robo';
-    const VERSION = '1.0.5';
+    const VERSION = '1.0.5-dev';
 
     /**
      * The currently active container object, or NULL if not initialized yet.


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests for covered functionality

### Summary
Keep the version at '-dev' between releases

### Description
To reduce confusion, this PR ensures that the Robo version will always end in '-dev' between releases.  The '-dev' modifier is removed during the release process, and put back again at the end.  The --beta flag is still supported; it will advance through beta1, beta2 and so on, if used.

Major and minor version advances will still need to be done by hand prior to release.

Changes are all to the main RoboFile, which has no tests; therefore, there are no tests in this PR either.