### PR TITLE
Fix: look for project bin directory in current working directory

### DIFF
--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -135,7 +135,8 @@ trait ExecCommand
      */
     protected function findProjectBin()
     {
-        $candidates = [ __DIR__ . '/../../vendor/bin', __DIR__ . '/../../bin' ];
+        $cwd = getcwd();
+        $candidates = [ __DIR__ . '/../../vendor/bin', __DIR__ . '/../../bin', $cwd . '/vendor/bin' ];
 
         // If this project is inside a vendor directory, give highest priority
         // to that directory.


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Needs tests

### Summary
This allows a globally installed Robo to resolve an executable
installed locally in `vendor/bin` under the current working directory.

### Description
The use case that lead me to this fix is having a locally installed phpunit, and a globally installed robo. Prior to the fix, it would fail to resolve the phpunit executable, whereas it resolved it just fine prior to version 1.x.

Signed-off-by: Antoine Busque <antoine.busque@pillrcompany.com>