### PR TITLE
Fix: use baseDir when provided as a parameter in the TmpFile constructor

### DIFF
--- a/src/Task/File/TmpFile.php
+++ b/src/Task/File/TmpFile.php
@@ -35,15 +35,15 @@ class TmpFile extends Write implements CompletionInterface
      */
     public function __construct($filename = 'tmp', $extension = '', $baseDir = '', $includeRandomPart = true)
     {
-        if (empty($base)) {
-            $base = sys_get_temp_dir();
+        if (empty($baseDir)) {
+            $baseDir = sys_get_temp_dir();
         }
         if ($includeRandomPart) {
             $random = static::randomString();
             $filename = "{$filename}_{$random}";
         }
         $filename .= $extension;
-        parent::__construct("{$base}/{$filename}");
+        parent::__construct("{$baseDir}/{$filename}");
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Fix a typo in the name of a variable.

### Description
The 3rd parameter of the constructor was ignored. An undefined variable was used instead but the usage of empty() silenced the error.
