### PR TITLE
Fix function name used by Changelog task

### DIFF
--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -174,13 +174,13 @@ class Changelog extends BaseTask implements BuilderAwareInterface
 
         /** @var \Robo\Result $result */
         // trying to append to changelog for today
-        $result = $this->collectionBuilder()->taskReplace($this->filename)
+        $result = $this->collectionBuilder()->taskReplaceInFile($this->filename)
             ->from($ver)
             ->to($text)
             ->run();
 
         if (!isset($result['replaced']) || !$result['replaced']) {
-            $result = $this->collectionBuilder()->taskReplace($this->filename)
+            $result = $this->collectionBuilder()->taskReplaceInFile($this->filename)
                 ->from($this->anchor)
                 ->to($this->anchor . "\n\n" . $text)
                 ->run();


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Fixed function name used by the Changelog task.

### Description
The Changelog task was failing because it called the function taskReplace. The correct name of the function to call is taskReplaceInFile.

