### PR TITLE
Adding setLogLevel() to taskExec().

### DIFF
--- a/docs/tasks/Base.md
+++ b/docs/tasks/Base.md
@@ -52,16 +52,22 @@ $this->taskExecStack()
 ```
 
 * `$this stopOnFail()` 
-
 * `executable($executable)`   * `param string` $executable
 * `exec($command)`   * `param string|string[]` $command
 * `stopOnFail($stopOnFail = null)`   * `param bool` $stopOnFail
 * `result($result)` 
 * `dir($dir)`  Changes working directory of command
 * `printed($arg)`  _Deprecated_. Should command output be printed
-* `printOutput($arg)`  Should command output be printed
-* `printMetadata($arg)`  Should command metadata (command, working directory, and timer) be printed
-* `silent($arg)`  Shortcut for setting printMetadata(false) and printOutput(false)
+* `printOutput($arg)`  Should command output be printed directly to screen, bypassing the logger.
+* `logOutput($arg)`  Should command output be logged. This implicitly disables output printing.
+* `logMetadata($arg)`  Should command metadata (command, working directory, and timer) be logged
+* `setLogLevel($arg)`  Determines the verbosity level at which command output is displayed on screen. Accepts [LogLevel](https://github.com/php-fig/log/blob/master/Psr/Log/LogLevel.php#L8) constants.
+* `silent($arg)`  Shortcut for setting logMetadata(false) and logOutput(false)
+
+### Handling output
+
+All tasks extending from `Robo\Task\BaseTask` inherit `setLogLevel()`, which sets the level at which task information is displayed on screen. For instance, `setLogLevel(LogLevel::INFO)` will display output only when a command is run with the `-v` argument.
+
 
 ## ParallelExec
 

--- a/docs/tasks/Base.md
+++ b/docs/tasks/Base.md
@@ -57,12 +57,12 @@ $this->taskExecStack()
 * `stopOnFail($stopOnFail = null)`   * `param bool` $stopOnFail
 * `result($result)` 
 * `dir($dir)`  Changes working directory of command
-* `printed($arg)`  _Deprecated_. Should command output be printed
-* `printOutput($arg)`  Should command output be printed directly to screen, bypassing the logger.
-* `logOutput($arg)`  Should command output be logged. This implicitly disables output printing.
-* `logMetadata($arg)`  Should command metadata (command, working directory, and timer) be logged
+* `printed($arg)`  _Deprecated_. Should command output be printed.
+* `printOutput($arg)`  Should command output be printed directly to screen, bypassing the logger. Default to true.
+* `logOutput($arg)`  Should command output be logged. This implicitly disables output printing. Defaults to false.
+* `logMetadata($arg)`  Should command metadata (command, working directory, and timer) be logged. Defaults to true.
 * `setLogLevel($arg)`  Determines the verbosity level at which command output is displayed on screen. Accepts [LogLevel](https://github.com/php-fig/log/blob/master/Psr/Log/LogLevel.php#L8) constants.
-* `silent($arg)`  Shortcut for setting logMetadata(false) and logOutput(false)
+* `silent($arg)`  Shortcut for setting logMetadata(false) and logOutput(false). Defaults to false.
 
 ### Handling output
 

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -71,6 +71,21 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     }
 
     /**
+     * @param int $logLevel
+     *
+     * @return $this
+     */
+    public function setLogLevel($logLevel)
+    {
+        $this->logLevel = $logLevel;
+        if (method_exists($this->currentTask, 'setLogLevel')) {
+            $this->currentTask->setLogLevel($logLevel);
+        }
+
+        return $this;
+    }
+
+    /**
      * @param bool $simulated
      *
      * @return $this
@@ -342,6 +357,9 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     {
         $reflection = new ReflectionClass($name);
         $task = $reflection->newInstanceArgs($args);
+        if (method_exists($this->currentTask, 'setLogLevel')) {
+            $this->currentTask->setLogLevel($this->logLevel);
+        }
         if (!$task) {
             throw new RuntimeException("Can not construct task $name");
         }

--- a/src/Collection/CompletionWrapper.php
+++ b/src/Collection/CompletionWrapper.php
@@ -62,6 +62,18 @@ class CompletionWrapper extends BaseTask implements WrappedTaskInterface
     }
 
     /**
+     * @param int $logLevel
+     */
+    public function setLogLevel($logLevel)
+    {
+        $this->logLevel = $logLevel;
+        $this->collection->setLogLevel($logLevel);
+        if (method_exists($this->task, 'setLogLevel')) {
+            $this->task->setLogLevel($logLevel);
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function original()

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -14,7 +14,12 @@ trait ExecCommand
     /**
      * @var bool
      */
-    protected $isPrinted = true;
+    protected $isOutputPrinted = true;
+
+    /**
+     * @var bool
+     */
+    protected $isOutputLogged = true;
 
     /**
      * @var bool
@@ -49,7 +54,7 @@ trait ExecCommand
      */
     public function getPrinted()
     {
-        return $this->isPrinted;
+        return $this->isOutputPrinted;
     }
 
     /**
@@ -67,7 +72,7 @@ trait ExecCommand
 
 
     /**
-     * Shortcut for setting isPrinted() and isMetadataPrinted() to false.
+     * Shortcut for setting isOutputPrinted, isOutputLogged, isMetadataPrinted.
      *
      * @param bool $arg
      *
@@ -76,7 +81,8 @@ trait ExecCommand
     public function silent($arg)
     {
         if (is_bool($arg)) {
-            $this->isPrinted = !$arg;
+            $this->isOutputPrinted = !$arg;
+            $this->isOutputLogged = !$arg;
             $this->isMetadataPrinted = !$arg;
         }
         return $this;
@@ -105,7 +111,22 @@ trait ExecCommand
     public function printOutput($arg)
     {
         if (is_bool($arg)) {
-            $this->isPrinted = $arg;
+            $this->isOutputPrinted = $arg;
+        }
+        return $this;
+    }
+
+    /**
+     * Should command output be printed
+     *
+     * @param bool $arg
+     *
+     * @return $this
+     */
+    public function logOutput($arg)
+    {
+        if (is_bool($arg)) {
+            $this->isOutputLogged = $arg;
         }
         return $this;
     }
@@ -117,7 +138,7 @@ trait ExecCommand
      *
      * @return $this
      */
-    public function printMetadata($arg)
+    public function logMetadata($arg)
     {
         if (is_bool($arg)) {
             $this->isMetadataPrinted = $arg;
@@ -233,7 +254,7 @@ trait ExecCommand
             $process->setWorkingDirectory($this->workingDirectory);
         }
         $this->getExecTimer()->start();
-        if ($this->isPrinted) {
+        if ($this->isOutputPrinted) {
             $process->run(function ($type, $buffer) {
                 print $buffer;
             });

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -19,12 +19,12 @@ trait ExecCommand
     /**
      * @var bool
      */
-    protected $isOutputLogged = true;
+    protected $isOutputLogged = false;
 
     /**
      * @var bool
      */
-    protected $isMetadataPrinted = true;
+    protected $isMetadataLogged = true;
 
     /**
      * @var string
@@ -72,7 +72,7 @@ trait ExecCommand
 
 
     /**
-     * Shortcut for setting isOutputPrinted, isOutputLogged, isMetadataPrinted.
+     * Shortcut for setting isOutputPrinted, isOutputLogged, isMetadataLogged.
      *
      * @param bool $arg
      *
@@ -83,7 +83,7 @@ trait ExecCommand
         if (is_bool($arg)) {
             $this->isOutputPrinted = !$arg;
             $this->isOutputLogged = !$arg;
-            $this->isMetadataPrinted = !$arg;
+            $this->isMetadataLogged = !$arg;
         }
         return $this;
     }
@@ -141,7 +141,7 @@ trait ExecCommand
     public function logMetadata($arg)
     {
         if (is_bool($arg)) {
-            $this->isMetadataPrinted = $arg;
+            $this->isMetadataLogged = $arg;
         }
         return $this;
     }

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -254,13 +254,15 @@ trait ExecCommand
             $process->setWorkingDirectory($this->workingDirectory);
         }
         $this->getExecTimer()->start();
-        if ($this->isOutputPrinted) {
-            $process->run(function ($type, $buffer) {
-                print $buffer;
-            });
-        } else {
-            $process->run();
-        }
+        $process->run(
+            function ($type, $buffer) {
+                if ($this->isOutputLogged) {
+                    $this->printTaskInfo($buffer);
+                } elseif ($this->isOutputPrinted) {
+                    print($buffer);
+                }
+            }
+        );
         $this->getExecTimer()->stop();
 
         return new Result($this, $process->getExitCode(), $process->getOutput(), ['time' => $this->getExecTimer()->elapsed()]);

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -21,6 +21,27 @@ trait TaskIO
     use ConfigAwareTrait;
 
     /**
+     * @var int
+     */
+    protected $logLevel = LogLevel::NOTICE;
+
+    /**
+     * @param int $logLevel
+     */
+    public function setLogLevel($logLevel)
+    {
+        $this->logLevel = $logLevel;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLogLevel()
+    {
+        return $this->logLevel;
+    }
+
+    /**
      * @return mixed|null|\Psr\Log\LoggerInterface
      */
     public function logger()
@@ -64,7 +85,7 @@ trait TaskIO
         // The 'note' style is used for both 'notice' and 'info' log levels;
         // However, 'notice' is printed at VERBOSITY_NORMAL, whereas 'info'
         // is only printed at VERBOSITY_VERBOSE.
-        $this->printTaskOutput(LogLevel::NOTICE, $text, $this->getTaskContext($context));
+        $this->printTaskOutput($this->logLevel, $text, $this->getTaskContext($context));
     }
 
     /**
@@ -84,7 +105,7 @@ trait TaskIO
         // override in the context so that this message will be
         // logged as SUCCESS if that log level is recognized.
         $context['_level'] = ConsoleLogLevel::SUCCESS;
-        $this->printTaskOutput(LogLevel::NOTICE, $text, $this->getTaskContext($context));
+        $this->printTaskOutput($this->logLevel, $text, $this->getTaskContext($context));
     }
 
     /**

--- a/src/Contract/TaskInterface.php
+++ b/src/Contract/TaskInterface.php
@@ -14,4 +14,6 @@ interface TaskInterface
      * @return \Robo\Result
      */
     public function run();
+
+
 }

--- a/src/Log/ResultPrinter.php
+++ b/src/Log/ResultPrinter.php
@@ -62,14 +62,18 @@ class ResultPrinter implements LoggerAwareInterface, ProgressIndicatorAwareInter
         $context = $result->getContext() + ['timer-label' => 'Time', '_style' => []];
         $context['_style']['message'] = '';
 
+        $log_level = method_exists($task, 'getLogLevel') ? $task->getLogLevel() : ConsoleLogLevel::ERROR;
+
         $printOutput = true;
         if ($task instanceof PrintedInterface) {
             $printOutput = !$task->getPrinted();
         }
         if ($printOutput) {
-            $this->printMessage(LogLevel::ERROR, "{message}", $context);
+            $this->printMessage($log_level, "{message}", $context);
         }
-        $this->printMessage(LogLevel::ERROR, 'Exit code {code}', $context);
+
+
+        $this->printMessage($log_level, 'Exit code {code}', $context);
         return true;
     }
 
@@ -83,10 +87,11 @@ class ResultPrinter implements LoggerAwareInterface, ProgressIndicatorAwareInter
     protected function printSuccess(Result $result)
     {
         $task = $result->getTask();
+        $log_level = method_exists($task, 'getLogLevel') ? $task->getLogLevel() : ConsoleLogLevel::SUCCESS;
         $context = $result->getContext() + ['timer-label' => 'in'];
         $time = $result->getExecutionTime();
         if ($time) {
-            $this->printMessage(ConsoleLogLevel::SUCCESS, 'Done', $context);
+            $this->printMessage($log_level, 'Done', $context);
         }
         return false;
     }

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -203,7 +203,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
      */
     protected function getResultData()
     {
-        if ($this->isMetadataPrinted) {
+        if ($this->isMetadataLogged) {
             return ['time' => $this->getExecutionTime()];
         }
 
@@ -215,7 +215,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
      */
     public function run()
     {
-        if ($this->isMetadataPrinted) {
+        if ($this->isMetadataLogged) {
             $this->printAction();
         }
         $this->process = new Process($this->getCommand());

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -235,19 +235,16 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
             $this->process->setEnv($this->env);
         }
 
-        if (!$this->background and !$this->isPrinted) {
-            $this->startTimer();
-            $this->process->run();
-            $this->stopTimer();
-            return new Result($this, $this->process->getExitCode(), $this->process->getOutput(), $this->getResultData());
-        }
-
-        if (!$this->background and $this->isPrinted) {
+        if (!$this->background) {
             $this->startTimer();
             $this->process->run(
                 function ($type, $buffer) {
                     $progressWasVisible = $this->hideTaskProgress();
-                    print($buffer);
+                    if ($this->isOutputLogged) {
+                        $this->printTaskInfo($buffer);
+                    } elseif ($this->isOutputPrinted) {
+                        print($buffer);
+                    }
                     $this->showTaskProgress($progressWasVisible);
                 }
             );

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -43,24 +43,24 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
     /**
      * @var bool
      */
-    protected $isPrinted = false;
+    protected $isOutputPrinted = false;
 
     /**
      * {@inheritdoc}
      */
     public function getPrinted()
     {
-        return $this->isPrinted;
+        return $this->isOutputPrinted;
     }
 
     /**
-     * @param bool $isPrinted
+     * @param bool $isOutputPrinted
      *
      * @return $this
      */
-    public function printed($isPrinted = true)
+    public function printed($isOutputPrinted = true)
     {
-        $this->isPrinted = $isPrinted;
+        $this->isOutputPrinted = $isOutputPrinted;
         return $this;
     }
 
@@ -140,7 +140,7 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
                 }
                 if (!$process->isRunning()) {
                     $this->advanceProgressIndicator();
-                    if ($this->isPrinted) {
+                    if ($this->isOutputPrinted) {
                         $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $process->getOutput(), '_style' => ['command' => 'fg=white;bg=magenta']]);
                         $errorOutput = $process->getErrorOutput();
                         if ($errorOutput) {

--- a/src/Task/Docker/Run.php
+++ b/src/Task/Docker/Run.php
@@ -88,7 +88,7 @@ class Run extends Base
      */
     public function getPrinted()
     {
-        return $this->isPrinted;
+        return $this->isOutputPrinted;
     }
 
     /**
@@ -96,7 +96,7 @@ class Run extends Base
      */
     public function getCommand()
     {
-        if ($this->isPrinted) {
+        if ($this->isOutputPrinted) {
             $this->option('-i');
         }
         if ($this->cidFile) {


### PR DESCRIPTION
So, this PR achieves the second item in #517:
> Set the verbosity level for any task. This is related to #512, but considered at a higher level .
>
> It would be great if we could set the verbosity level of any task's output. E.g, I'd like a given implementation of taskExec() to display it's output only if -v has been passed, and otherwise print nothing to the screen. $this->taskExec('compass')->setVerbosity(SOME_CONSTANT);.

E.g., if I wanted to make use of the taskFilesystemStack's mkdir() method and set its log level to INFO, I would:
```php
<?php
   $this->taskFilesystemStack()
     ->logMetadata(true)
     ->logOutput(true)
     ->setLogLevel(LogLevel::INFO)
     ->mkdir($dir)
     ->run();
```

This would display task output only if the `-v` argument were passed to the command.