### PR TITLE
Do not call inflect unless the task needs & can do it.

### DIFF
--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -357,7 +357,9 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
      */
     protected function fixTask($task, $args)
     {
-        $task->inflect($this);
+        if ($task instanceof InflectionInterface) {
+            $task->inflect($this);
+        }
         if ($task instanceof BuilderAwareInterface) {
             $task->setBuilder($this);
         }

--- a/src/Task/Development/SemVer.php
+++ b/src/Task/Development/SemVer.php
@@ -210,6 +210,9 @@ class SemVer implements TaskInterface
     {
         extract($this->version);
         $semver = sprintf(self::SEMVER, $major, $minor, $patch, $special, $metadata);
+        if (empty($this->path)) {
+            return true;
+        }
         if (is_writeable($this->path) === false || file_put_contents($this->path, $semver) === false) {
             throw new TaskException($this, 'Failed to write semver file.');
         }


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Fixes the SemVer task, broken in Robo 1.x when used with the collection builder.

### Description
The collection builder was calling `inflect()` on tasks that neither needed nor were able to `inflect`. Now, this step is skipped for simple tasks that do not inflect.
