### PR TITLE
Use name variable for Githubrelease name

### DIFF
--- a/src/Task/Development/GitHubRelease.php
+++ b/src/Task/Development/GitHubRelease.php
@@ -190,7 +190,7 @@ class GitHubRelease extends GitHub
             [
                 "tag_name" => $this->tag,
                 "target_commitish" => $this->comittish,
-                "name" => $this->tag,
+                "name" => $this->name,
                 "body" => $this->getBody(),
                 "draft" => $this->draft,
                 "prerelease" => $this->prerelease


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Use name variable for Github release name.

### Description
The GithubRelease task provides a name method to set the release name, but when creating the release, it uses the tag variable instead of the name variable. 

