### PR TITLE
Removed redundant @method tags & unused imports

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -1,7 +1,5 @@
 <?php
 use Symfony\Component\Finder\Finder;
-use Robo\Result;
-use Robo\Collection\CollectionBuilder;
 
 class RoboFile extends \Robo\Tasks
 {

--- a/examples/RoboFile.php
+++ b/examples/RoboFile.php
@@ -1,7 +1,5 @@
 <?php
 use Robo\Result;
-use Robo\ResultData;
-use Robo\Collection\CollectionBuilder;
 
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\OutputFormatters\Options\FormatterOptions;

--- a/src/Application.php
+++ b/src/Application.php
@@ -3,8 +3,6 @@ namespace Robo;
 
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 
 class Application extends SymfonyApplication

--- a/src/Collection/CallableTask.php
+++ b/src/Collection/CallableTask.php
@@ -3,7 +3,6 @@ namespace Robo\Collection;
 
 use Robo\Result;
 use Robo\Contract\TaskInterface;
-use Robo\Collection\Collection;
 
 /**
  * Creates a task wrapper that converts any Callable into an

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -12,8 +12,6 @@ use Robo\Exception\TaskException;
 use Robo\Exception\TaskExitException;
 use Robo\Contract\CommandInterface;
 
-
-use Robo\Common\ProgressIndicatorAwareTrait;
 use Robo\Contract\InflectionInterface;
 
 /**

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -1,26 +1,17 @@
 <?php
 namespace Robo\Collection;
 
-use Guzzle\Inflection\InflectorInterface;
 use Robo\Config;
-use Robo\Common\Timer;
 use Psr\Log\LogLevel;
 use Robo\Contract\InflectionInterface;
 use Robo\Contract\TaskInterface;
 use Robo\Contract\CompletionInterface;
 use Robo\Contract\WrappedTaskInterface;
-use Robo\Collection\NestedCollectionInterface;
-use Robo\LoadAllTasks;
 use Robo\Task\Simulator;
-use Robo\Collection\CompletionWrapper;
-use Robo\Collection\Temporary;
-use Robo\Contract\ConfigAwareInterface;
-use Robo\Common\ConfigAwareTrait;
 use ReflectionClass;
 use Robo\Task\BaseTask;
 use Robo\Contract\BuilderAwareInterface;
 use Robo\Contract\CommandInterface;
-use Robo\Exception\TaskException;
 
 /**
  * Creates a collection, and adds tasks to it.  The collection builder

--- a/src/Collection/NestedCollectionInterface.php
+++ b/src/Collection/NestedCollectionInterface.php
@@ -1,9 +1,6 @@
 <?php
 namespace Robo\Collection;
 
-use Psr\Log\LogLevel;
-use Robo\Contract\TaskInterface;
-
 interface NestedCollectionInterface
 {
     /**

--- a/src/Collection/TaskForEach.php
+++ b/src/Collection/TaskForEach.php
@@ -1,11 +1,9 @@
 <?php
 namespace Robo\Collection;
 
-use Robo\Collection\NestedCollectionInterface;
 use Robo\Result;
 use Robo\TaskInfo;
 use Robo\Task\BaseTask;
-use Robo\Contract\TaskInterface;
 use Robo\Contract\BuilderAwareInterface;
 use Robo\Common\BuilderAwareTrait;
 

--- a/src/Collection/Temporary.php
+++ b/src/Collection/Temporary.php
@@ -2,8 +2,6 @@
 
 namespace Robo\Collection;
 
-use Robo\Contract\TaskInterface;
-
 /**
  * The temporary collection keeps track of the global collection of
  * temporary cleanup tasks in instances where temporary-generating

--- a/src/Common/BuilderAwareTrait.php
+++ b/src/Common/BuilderAwareTrait.php
@@ -2,7 +2,6 @@
 
 namespace Robo\Common;
 
-use Robo\Robo;
 use Robo\Collection\CollectionBuilder;
 
 trait BuilderAwareTrait

--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -1,12 +1,7 @@
 <?php
 namespace Robo\Common;
 
-use Robo\Robo;
 use Symfony\Component\Console\Helper\QuestionHelper;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -4,9 +4,7 @@ namespace Robo\Common;
 use Robo\Robo;
 use Robo\TaskInfo;
 use Consolidation\Log\ConsoleLogLevel;
-use Robo\Common\ConfigAwareTrait;
 use Psr\Log\LoggerAwareTrait;
-use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Robo\Contract\ProgressIndicatorAwareInterface;
 

--- a/src/GlobalOptionsEventListener.php
+++ b/src/GlobalOptionsEventListener.php
@@ -3,7 +3,6 @@ namespace Robo;
 
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Robo\Contract\ConfigAwareInterface;
 use Robo\Common\ConfigAwareTrait;

--- a/src/Log/ResultPrinter.php
+++ b/src/Log/ResultPrinter.php
@@ -2,13 +2,11 @@
 namespace Robo\Log;
 
 use Robo\Result;
-use Robo\TaskInfo;
 use Robo\Contract\PrintedInterface;
 use Robo\Contract\ProgressIndicatorAwareInterface;
 use Robo\Common\ProgressIndicatorAwareTrait;
 
 use Psr\Log\LogLevel;
-use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Consolidation\Log\ConsoleLogLevel;

--- a/src/Log/RoboLogStyle.php
+++ b/src/Log/RoboLogStyle.php
@@ -3,8 +3,6 @@ namespace Robo\Log;
 
 use Robo\Common\TimeKeeper;
 use Consolidation\Log\LogOutputStyler;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\OutputStyle;
 
 /**
  * Robo Log Styler.

--- a/src/Log/RoboLogger.php
+++ b/src/Log/RoboLogger.php
@@ -1,17 +1,10 @@
 <?php
 namespace Robo\Log;
 
-use Robo\Result;
-use Robo\TaskInfo;
-use Robo\Contract\PrintedInterface;
-use Robo\Contract\LogResultInterface;
-use Consolidation\Log\ConsoleLogLevel;
 use Consolidation\Log\Logger;
 
 use Psr\Log\LogLevel;
-use Psr\Log\AbstractLogger;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Logger\ConsoleLogger;
 
 /**
  * Robo's default logger

--- a/src/Result.php
+++ b/src/Result.php
@@ -2,7 +2,6 @@
 namespace Robo;
 
 use Robo\Contract\TaskInterface;
-use Robo\Contract\LogResultInterface;
 use Robo\Exception\TaskExitException;
 
 class Result extends ResultData

--- a/src/ResultData.php
+++ b/src/ResultData.php
@@ -1,7 +1,6 @@
 <?php
 namespace Robo;
 
-use Robo\Contract\LogResultInterface;
 use Consolidation\AnnotatedCommand\ExitCodeInterface;
 use Consolidation\AnnotatedCommand\OutputDataInterface;
 

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -1,15 +1,11 @@
 <?php
 namespace Robo;
 
-use League\Container\Container;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\StringInput;
-use Consolidation\AnnotatedCommand\PassThroughArgsInput;
 use Robo\Contract\BuilderAwareInterface;
 use Robo\Common\IO;
 use Robo\Exception\TaskExitException;
-use League\Container\ContainerInterface;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
 

--- a/src/Task/Archive/Extract.php
+++ b/src/Task/Archive/Extract.php
@@ -31,8 +31,6 @@ use Robo\Common\BuilderAwareTrait;
  *  ->run();
  * ?>
  * ```
- *
- * @method to(string) location to store extracted files
  */
 class Extract extends BaseTask implements BuilderAwareInterface
 {

--- a/src/Task/Base/ExecStack.php
+++ b/src/Task/Base/ExecStack.php
@@ -18,8 +18,6 @@ use Robo\Task\Base;
  *
  * ?>
  * ```
- *
- * @method $this stopOnFail()
  */
 class ExecStack extends CommandStack
 {

--- a/src/Task/Base/ExecStack.php
+++ b/src/Task/Base/ExecStack.php
@@ -2,7 +2,6 @@
 namespace Robo\Task\Base;
 
 use Robo\Task\CommandStack;
-use Robo\Task\Base;
 
 /**
  * Execute commands one by one in stack.

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -1,8 +1,6 @@
 <?php
 namespace Robo\Task\Base;
 
-use Robo\Contract\ProgressIndicatorAwareInterface;
-use Robo\Common\ProgressIndicatorAwareTrait;
 use Robo\Contract\CommandInterface;
 use Robo\Contract\PrintedInterface;
 use Robo\Result;

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -22,10 +22,6 @@ use Symfony\Component\Process\Process;
  *   ->run();
  * ?>
  * ```
- *
- *
- * @method \Robo\Task\Base\ParallelExec timeout(int $timeout) stops process if it runs longer then `$timeout` (seconds)
- * @method \Robo\Task\Base\ParallelExec idleTimeout(int $timeout) stops process if it does not output for time longer then `$timeout` (seconds)
  */
 class ParallelExec extends BaseTask implements CommandInterface, PrintedInterface
 {
@@ -82,6 +78,8 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
     }
 
     /**
+     * Stops process if it runs longer then `$timeout` (seconds).
+     *
      * @param int $timeout
      *
      * @return $this
@@ -93,6 +91,8 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
     }
 
     /**
+     * Stops process if it does not output for time longer then `$timeout` (seconds).
+     *
      * @param int $idleTimeout
      *
      * @return $this

--- a/src/Task/Base/SymfonyCommand.php
+++ b/src/Task/Base/SymfonyCommand.php
@@ -6,7 +6,6 @@ use Robo\Result;
 use Robo\Task\BaseTask;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * Executes Symfony Command

--- a/src/Task/Bower/Install.php
+++ b/src/Task/Bower/Install.php
@@ -1,7 +1,6 @@
 <?php
 namespace Robo\Task\Bower;
 
-use Robo\Task\Bower;
 use Robo\Contract\CommandInterface;
 
 /**

--- a/src/Task/Bower/Update.php
+++ b/src/Task/Bower/Update.php
@@ -1,8 +1,6 @@
 <?php
 namespace Robo\Task\Bower;
 
-use Robo\Task\Bower;
-
 /**
  * Bower Update
  *

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -6,7 +6,6 @@ use Robo\Common\ExecCommand;
 use Robo\Contract\PrintedInterface;
 use Robo\Result;
 use Robo\Contract\CommandInterface;
-use Robo\Common\DynamicParams;
 use Robo\Exception\TaskException;
 
 abstract class CommandStack extends BaseTask implements CommandInterface, PrintedInterface

--- a/src/Task/Composer/Base.php
+++ b/src/Task/Composer/Base.php
@@ -1,7 +1,6 @@
 <?php
 namespace Robo\Task\Composer;
 
-use Robo\Robo;
 use Robo\Task\BaseTask;
 use Robo\Exception\TaskException;
 

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -33,10 +33,6 @@ use Robo\Common\BuilderAwareTrait;
  *  ->run();
  * ?>
  * ```
- *
- * @method Development\Changelog filename(string $filename)
- * @method Development\Changelog anchor(string $anchor)
- * @method Development\Changelog version(string $version)
  */
 class Changelog extends BaseTask implements BuilderAwareInterface
 {

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -2,10 +2,7 @@
 namespace Robo\Task\Development;
 
 use Robo\Task\BaseTask;
-use Robo\Task\File\Replace;
-use Robo\Task\Filesystem;
 use Robo\Result;
-use Robo\Task\Development;
 use Robo\Contract\BuilderAwareInterface;
 use Robo\Common\BuilderAwareTrait;
 

--- a/src/Task/Development/GenerateMarkdownDoc.php
+++ b/src/Task/Development/GenerateMarkdownDoc.php
@@ -41,24 +41,6 @@ use Robo\Common\BuilderAwareTrait;
  *          return strpos($r->name, 'save')===0 ? "[Saves to the database]\n" . $text : $text;
  *      })->run();
  * ```
- *
- * @method \Robo\Task\Development\GenerateMarkdownDoc docClass(string $classname) put a class you want to be documented
- * @method \Robo\Task\Development\GenerateMarkdownDoc filterMethods(\Closure $func) using callback function filter out methods that won't be documented
- * @method \Robo\Task\Development\GenerateMarkdownDoc filterClasses(\Closure $func) using callback function filter out classes that won't be documented
- * @method \Robo\Task\Development\GenerateMarkdownDoc filterProperties(\Closure $func) using callback function filter out properties that won't be documented
- * @method \Robo\Task\Development\GenerateMarkdownDoc processClass(\Closure $func) post-process class documentation
- * @method \Robo\Task\Development\GenerateMarkdownDoc processClassSignature(\Closure $func) post-process class signature. Provide *false* to skip.
- * @method \Robo\Task\Development\GenerateMarkdownDoc processClassDocBlock(\Closure $func) post-process class docblock contents. Provide *false* to skip.
- * @method \Robo\Task\Development\GenerateMarkdownDoc processMethod(\Closure $func) post-process method documentation. Provide *false* to skip.
- * @method \Robo\Task\Development\GenerateMarkdownDoc processMethodSignature(\Closure $func) post-process method signature. Provide *false* to skip.
- * @method \Robo\Task\Development\GenerateMarkdownDoc processMethodDocBlock(\Closure $func) post-process method docblock contents. Provide *false* to skip.
- * @method \Robo\Task\Development\GenerateMarkdownDoc processProperty(\Closure $func) post-process property documentation. Provide *false* to skip.
- * @method \Robo\Task\Development\GenerateMarkdownDoc processPropertySignature(\Closure $func) post-process property signature. Provide *false* to skip.
- * @method \Robo\Task\Development\GenerateMarkdownDoc processPropertyDocBlock(\Closure $func) post-process property docblock contents. Provide *false* to skip.
- * @method \Robo\Task\Development\GenerateMarkdownDoc reorder(\Closure $func) use a function to reorder classes
- * @method \Robo\Task\Development\GenerateMarkdownDoc reorderMethods(\Closure $func) use a function to reorder methods in class
- * @method \Robo\Task\Development\GenerateMarkdownDoc prepend($text) inserts text into beginning of markdown file
- * @method \Robo\Task\Development\GenerateMarkdownDoc append($text) inserts text in the end of markdown file
  */
 class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
 {
@@ -190,6 +172,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Put a class you want to be documented.
+     *
      * @param string $item
      *
      * @return $this
@@ -201,6 +185,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Using a callback function filter out methods that won't be documented.
+     *
      * @param callable $filterMethods
      *
      * @return $this
@@ -212,6 +198,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Using a callback function filter out classes that won't be documented.
+     *
      * @param callable $filterClasses
      *
      * @return $this
@@ -223,6 +211,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Using a callback function filter out properties that won't be documented.
+     *
      * @param callable $filterProperties
      *
      * @return $this
@@ -234,6 +224,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Post-process class documentation.
+     *
      * @param callable $processClass
      *
      * @return $this
@@ -245,6 +237,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Post-process class signature. Provide *false* to skip.
+     *
      * @param callable|false $processClassSignature
      *
      * @return $this
@@ -256,6 +250,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Post-process class docblock contents. Provide *false* to skip.
+     *
      * @param callable|false $processClassDocBlock
      *
      * @return $this
@@ -267,6 +263,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Post-process method documentation. Provide *false* to skip.
+     *
      * @param callable|false $processMethod
      *
      * @return $this
@@ -278,6 +276,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Post-process method signature. Provide *false* to skip.
+     *
      * @param callable|false $processMethodSignature
      *
      * @return $this
@@ -289,6 +289,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Post-process method docblock contents. Provide *false* to skip.
+     *
      * @param callable|false $processMethodDocBlock
      *
      * @return $this
@@ -300,6 +302,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Post-process property documentation. Provide *false* to skip.
+     *
      * @param callable|false $processProperty
      *
      * @return $this
@@ -311,6 +315,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Post-process property signature. Provide *false* to skip.
+     *
      * @param callable|false $processPropertySignature
      *
      * @return $this
@@ -322,6 +328,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Post-process property docblock contents. Provide *false* to skip.
+     *
      * @param callable|false $processPropertyDocBlock
      *
      * @return $this
@@ -333,6 +341,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Use a function to reorder classes.
+     *
      * @param callable $reorder
      *
      * @return $this
@@ -344,6 +354,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Use a function to reorder methods in class.
+     *
      * @param callable $reorderMethods
      *
      * @return $this
@@ -377,6 +389,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Inserts text at the beginning of markdown file.
+     *
      * @param string $prepend
      *
      * @return $this
@@ -388,6 +402,8 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     }
 
     /**
+     * Inserts text at the end of markdown file.
+     *
      * @param string $append
      *
      * @return $this

--- a/src/Task/Development/GenerateMarkdownDoc.php
+++ b/src/Task/Development/GenerateMarkdownDoc.php
@@ -2,10 +2,7 @@
 namespace Robo\Task\Development;
 
 use Robo\Task\BaseTask;
-use Robo\Task\File\Write;
-use Robo\Task\Filesystem;
 use Robo\Result;
-use Robo\Task\Development;
 use Robo\Contract\BuilderAwareInterface;
 use Robo\Common\BuilderAwareTrait;
 

--- a/src/Task/Development/GenerateTask.php
+++ b/src/Task/Development/GenerateTask.php
@@ -2,7 +2,6 @@
 namespace Robo\Task\Development;
 
 use Robo\Task\BaseTask;
-use Symfony\Component\Process\ProcessUtils;
 use Robo\Result;
 
 /**

--- a/src/Task/Development/GitHub.php
+++ b/src/Task/Development/GitHub.php
@@ -4,10 +4,6 @@ namespace Robo\Task\Development;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
 
-/**
- * @method \Robo\Task\Development\GitHub repo(string)
- * @method \Robo\Task\Development\GitHub owner(string)
- */
 abstract class GitHub extends BaseTask
 {
     const GITHUB_URL = 'https://api.github.com';

--- a/src/Task/Development/PackPhar.php
+++ b/src/Task/Development/PackPhar.php
@@ -2,7 +2,6 @@
 namespace Robo\Task\Development;
 
 use Robo\Contract\ProgressIndicatorAwareInterface;
-use Robo\Common\ProgressIndicatorAwareTrait;
 use Robo\Contract\PrintedInterface;
 use Robo\Result;
 use Robo\Task\BaseTask;

--- a/src/Task/File/Replace.php
+++ b/src/Task/File/Replace.php
@@ -30,10 +30,6 @@ use Robo\Task\BaseTask;
  *  ->run();
  * ?>
  * ```
- *
- * @method regex(string) regex to match string to be replaced
- * @method from(string|array) string(s) to be replaced
- * @method to(string|array) value(s) to be set as a replacement
  */
 class Replace extends BaseTask
 {
@@ -43,12 +39,12 @@ class Replace extends BaseTask
     protected $filename;
 
     /**
-     * @var string[]
+     * @var string|string[]
      */
     protected $from;
 
     /**
-     * @var string[]
+     * @var string|string[]
      */
     protected $to;
 
@@ -77,7 +73,9 @@ class Replace extends BaseTask
     }
 
     /**
-     * @param string $from
+     * String(s) to be replaced.
+     *
+     * @param string|string[] $from
      *
      * @return $this
      */
@@ -88,7 +86,9 @@ class Replace extends BaseTask
     }
 
     /**
-     * @param string $to
+     * Value(s) to be set as a replacement.
+     *
+     * @param string|string[] $to
      *
      * @return $this
      */
@@ -99,6 +99,8 @@ class Replace extends BaseTask
     }
 
     /**
+     * Regex to match string to be replaced.
+     *
      * @param string $regex
      *
      * @return $this

--- a/src/Task/File/TmpFile.php
+++ b/src/Task/File/TmpFile.php
@@ -2,7 +2,6 @@
 
 namespace Robo\Task\File;
 
-use Robo\Collection\Collection;
 use Robo\Contract\CompletionInterface;
 
 /**

--- a/src/Task/File/Write.php
+++ b/src/Task/File/Write.php
@@ -17,8 +17,6 @@ use Robo\Task\BaseTask;
  *      ->run();
  * ?>
  * ```
- *
- * @method append()
  */
 class Write extends BaseTask
 {

--- a/src/Task/File/loadTasks.php
+++ b/src/Task/File/loadTasks.php
@@ -1,8 +1,6 @@
 <?php
 namespace Robo\Task\File;
 
-use Robo\Collection\Temporary;
-
 trait loadTasks
 {
     /**

--- a/src/Task/Filesystem/FilesystemStack.php
+++ b/src/Task/Filesystem/FilesystemStack.php
@@ -29,16 +29,16 @@ use Robo\Common\BuilderAwareTrait;
  * ?>
  * ```
  *
- * @method $this mkdir($dir)
- * @method $this touch($file)
- * @method $this copy($from, $to, $force = null)
- * @method $this chmod($file, $permissions, $umask = null, $recursive = null)
- * @method $this chgrp($file, $group, $recursive = null)
- * @method $this chown($file, $user, $recursive = null)
- * @method $this remove($file)
- * @method $this rename($from, $to)
- * @method $this symlink($from, $to)
- * @method $this mirror($from, $to)
+ * @method $this mkdir(string|array|\Traversable $dir, int $mode = 0777)
+ * @method $this touch(string|array|\Traversable $file, int $time = null, int $atime = null)
+ * @method $this copy(string $from, string $to, bool $force = false)
+ * @method $this chmod(string|array|\Traversable $file, int $permissions, int $umask = 0000, bool $recursive = false)
+ * @method $this chgrp(string|array|\Traversable $file, string $group, bool $recursive = false)
+ * @method $this chown(string|array|\Traversable $file, string $user, bool $recursive = false)
+ * @method $this remove(string|array|\Traversable $file)
+ * @method $this rename(string $from, string $to, bool $force = false)
+ * @method $this symlink(string $from, string $to, bool $copyOnWindows = false)
+ * @method $this mirror(string $from, string $to, \Traversable $iterator = null, array $options = [])
  */
 class FilesystemStack extends StackBasedTask implements BuilderAwareInterface
 {

--- a/src/Task/Filesystem/FilesystemStack.php
+++ b/src/Task/Filesystem/FilesystemStack.php
@@ -1,10 +1,8 @@
 <?php
 namespace Robo\Task\Filesystem;
 
-use Robo\Result;
 use Robo\Task\StackBasedTask;
 use Symfony\Component\Filesystem\Filesystem as sfFilesystem;
-use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Robo\Contract\BuilderAwareInterface;
 use Robo\Common\BuilderAwareTrait;

--- a/src/Task/Filesystem/TmpDir.php
+++ b/src/Task/Filesystem/TmpDir.php
@@ -3,7 +3,6 @@
 namespace Robo\Task\Filesystem;
 
 use Robo\Result;
-use Robo\Collection\Collection;
 use Robo\Contract\CompletionInterface;
 
 /**

--- a/src/Task/Filesystem/WorkDir.php
+++ b/src/Task/Filesystem/WorkDir.php
@@ -3,8 +3,6 @@
 namespace Robo\Task\Filesystem;
 
 use Robo\Result;
-use Robo\Collection\Collection;
-use Robo\Contract\CompletionInterface;
 use Robo\Contract\RollbackInterface;
 use Robo\Contract\BuilderAwareInterface;
 use Robo\Common\BuilderAwareTrait;

--- a/src/Task/Filesystem/loadShortcuts.php
+++ b/src/Task/Filesystem/loadShortcuts.php
@@ -1,8 +1,6 @@
 <?php
 namespace Robo\Task\Filesystem;
 
-use Robo\Collection\Temporary;
-
 trait loadShortcuts
 {
     /**

--- a/src/Task/Filesystem/loadTasks.php
+++ b/src/Task/Filesystem/loadTasks.php
@@ -1,8 +1,6 @@
 <?php
 namespace Robo\Task\Filesystem;
 
-use Robo\Collection\Temporary;
-
 trait loadTasks
 {
     /**

--- a/src/Task/Gulp/Run.php
+++ b/src/Task/Gulp/Run.php
@@ -1,7 +1,6 @@
 <?php
 namespace Robo\Task\Gulp;
 
-use Robo\Task\Gulp;
 use Robo\Contract\CommandInterface;
 
 /**

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -3,7 +3,6 @@ namespace Robo\Task\Remote;
 
 use Robo\Contract\CommandInterface;
 use Robo\Task\BaseTask;
-use Robo\Task\Remote;
 use Robo\Exception\TaskException;
 
 /**

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -44,11 +44,6 @@ use Robo\Exception\TaskException;
  *   $rsync->run();
  * }
  * ```
- *
- * @method \Robo\Task\Remote\Rsync fromUser(string $user)
- * @method \Robo\Task\Remote\Rsync fromHost(string $hostname)
- * @method \Robo\Task\Remote\Rsync toUser(string $user)
- * @method \Robo\Task\Remote\Rsync toHost(string $hostname)
  */
 class Rsync extends BaseTask implements CommandInterface
 {

--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -2,7 +2,6 @@
 
 namespace Robo\Task\Remote;
 
-use Robo\Result;
 use Robo\Contract\CommandInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;

--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -41,10 +41,6 @@ use Robo\Contract\SimulatedInterface;
  * ```php
  * \Robo\Task\Remote\Ssh::configure('remoteDir', '/some-dir');
  * ```
- *
- * @method $this stopOnFail(bool $stopOnFail) Whether or not to chain commands together with &&
- *                                            and stop the chain if one command fails
- * @method $this remoteDir(string $remoteWorkingDirectory) Changes to the given directory before running commands
  */
 class Ssh extends BaseTask implements CommandInterface, SimulatedInterface
 {
@@ -111,6 +107,8 @@ class Ssh extends BaseTask implements CommandInterface, SimulatedInterface
     }
 
     /**
+     * Whether or not to chain commands together with && and stop the chain if one command fails.
+     *
      * @param bool $stopOnFail
      *
      * @return $this
@@ -122,6 +120,8 @@ class Ssh extends BaseTask implements CommandInterface, SimulatedInterface
     }
 
     /**
+     * Changes to the given directory before running commands.
+     *
      * @param string $remoteDir
      *
      * @return $this

--- a/src/Task/Simulator.php
+++ b/src/Task/Simulator.php
@@ -8,7 +8,6 @@ use Robo\Result;
 use Robo\Contract\TaskInterface;
 use Robo\Contract\SimulatedInterface;
 use Robo\Log\RoboLogLevel;
-use Psr\Log\LogLevel;
 use Robo\Contract\CommandInterface;
 
 class Simulator extends BaseTask implements CommandInterface

--- a/src/Task/StackBasedTask.php
+++ b/src/Task/StackBasedTask.php
@@ -2,8 +2,6 @@
 namespace Robo\Task;
 
 use Robo\Result;
-use Robo\Task\BaseTask;
-use Robo\Contract\TaskInterface;
 
 /**
  * Extend StackBasedTask to create a Robo task that

--- a/tests/_helpers/CliGuy.php
+++ b/tests/_helpers/CliGuy.php
@@ -17,9 +17,6 @@
  * @SuppressWarnings(PHPMD)
 */
 
-use League\Container\ContainerAwareInterface;
-use League\Container\ContainerAwareTrait;
-
 class CliGuy extends \Codeception\Actor
 {
     use _generated\CliGuyActions;

--- a/tests/_helpers/CliHelper.php
+++ b/tests/_helpers/CliHelper.php
@@ -3,7 +3,6 @@ namespace Codeception\Module;
 
 use Robo\Robo;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Output\NullOutput;
 
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;

--- a/tests/_helpers/CodeGuy.php
+++ b/tests/_helpers/CodeGuy.php
@@ -13,6 +13,7 @@
  * @method void lookForwardTo($achieveValue)
  * @method void comment($description)
  * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = null)
+ * @method void capturedOutputStream()
  *
  * @SuppressWarnings(PHPMD)
 */

--- a/tests/_helpers/CodeHelper.php
+++ b/tests/_helpers/CodeHelper.php
@@ -6,8 +6,6 @@ namespace Codeception\Module;
 
 use Robo\Robo;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class CodeHelper extends \Codeception\Module
 {

--- a/tests/_helpers/SeeInOutputTrait.php
+++ b/tests/_helpers/SeeInOutputTrait.php
@@ -2,7 +2,6 @@
 namespace Codeception\Module;
 
 use Robo\Robo;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/tests/cli/CollectionCest.php
+++ b/tests/cli/CollectionCest.php
@@ -3,9 +3,7 @@ namespace Robo;
 
 use \CliGuy;
 
-use Robo\Contract\TaskInterface;
 use Robo\Collection\Temporary;
-use Robo\Result;
 
 class CollectionCest
 {

--- a/tests/cli/GenerateMarkdownDocCest.php
+++ b/tests/cli/GenerateMarkdownDocCest.php
@@ -3,10 +3,6 @@ namespace Robo;
 
 use \CliGuy;
 
-use Robo\Contract\TaskInterface;
-use Robo\Collection\Temporary;
-use Robo\Result;
-
 class GenerateMarkdownDocCest
 {
     public function _before(CliGuy $I)

--- a/tests/cli/SimulatedCest.php
+++ b/tests/cli/SimulatedCest.php
@@ -3,10 +3,6 @@ namespace Robo;
 
 use \CliGuy;
 
-use Robo\Contract\TaskInterface;
-use Robo\Collection\Temporary;
-use Robo\Result;
-
 class SimulatedCest
 {
     public function _before(CliGuy $I)

--- a/tests/cli/_bootstrap.php
+++ b/tests/cli/_bootstrap.php
@@ -2,8 +2,5 @@
 // Here you can initialize variables that will for your tests
 
 use Robo\Robo;
-use Robo\Runner;
-use League\Container\Container;
-use Symfony\Component\Console\Input\StringInput;
 
 $container = Robo::createDefaultContainer();

--- a/tests/src/RoboFileFixture.php
+++ b/tests/src/RoboFileFixture.php
@@ -2,15 +2,11 @@
 
 namespace Robo;
 
-use Robo\Result;
-use Robo\ResultData;
-use Robo\Collection\CollectionBuilder;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerAwareInterface;
 
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareInterface;
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareTrait;
-use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/tests/unit/ApplicationTest.php
+++ b/tests/unit/ApplicationTest.php
@@ -2,9 +2,6 @@
 require_once codecept_data_dir() . 'TestedRoboFile.php';
 
 use Robo\Robo;
-use Robo\Runner;
-use League\Container\Container;
-use Consolidation\AnnotatedCommand\AnnotatedCommandFactory;
 use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 
 class ApplicationTest extends \Codeception\TestCase\Test

--- a/tests/unit/Common/ResourceExistenceChecker.php
+++ b/tests/unit/Common/ResourceExistenceChecker.php
@@ -1,7 +1,5 @@
 <?php
 use Robo\Common\ResourceExistenceChecker;
-use Robo\Result;
-use Robo\Task\BaseTask;
 
 class ResourceExistenceCheckerTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/OutputTest.php
+++ b/tests/unit/OutputTest.php
@@ -1,7 +1,5 @@
 <?php
-use AspectMock\Test as test;
 use Robo\Robo;
-use Robo\Common\IO;
 
 class OutputTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/RunnerTest.php
+++ b/tests/unit/RunnerTest.php
@@ -1,6 +1,5 @@
 <?php
 use Robo\Robo;
-use Symfony\Component\Console\Output\BufferedOutput;
 
 class RunnerTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/AtoumTest.php
+++ b/tests/unit/Task/AtoumTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class AtoumTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/BehatTest.php
+++ b/tests/unit/Task/BehatTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class BehatTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/BowerTest.php
+++ b/tests/unit/Task/BowerTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class BowerTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/CodeceptionTest.php
+++ b/tests/unit/Task/CodeceptionTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class CodeceptionTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/CollectionTest.php
+++ b/tests/unit/Task/CollectionTest.php
@@ -8,9 +8,7 @@ namespace unit;
 
 use Robo\Result;
 use Robo\Task\BaseTask;
-use Robo\Contract\TaskInterface;
 use Robo\Collection\Collection;
-use Robo\Robo;
 
 class CollectionTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/CommandStackTest.php
+++ b/tests/unit/Task/CommandStackTest.php
@@ -1,6 +1,5 @@
 <?php
 use Codeception\Util\Stub;
-use Robo\Robo;
 
 class CommandStackTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/ComposerTest.php
+++ b/tests/unit/Task/ComposerTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class ComposerTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/DockerTest.php
+++ b/tests/unit/Task/DockerTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class DockerTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/ExecTaskTest.php
+++ b/tests/unit/Task/ExecTaskTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class ExecTaskTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/GitTest.php
+++ b/tests/unit/Task/GitTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class GitTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/GulpTest.php
+++ b/tests/unit/Task/GulpTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class GulpTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/HgTest.php
+++ b/tests/unit/Task/HgTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class HgTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/NpmTest.php
+++ b/tests/unit/Task/NpmTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class NpmTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/PHPServerTest.php
+++ b/tests/unit/Task/PHPServerTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class PHPServerTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/PHPUnitTest.php
+++ b/tests/unit/Task/PHPUnitTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class PHPUnitTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/ParallelExecTest.php
+++ b/tests/unit/Task/ParallelExecTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class ParallelExecTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/PhpspecTest.php
+++ b/tests/unit/Task/PhpspecTest.php
@@ -1,6 +1,5 @@
 <?php
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class PhpspecTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/RsyncTest.php
+++ b/tests/unit/Task/RsyncTest.php
@@ -1,8 +1,5 @@
 <?php
 
-use AspectMock\Test as test;
-use Robo\Robo;
-
 class RsyncTest extends \Codeception\TestCase\Test
 {
     /**

--- a/tests/unit/Task/SemVerTest.php
+++ b/tests/unit/Task/SemVerTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use AspectMock\Test as test;
-use Robo\Robo;
 
 class SemVerTest extends \Codeception\TestCase\Test
 {

--- a/tests/unit/Task/SshTest.php
+++ b/tests/unit/Task/SshTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use AspectMock\Test as test;
 use Robo\Robo;
 
 class SshTest extends \Codeception\TestCase\Test


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Removed redundant @method tags & unused imports.

### Description
Most @method tags are redundant since, in the meantime, those methods were rewritten to not be magic ones. I've moved all the descriptions to the phpdoc for the actual methods. Also updated the @method tags on the `FilesystemStack` class to match the Symfony filesystem methods.

Removed all unused imports & those that tried to import classes that have been removed.