### PR TITLE
Website should use updated namespace consolidation

### DIFF
--- a/home.html
+++ b/home.html
@@ -91,13 +91,13 @@ Follow @Robo_PHP
                 <p>Add to <code>composer.json</code> of your project</p>
                 <pre>
 <code class="json">require-dev: {
-    "codegyre/robo": "*"
+    "consolidation/robo": "*"
 }
 </code></pre>
 
                 or install it globally:
 
-<pre><code>composer global require codegyre/robo</code></pre>
+<pre><code>composer global require consolidation/robo</code></pre>
 
                 <a class="btn btn-success right" href="http://robo.li/robo.phar">Download robo.phar</a>
                 <h3>Using Phar</h3>


### PR DESCRIPTION
the namespace of the package was changed from codegyre to consolidation a while ago. documenation still had old name.
