### PR TITLE
Adding printMetadata() option to exec command.

### DIFF
--- a/docs/tasks/Base.md
+++ b/docs/tasks/Base.md
@@ -56,7 +56,8 @@ $this->taskExecStack()
 * `stopOnFail($stopOnFail = null)`   * `param bool` $stopOnFail
 * `result($result)` 
 * `dir($dir)`  Changes working directory of command
-* `printed($arg)`  Should command output be printed
+* `printOutput($arg)`  Should command output be printed
+* `printMetadata($arg)`  Should command metadata (command, working directory, and timer) be printed
 
 ## ParallelExec
 

--- a/docs/tasks/Base.md
+++ b/docs/tasks/Base.md
@@ -58,6 +58,7 @@ $this->taskExecStack()
 * `dir($dir)`  Changes working directory of command
 * `printOutput($arg)`  Should command output be printed
 * `printMetadata($arg)`  Should command metadata (command, working directory, and timer) be printed
+* `silent($arg)`  Shortcut for setting printMetadata(false) and printOutput(false)
 
 ## ParallelExec
 

--- a/docs/tasks/Base.md
+++ b/docs/tasks/Base.md
@@ -56,6 +56,7 @@ $this->taskExecStack()
 * `stopOnFail($stopOnFail = null)`   * `param bool` $stopOnFail
 * `result($result)` 
 * `dir($dir)`  Changes working directory of command
+* `printed($arg)`  _Deprecated_. Should command output be printed
 * `printOutput($arg)`  Should command output be printed
 * `printMetadata($arg)`  Should command metadata (command, working directory, and timer) be printed
 * `silent($arg)`  Shortcut for setting printMetadata(false) and printOutput(false)

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -91,10 +91,8 @@ trait ExecCommand
      */
     public function printed($arg)
     {
-        if (is_bool($arg)) {
-            $this->isPrinted = $arg;
-        }
-        return $this;
+        $this->logger()->warning("printed() is deprecated. Please use printOutput().");
+        return $this->printOutput($arg);
     }
 
     /**
@@ -106,7 +104,10 @@ trait ExecCommand
      */
     public function printOutput($arg)
     {
-        return $this->printed($arg);
+        if (is_bool($arg)) {
+            $this->isPrinted = $arg;
+        }
+        return $this;
     }
 
     /**

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -90,7 +90,7 @@ trait ExecCommand
      */
     public function printOutput($arg)
     {
-       return $this->printed($arg);
+        return $this->printed($arg);
     }
 
     /**
@@ -100,7 +100,8 @@ trait ExecCommand
      *
      * @return $this
      */
-    public function printMetadata($arg) {
+    public function printMetadata($arg)
+    {
         if (is_bool($arg)) {
             $this->isMetadataPrinted = $arg;
         }

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -67,6 +67,22 @@ trait ExecCommand
 
 
     /**
+     * Shortcut for setting isPrinted() and isMetadataPrinted() to false.
+     *
+     * @param bool $arg
+     *
+     * @return $this
+     */
+    public function silent($arg)
+    {
+        if (is_bool($arg)) {
+            $this->isPrinted = !$arg;
+            $this->isMetadataPrinted = !$arg;
+        }
+        return $this;
+    }
+
+    /**
      * Should command output be printed
      *
      * @param bool $arg

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -17,6 +17,11 @@ trait ExecCommand
     protected $isPrinted = true;
 
     /**
+     * @var bool
+     */
+    protected $isMetadataPrinted = true;
+
+    /**
      * @var string
      */
     protected $workingDirectory;
@@ -72,6 +77,32 @@ trait ExecCommand
     {
         if (is_bool($arg)) {
             $this->isPrinted = $arg;
+        }
+        return $this;
+    }
+
+    /**
+     * Should command output be printed
+     *
+     * @param bool $arg
+     *
+     * @return $this
+     */
+    public function printOutput($arg)
+    {
+       return $this->printed($arg);
+    }
+
+    /**
+     * Should command metadata be printed. I,e., command and timer.
+     *
+     * @param bool $arg
+     *
+     * @return $this
+     */
+    public function printMetadata($arg) {
+        if (is_bool($arg)) {
+            $this->isMetadataPrinted = $arg;
         }
         return $this;
     }

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -162,7 +162,8 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
      * @return array
      *   The data array passed to Result().
      */
-    protected function getResultData() {
+    protected function getResultData()
+    {
         if ($this->isMetadataPrinted) {
             return ['time' => $this->getExecutionTime()];
         }

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -157,11 +157,27 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
     }
 
     /**
+     * Gets the data array to be passed to Result().
+     *
+     * @return array
+     *   The data array passed to Result().
+     */
+    protected function getResultData() {
+        if ($this->isMetadataPrinted) {
+            return ['time' => $this->getExecutionTime()];
+        }
+
+        return [];
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function run()
     {
-        $this->printAction();
+        if ($this->isMetadataPrinted) {
+            $this->printAction();
+        }
         $this->process = new Process($this->getCommand());
         $this->process->setTimeout($this->timeout);
         $this->process->setIdleTimeout($this->idleTimeout);
@@ -175,7 +191,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
             $this->startTimer();
             $this->process->run();
             $this->stopTimer();
-            return new Result($this, $this->process->getExitCode(), $this->process->getOutput(), ['time' => $this->getExecutionTime()]);
+            return new Result($this, $this->process->getExitCode(), $this->process->getOutput(), $this->getResultData());
         }
 
         if (!$this->background and $this->isPrinted) {
@@ -188,7 +204,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
                 }
             );
             $this->stopTimer();
-            return new Result($this, $this->process->getExitCode(), $this->process->getOutput(), ['time' => $this->getExecutionTime()]);
+            return new Result($this, $this->process->getExitCode(), $this->process->getOutput(), $this->getResultData());
         }
 
         try {


### PR DESCRIPTION
This PR introduces two new abilities:
- Use exec task _without_ printing command, working directory, and timer. This allows the task to be truly silent.`$this->taskExec("something")->silent(true)->run();`
- Use exec task to print output but _not_ print metadata, like the timer. This makes the call a bit more "passthru". `$this->taskExec("something")->printOutput(true)->printMetadata(false)->run();`