### PR TITLE
Making printTaskProgress() json ouput more legible.

### DIFF
--- a/src/Task/StackBasedTask.php
+++ b/src/Task/StackBasedTask.php
@@ -114,7 +114,7 @@ abstract class StackBasedTask extends BaseTask
      */
     protected function printTaskProgress($command, $action)
     {
-        $this->printTaskInfo('{command} {action}', ['command' => "{$command[1]}", 'action' => json_encode($action)]);
+        $this->printTaskInfo('{command} {action}', ['command' => "{$command[1]}", 'action' => json_encode($action, JSON_UNESCAPED_SLASHES)]);
     }
 
     /**


### PR DESCRIPTION
Currently, slashes are displayed as escaped when printed via printTaskProgress(). This is difficult to read and does not seem necessary since it's intended for humans. 