### PR TITLE
Change access to protected for IO methods.

### DIFF
--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -76,7 +76,7 @@ trait IO
      * @param int $length
      * @param string $format
      */
-    private function formattedOutput($text, $length, $format)
+    protected function formattedOutput($text, $length, $format)
     {
         $lines = explode("\n", trim($text, "\n"));
         $maxLineLength = array_reduce(array_map('strlen', $lines), 'max');
@@ -143,7 +143,7 @@ trait IO
      *
      * @return string
      */
-    private function doAsk(Question $question)
+    protected function doAsk(Question $question)
     {
         return $this->getDialog()->ask($this->input(), $this->output(), $question);
     }
@@ -153,7 +153,7 @@ trait IO
      *
      * @return string
      */
-    private function formatQuestion($message)
+    protected function formatQuestion($message)
     {
         return  "<question>?  $message</question> ";
     }
@@ -169,7 +169,7 @@ trait IO
     /**
      * @param $text
      */
-    private function writeln($text)
+    protected function writeln($text)
     {
         $this->output()->writeln($text);
     }


### PR DESCRIPTION
In attempting to override IO methods such as yell() or ask(), I found that I was stymied by various IO methods having private access. Perhaps there is a reason for this, but I found it useful to be able to call methods such as formatQuestion() from my own overridden confirm() method. 

This makes it much easier, and DRYer, to override output formatting.