### PR TITLE
Disabling output for TaskExec() background processes.

### DIFF
--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -256,6 +256,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
         }
 
         try {
+            $this->process->disableOutput();
             $this->process->start();
         } catch (\Exception $e) {
             return Result::fromException($this, $e);


### PR DESCRIPTION
Currently, a `TaskExec()` process with `background(true)` will still print output to screen. This does not seem like intended functionality. 

If we wanted, we could do this only when `printOutput(false)`.