### PR TITLE
Abstracting process execution logic into ExecTrait.php.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ before_script:
   - if [ "$dependencies" = "highest" ]; then composer update --prefer-dist -n; fi;
 
 script:
-  - if [ "$dependencies" != "highest" ]; ./robo test
-  - if [ "$dependencies" = "highest" ]; ./robo test --coverage
+  - if [ "$dependencies" != "highest" ]; then ./robo test; fi;
+  - if [ "$dependencies" = "highest" ]; then ./robo test --coverage; fi;
 
 after_success:
   - if [ "$dependencies" = "highest" ]; travis_retry php vendor/bin/coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ before_script:
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-dist --prefer-lowest -n; fi;
   - if [ "$dependencies" = "highest" ]; then composer update --prefer-dist -n; fi;
 
-script: "./robo test --coverage"
+script:
+  - if [ "$dependencies" != "highest" ]; ./robo test
+  - if [ "$dependencies" = "highest" ]; ./robo test --coverage
 
 after_success:
   - if [ "$dependencies" = "highest" ]; travis_retry php vendor/bin/coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 script: "./robo test --coverage"
 
 after_success:
-  - travis_retry php vendor/bin/coveralls -v
+  - if [ "$dependencies" = "highest" ]; travis_retry php vendor/bin/coveralls -v
 
 # Prior to a deploy, build a fresh robo.phar
 before_deploy:

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -124,7 +124,8 @@ trait ExecCommand
         return $cmd;
     }
 
-    public function getCommand() {
+    public function getCommand()
+    {
         return $this->process->getCommandLine();
     }
 

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -136,8 +136,7 @@ trait ExecCommand
      */
     protected function executeCommand($command)
     {
-        $this->process = new Process($command);
-        $result_data = $this->execute();
+        $result_data = $this->execute(new Process($command));
         return new Result(
             $this,
             $result_data->getExitCode(),

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -11,20 +11,7 @@ use Symfony\Component\Process\Process;
  */
 trait ExecCommand
 {
-    /**
-     * @var bool
-     */
-    protected $isPrinted = true;
-
-    /**
-     * @var bool
-     */
-    protected $isMetadataPrinted = true;
-
-    /**
-     * @var string
-     */
-    protected $workingDirectory;
+    use ExecTrait;
 
     /**
      * @var \Robo\Common\TimeKeeper
@@ -40,89 +27,6 @@ trait ExecCommand
             $this->execTimer = new TimeKeeper();
         }
         return $this->execTimer;
-    }
-
-    /**
-     * Is command printing its output to screen
-     *
-     * @return bool
-     */
-    public function getPrinted()
-    {
-        return $this->isPrinted;
-    }
-
-    /**
-     * Changes working directory of command
-     *
-     * @param string $dir
-     *
-     * @return $this
-     */
-    public function dir($dir)
-    {
-        $this->workingDirectory = $dir;
-        return $this;
-    }
-
-
-    /**
-     * Shortcut for setting isPrinted() and isMetadataPrinted() to false.
-     *
-     * @param bool $arg
-     *
-     * @return $this
-     */
-    public function silent($arg)
-    {
-        if (is_bool($arg)) {
-            $this->isPrinted = !$arg;
-            $this->isMetadataPrinted = !$arg;
-        }
-        return $this;
-    }
-
-    /**
-     * Should command output be printed
-     *
-     * @param bool $arg
-     *
-     * @return $this
-     */
-    public function printed($arg)
-    {
-        $this->logger()->warning("printed() is deprecated. Please use printOutput().");
-        return $this->printOutput($arg);
-    }
-
-    /**
-     * Should command output be printed
-     *
-     * @param bool $arg
-     *
-     * @return $this
-     */
-    public function printOutput($arg)
-    {
-        if (is_bool($arg)) {
-            $this->isPrinted = $arg;
-        }
-        return $this;
-    }
-
-    /**
-     * Should command metadata be printed. I,e., command and timer.
-     *
-     * @param bool $arg
-     *
-     * @return $this
-     */
-    public function printMetadata($arg)
-    {
-        if (is_bool($arg)) {
-            $this->isMetadataPrinted = $arg;
-        }
-        return $this;
     }
 
     /**
@@ -227,21 +131,6 @@ trait ExecCommand
      */
     protected function executeCommand($command)
     {
-        $process = new Process($command);
-        $process->setTimeout(null);
-        if ($this->workingDirectory) {
-            $process->setWorkingDirectory($this->workingDirectory);
-        }
-        $this->getExecTimer()->start();
-        if ($this->isPrinted) {
-            $process->run(function ($type, $buffer) {
-                print $buffer;
-            });
-        } else {
-            $process->run();
-        }
-        $this->getExecTimer()->stop();
-
-        return new Result($this, $process->getExitCode(), $process->getOutput(), ['time' => $this->getExecTimer()->elapsed()]);
+        return $this->execute($command);
     }
 }

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -131,6 +131,13 @@ trait ExecCommand
      */
     protected function executeCommand($command)
     {
-        return $this->execute($command);
+
+        $result_data = $this->execute($command);
+        return new Result(
+            $this,
+            $result_data->getExitCode(),
+            $result_data->getMessage(),
+            $result_data->getData()
+        );
     }
 }

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -124,6 +124,10 @@ trait ExecCommand
         return $cmd;
     }
 
+    public function getCommand() {
+        return $this->process->getCommandLine();
+    }
+
     /**
      * @param string $command
      *
@@ -131,8 +135,8 @@ trait ExecCommand
      */
     protected function executeCommand($command)
     {
-
-        $result_data = $this->execute($command);
+        $this->process = new Process($command);
+        $result_data = $this->execute();
         return new Result(
             $this,
             $result_data->getExitCode(),

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -49,7 +49,7 @@ trait ExecTrait
     /**
      * @var boolean
      */
-    protected $interactive;
+    protected $interactive = false;
 
     /**
      * @var bool
@@ -325,8 +325,10 @@ trait ExecTrait
     {
         if ($this->background && $this->process->isRunning()) {
             $this->process->stop();
-            $this->printTaskInfo("Stopped {command}",
-                ['command' => $this->getCommand()]);
+            $this->printTaskInfo(
+                "Stopped {command}",
+                ['command' => $this->getCommand()]
+            );
         }
     }
 

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -1,0 +1,341 @@
+<?php
+
+namespace Robo\Common;
+
+use Psr\Log\LoggerAwareTrait;
+use Robo\Result;
+use Symfony\Component\Process\Process;
+
+/**
+ * Class ExecTrait
+ * @package Robo\Common
+ */
+trait ExecTrait {
+
+    use LoggerAwareTrait;
+    use Timer;
+
+    /**
+     * @var bool
+     */
+    protected $background = FALSE;
+
+    /**
+     * @var null|int
+     */
+    protected $timeout = NULL;
+
+    /**
+     * @var null|int
+     */
+    protected $idleTimeout = NULL;
+
+    /**
+     * @var null|array
+     */
+    protected $env = NULL;
+
+    /**
+     * @var Process
+     */
+    protected $process;
+
+    /**
+     * @var resource|string
+     */
+    protected $input;
+
+    /**
+     * @var boolean
+     */
+    protected $interactive;
+
+    /**
+     * @var bool
+     */
+    protected $isPrinted = TRUE;
+
+    /**
+     * @var bool
+     */
+    protected $isMetadataPrinted = TRUE;
+
+    /**
+     * @var string
+     */
+    protected $workingDirectory;
+
+    /**
+     * Sets $this->interactive() based on posix_isatty().
+     */
+    public function detectInteractive() {
+        if (!isset($this->interactive) && function_exists('posix_isatty')) {
+            $this->interactive = posix_isatty(STDOUT);
+        }
+    }
+
+    /**
+     * Executes command in background mode (asynchronously)
+     *
+     * @return $this
+     */
+    public function background($arg = TRUE) {
+        $this->background = $arg;
+        return $this;
+    }
+
+    /**
+     * Stop command if it runs longer then $timeout in seconds
+     *
+     * @param int $timeout
+     *
+     * @return $this
+     */
+    public function timeout($timeout) {
+        $this->timeout = $timeout;
+        return $this;
+    }
+
+    /**
+     * Stops command if it does not output something for a while
+     *
+     * @param int $timeout
+     *
+     * @return $this
+     */
+    public function idleTimeout($timeout) {
+        $this->idleTimeout = $timeout;
+        return $this;
+    }
+
+    /**
+     * Sets the environment variables for the command
+     *
+     * @param array $env
+     *
+     * @return $this
+     */
+    public function env(array $env) {
+        $this->env = $env;
+        return $this;
+    }
+
+    /**
+     * Pass an input to the process. Can be resource created with fopen() or string
+     *
+     * @param resource|string $input
+     *
+     * @return $this
+     */
+    public function setInput($input) {
+        $this->input = $input;
+        return $this;
+    }
+
+    /**
+     * Attach tty to process for interactive input
+     *
+     * @param $interactive bool
+     *
+     * @return $this
+     */
+    public function interactive($interactive) {
+        $this->interactive = $interactive;
+        return $this;
+    }
+
+
+    /**
+     * Is command printing its output to screen
+     *
+     * @return bool
+     */
+    public function getPrinted() {
+        return $this->isPrinted;
+    }
+
+    /**
+     * Changes working directory of command
+     *
+     * @param string $dir
+     *
+     * @return $this
+     */
+    public function dir($dir) {
+        $this->workingDirectory = $dir;
+        return $this;
+    }
+
+    /**
+     * Shortcut for setting isPrinted() and isMetadataPrinted() to false.
+     *
+     * @param bool $arg
+     *
+     * @return $this
+     */
+    public function silent($arg) {
+        if (is_bool($arg)) {
+            $this->isPrinted = !$arg;
+            $this->isMetadataPrinted = !$arg;
+        }
+        return $this;
+    }
+
+    /**
+     * Should command output be printed
+     *
+     * @param bool $arg
+     *
+     * @return $this
+     *
+     * @deprecated
+     */
+    public function printed($arg) {
+        $this->logger->warning("printed() is deprecated. Please use printOutput().");
+        return $this->printOutput($arg);
+    }
+
+    /**
+     * Should command output be printed
+     *
+     * @param bool $arg
+     *
+     * @return $this
+     */
+    public function printOutput($arg) {
+        if (is_bool($arg)) {
+            $this->isPrinted = $arg;
+        }
+        return $this;
+    }
+
+    /**
+     * Should command metadata be printed. I,e., command and timer.
+     *
+     * @param bool $arg
+     *
+     * @return $this
+     */
+    public function printMetadata($arg) {
+        if (is_bool($arg)) {
+            $this->isMetadataPrinted = $arg;
+        }
+        return $this;
+    }
+
+    /**
+     *
+     */
+    public function __destruct() {
+        $this->stop();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run() {
+        $output_callback =
+            function ($type, $buffer) {
+                $progressWasVisible = $this->hideTaskProgress();
+                print($buffer);
+                $this->showTaskProgress($progressWasVisible);
+            };
+
+        return $this->execute($this->getCommand(), $output_callback);
+    }
+
+    /**
+     * @param $command
+     * @param null $output_callback
+     *
+     * @return \Robo\Result
+     */
+    public function execute($command, $output_callback = NULL) {
+       if (!$output_callback) {
+            $output_callback = function ($type, $buffer) {
+                print($buffer);
+            };
+        }
+
+        if ($this->isMetadataPrinted) {
+            $this->printAction();
+        }
+        $this->process = new Process($command);
+        $this->process->setTimeout($this->timeout);
+        $this->process->setIdleTimeout($this->idleTimeout);
+        $this->process->setWorkingDirectory($this->workingDirectory);
+
+        if ($this->input) {
+            $this->process->setInput($this->input);
+        }
+
+        if ($this->interactive) {
+            $this->process->setTty(TRUE);
+        }
+
+        if (isset($this->env)) {
+            $this->process->setEnv($this->env);
+        }
+
+        if (!$this->background and !$this->isPrinted) {
+            $this->startTimer();
+            $this->process->run();
+            $this->stopTimer();
+            return new Result($this, $this->process->getExitCode(),
+                $this->process->getOutput(), $this->getResultData());
+        }
+
+        if (!$this->background and $this->isPrinted) {
+            $this->startTimer();
+            $this->process->run($output_callback);
+            $this->stopTimer();
+            return new Result($this, $this->process->getExitCode(),
+                $this->process->getOutput(), $this->getResultData());
+        }
+
+        try {
+            $this->process->start();
+        } catch (\Exception $e) {
+            return Result::fromException($this, $e);
+        }
+        return Result::success($this);
+    }
+
+    /**
+     *
+     */
+    protected function stop() {
+        if ($this->background && $this->process->isRunning()) {
+            $this->process->stop();
+            $this->printTaskInfo("Stopped {command}",
+                ['command' => $this->getCommand()]);
+        }
+    }
+
+    /**
+     * @param array $context
+     */
+    protected function printAction($context = []) {
+        $command = $this->getCommand();
+        $dir = $this->workingDirectory ? " in {dir}" : "";
+        $this->printTaskInfo("Running {command}$dir", [
+                'command' => $command,
+                'dir' => $this->workingDirectory
+            ] + $context);
+    }
+
+    /**
+     * Gets the data array to be passed to Result().
+     *
+     * @return array
+     *   The data array passed to Result().
+     */
+    protected function getResultData() {
+        if ($this->isMetadataPrinted) {
+            return ['time' => $this->getExecutionTime()];
+        }
+
+        return [];
+    }
+
+}

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -250,23 +250,16 @@ trait ExecTrait
      */
     public function run()
     {
-        $output_callback =
-            function ($type, $buffer) {
-                $progressWasVisible = $this->hideTaskProgress();
-                print($buffer);
-                $this->showTaskProgress($progressWasVisible);
-            };
-
-        return $this->execute($this->getCommand(), $output_callback);
+        return $this->execute($this->getCommand());
     }
 
     /**
-     * @param $command
-     * @param null $output_callback
+     * @param string $command
+     * @param callable $output_callback
      *
      * @return \Robo\Result
      */
-    public function execute($command, $output_callback = null)
+    protected function execute($command, $output_callback = null)
     {
         if (!$output_callback) {
             $output_callback = function ($type, $buffer) {

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -62,6 +62,17 @@ trait ExecTrait
      */
     protected $workingDirectory;
 
+    /** @var string */
+    protected $command;
+
+    /**
+     * @return string
+     */
+    public function getCommand()
+    {
+        return $this->command;
+    }
+
     /**
      * Sets $this->interactive() based on posix_isatty().
      */

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -352,5 +352,4 @@ trait ExecTrait
 
         return [];
     }
-
 }

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -12,10 +12,6 @@ use Symfony\Component\Process\Process;
  */
 trait ExecTrait
 {
-
-    use LoggerAwareTrait;
-    use Timer;
-
     /**
      * @var bool
      */
@@ -242,7 +238,9 @@ trait ExecTrait
      */
     public function __destruct()
     {
-        $this->stop();
+        if (!$this->background()) {
+            $this->stop();
+        }
     }
 
     /**
@@ -291,16 +289,24 @@ trait ExecTrait
             $this->startTimer();
             $this->process->run();
             $this->stopTimer();
-            return new Result($this, $this->process->getExitCode(),
-                $this->process->getOutput(), $this->getResultData());
+            return new Result(
+                $this,
+                $this->process->getExitCode(),
+                $this->process->getOutput(),
+                $this->getResultData()
+            );
         }
 
         if (!$this->background and $this->isPrinted) {
             $this->startTimer();
             $this->process->run($output_callback);
             $this->stopTimer();
-            return new Result($this, $this->process->getExitCode(),
-                $this->process->getOutput(), $this->getResultData());
+            return new Result(
+                $this,
+                $this->process->getExitCode(),
+                $this->process->getOutput(),
+                $this->getResultData()
+            );
         }
 
         try {

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -63,17 +63,6 @@ trait ExecTrait
      */
     protected $workingDirectory;
 
-    /** @var string */
-    protected $command;
-
-    /**
-     * @return string
-     */
-    public function getCommand()
-    {
-        return $this->command;
-    }
-
     /**
      * Sets $this->interactive() based on posix_isatty().
      */
@@ -261,7 +250,7 @@ trait ExecTrait
      *
      * @return \Robo\ResultData
      */
-    protected function execute($command, $output_callback = null)
+    protected function execute($output_callback = null)
     {
         if (!$output_callback) {
             $output_callback = function ($type, $buffer) {
@@ -272,7 +261,6 @@ trait ExecTrait
         if ($this->isMetadataPrinted) {
             $this->printAction();
         }
-        $this->process = new Process($command);
         $this->process->setTimeout($this->timeout);
         $this->process->setIdleTimeout($this->idleTimeout);
         $this->process->setWorkingDirectory($this->workingDirectory);

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -4,6 +4,7 @@ namespace Robo\Common;
 
 use Psr\Log\LoggerAwareTrait;
 use Robo\Result;
+use Robo\ResultData;
 use Symfony\Component\Process\Process;
 
 /**
@@ -255,18 +256,10 @@ trait ExecTrait
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function run()
-    {
-        return $this->execute($this->getCommand());
-    }
-
-    /**
      * @param string $command
      * @param callable $output_callback
      *
-     * @return \Robo\Result
+     * @return \Robo\ResultData
      */
     protected function execute($command, $output_callback = null)
     {
@@ -300,8 +293,7 @@ trait ExecTrait
             $this->startTimer();
             $this->process->run();
             $this->stopTimer();
-            return new Result(
-                $this,
+            return new ResultData(
                 $this->process->getExitCode(),
                 $this->process->getOutput(),
                 $this->getResultData()
@@ -312,8 +304,7 @@ trait ExecTrait
             $this->startTimer();
             $this->process->run($output_callback);
             $this->stopTimer();
-            return new Result(
-                $this,
+            return new ResultData(
                 $this->process->getExitCode(),
                 $this->process->getOutput(),
                 $this->getResultData()
@@ -323,9 +314,13 @@ trait ExecTrait
         try {
             $this->process->start();
         } catch (\Exception $e) {
-            return Result::fromException($this, $e);
+            return new ResultData(
+                $this->process->getExitCode(),
+                $e->getMessage(),
+                $this->getResultData()
+            );
         }
-        return Result::success($this);
+        return new ResultData($this->process->getExitCode());
     }
 
     /**

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -10,7 +10,8 @@ use Symfony\Component\Process\Process;
  * Class ExecTrait
  * @package Robo\Common
  */
-trait ExecTrait {
+trait ExecTrait
+{
 
     use LoggerAwareTrait;
     use Timer;
@@ -18,22 +19,22 @@ trait ExecTrait {
     /**
      * @var bool
      */
-    protected $background = FALSE;
+    protected $background = false;
 
     /**
      * @var null|int
      */
-    protected $timeout = NULL;
+    protected $timeout = null;
 
     /**
      * @var null|int
      */
-    protected $idleTimeout = NULL;
+    protected $idleTimeout = null;
 
     /**
      * @var null|array
      */
-    protected $env = NULL;
+    protected $env = null;
 
     /**
      * @var Process
@@ -53,12 +54,12 @@ trait ExecTrait {
     /**
      * @var bool
      */
-    protected $isPrinted = TRUE;
+    protected $isPrinted = true;
 
     /**
      * @var bool
      */
-    protected $isMetadataPrinted = TRUE;
+    protected $isMetadataPrinted = true;
 
     /**
      * @var string
@@ -68,7 +69,8 @@ trait ExecTrait {
     /**
      * Sets $this->interactive() based on posix_isatty().
      */
-    public function detectInteractive() {
+    public function detectInteractive()
+    {
         if (!isset($this->interactive) && function_exists('posix_isatty')) {
             $this->interactive = posix_isatty(STDOUT);
         }
@@ -79,7 +81,8 @@ trait ExecTrait {
      *
      * @return $this
      */
-    public function background($arg = TRUE) {
+    public function background($arg = true)
+    {
         $this->background = $arg;
         return $this;
     }
@@ -91,7 +94,8 @@ trait ExecTrait {
      *
      * @return $this
      */
-    public function timeout($timeout) {
+    public function timeout($timeout)
+    {
         $this->timeout = $timeout;
         return $this;
     }
@@ -103,7 +107,8 @@ trait ExecTrait {
      *
      * @return $this
      */
-    public function idleTimeout($timeout) {
+    public function idleTimeout($timeout)
+    {
         $this->idleTimeout = $timeout;
         return $this;
     }
@@ -115,7 +120,8 @@ trait ExecTrait {
      *
      * @return $this
      */
-    public function env(array $env) {
+    public function env(array $env)
+    {
         $this->env = $env;
         return $this;
     }
@@ -127,7 +133,8 @@ trait ExecTrait {
      *
      * @return $this
      */
-    public function setInput($input) {
+    public function setInput($input)
+    {
         $this->input = $input;
         return $this;
     }
@@ -139,7 +146,8 @@ trait ExecTrait {
      *
      * @return $this
      */
-    public function interactive($interactive) {
+    public function interactive($interactive)
+    {
         $this->interactive = $interactive;
         return $this;
     }
@@ -150,7 +158,8 @@ trait ExecTrait {
      *
      * @return bool
      */
-    public function getPrinted() {
+    public function getPrinted()
+    {
         return $this->isPrinted;
     }
 
@@ -161,7 +170,8 @@ trait ExecTrait {
      *
      * @return $this
      */
-    public function dir($dir) {
+    public function dir($dir)
+    {
         $this->workingDirectory = $dir;
         return $this;
     }
@@ -173,7 +183,8 @@ trait ExecTrait {
      *
      * @return $this
      */
-    public function silent($arg) {
+    public function silent($arg)
+    {
         if (is_bool($arg)) {
             $this->isPrinted = !$arg;
             $this->isMetadataPrinted = !$arg;
@@ -190,7 +201,8 @@ trait ExecTrait {
      *
      * @deprecated
      */
-    public function printed($arg) {
+    public function printed($arg)
+    {
         $this->logger->warning("printed() is deprecated. Please use printOutput().");
         return $this->printOutput($arg);
     }
@@ -202,7 +214,8 @@ trait ExecTrait {
      *
      * @return $this
      */
-    public function printOutput($arg) {
+    public function printOutput($arg)
+    {
         if (is_bool($arg)) {
             $this->isPrinted = $arg;
         }
@@ -216,7 +229,8 @@ trait ExecTrait {
      *
      * @return $this
      */
-    public function printMetadata($arg) {
+    public function printMetadata($arg)
+    {
         if (is_bool($arg)) {
             $this->isMetadataPrinted = $arg;
         }
@@ -226,14 +240,16 @@ trait ExecTrait {
     /**
      *
      */
-    public function __destruct() {
+    public function __destruct()
+    {
         $this->stop();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function run() {
+    public function run()
+    {
         $output_callback =
             function ($type, $buffer) {
                 $progressWasVisible = $this->hideTaskProgress();
@@ -250,8 +266,9 @@ trait ExecTrait {
      *
      * @return \Robo\Result
      */
-    public function execute($command, $output_callback = NULL) {
-       if (!$output_callback) {
+    public function execute($command, $output_callback = null)
+    {
+        if (!$output_callback) {
             $output_callback = function ($type, $buffer) {
                 print($buffer);
             };
@@ -270,7 +287,7 @@ trait ExecTrait {
         }
 
         if ($this->interactive) {
-            $this->process->setTty(TRUE);
+            $this->process->setTty(true);
         }
 
         if (isset($this->env)) {
@@ -304,7 +321,8 @@ trait ExecTrait {
     /**
      *
      */
-    protected function stop() {
+    protected function stop()
+    {
         if ($this->background && $this->process->isRunning()) {
             $this->process->stop();
             $this->printTaskInfo("Stopped {command}",
@@ -315,7 +333,8 @@ trait ExecTrait {
     /**
      * @param array $context
      */
-    protected function printAction($context = []) {
+    protected function printAction($context = [])
+    {
         $command = $this->getCommand();
         $dir = $this->workingDirectory ? " in {dir}" : "";
         $this->printTaskInfo("Running {command}$dir", [
@@ -330,7 +349,8 @@ trait ExecTrait {
      * @return array
      *   The data array passed to Result().
      */
-    protected function getResultData() {
+    protected function getResultData()
+    {
         if ($this->isMetadataPrinted) {
             return ['time' => $this->getExecutionTime()];
         }

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -245,13 +245,15 @@ trait ExecTrait
     }
 
     /**
-     * @param string $command
+     * @param Process $process
      * @param callable $output_callback
      *
      * @return \Robo\ResultData
      */
-    protected function execute($output_callback = null)
+    protected function execute($process, $output_callback = null)
     {
+        $this->process = $process;
+
         if (!$output_callback) {
             $output_callback = function ($type, $buffer) {
                 print($buffer);
@@ -316,7 +318,7 @@ trait ExecTrait
      */
     protected function stop()
     {
-        if ($this->background && $this->process->isRunning()) {
+        if ($this->background && isset($this->process) && $this->process->isRunning()) {
             $this->process->stop();
             $this->printTaskInfo(
                 "Stopped {command}",

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -235,16 +235,6 @@ trait ExecTrait
     }
 
     /**
-     *
-     */
-    public function __destruct()
-    {
-        if (!$this->background()) {
-            $this->stop();
-        }
-    }
-
-    /**
      * @param Process $process
      * @param callable $output_callback
      *

--- a/src/Common/ProcessExecutor.php
+++ b/src/Common/ProcessExecutor.php
@@ -18,11 +18,13 @@ class ProcessExecutor
         $this->logger = Robo::logger();
     }
 
-    public function getCommand() {
+    public function getCommand()
+    {
         return $this->process->getCommandLine();
     }
 
-    public function run() {
+    public function run()
+    {
         return $this->execute($this->getCommand());
     }
 }

--- a/src/Common/ProcessExecutor.php
+++ b/src/Common/ProcessExecutor.php
@@ -6,21 +6,15 @@ use Robo\Contract\TaskInterface;
 use Robo\Robo;
 use Robo\Task\BaseTask;
 
-class ProcessExecutor extends BaseTask implements TaskInterface
+class ProcessExecutor implements TaskInterface
 {
     use ExecTrait;
-
-    /** @var string */
-    protected $command;
+    use TaskIO; // uses LoggerAwareTrait and ConfigAwareTrait
+    use ProgressIndicatorAwareTrait;
 
     public function __construct($command)
     {
         $this->command = $command;
         $this->logger = Robo::logger();
-    }
-
-    public function getCommand()
-    {
-        return $this->command;
     }
 }

--- a/src/Common/ProcessExecutor.php
+++ b/src/Common/ProcessExecutor.php
@@ -5,18 +5,21 @@ namespace Robo\Common;
 use Robo\Robo;
 use Robo\Task\BaseTask;
 
-class ProcessExecutor extends BaseTask {
-  use ExecTrait;
+class ProcessExecutor extends BaseTask
+{
+    use ExecTrait;
 
-  /** @var string */
-  protected $command;
+    /** @var string */
+    protected $command;
 
-  public function __construct($command) {
-      $this->command = $command;
-      $this->logger = Robo::logger();
-  }
+    public function __construct($command)
+    {
+        $this->command = $command;
+        $this->logger = Robo::logger();
+    }
 
-  public function getCommand() {
-      return $this->command;
-  }
+    public function getCommand()
+    {
+        return $this->command;
+    }
 }

--- a/src/Common/ProcessExecutor.php
+++ b/src/Common/ProcessExecutor.php
@@ -12,10 +12,14 @@ class ProcessExecutor
     use TaskIO; // uses LoggerAwareTrait and ConfigAwareTrait
     use ProgressIndicatorAwareTrait;
 
-    public function __construct($command)
+    public function __construct($process)
     {
-        $this->command = $command;
+        $this->process = $process;
         $this->logger = Robo::logger();
+    }
+
+    public function getCommand() {
+        return $this->process->getCommandLine();
     }
 
     public function run() {

--- a/src/Common/ProcessExecutor.php
+++ b/src/Common/ProcessExecutor.php
@@ -2,10 +2,11 @@
 
 namespace Robo\Common;
 
+use Robo\Contract\TaskInterface;
 use Robo\Robo;
 use Robo\Task\BaseTask;
 
-class ProcessExecutor extends BaseTask
+class ProcessExecutor extends BaseTask implements TaskInterface
 {
     use ExecTrait;
 

--- a/src/Common/ProcessExecutor.php
+++ b/src/Common/ProcessExecutor.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Robo\Common;
+
+use Robo\Robo;
+use Robo\Task\BaseTask;
+
+class ProcessExecutor extends BaseTask {
+  use ExecTrait;
+
+  /** @var string */
+  protected $command;
+
+  public function __construct($command) {
+      $this->command = $command;
+      $this->logger = Robo::logger();
+  }
+
+  public function getCommand() {
+      return $this->command;
+  }
+}

--- a/src/Common/ProcessExecutor.php
+++ b/src/Common/ProcessExecutor.php
@@ -25,6 +25,6 @@ class ProcessExecutor
 
     public function run()
     {
-        return $this->execute($this->getCommand());
+        return $this->execute($this->process);
     }
 }

--- a/src/Common/ProcessExecutor.php
+++ b/src/Common/ProcessExecutor.php
@@ -6,7 +6,7 @@ use Robo\Contract\TaskInterface;
 use Robo\Robo;
 use Robo\Task\BaseTask;
 
-class ProcessExecutor implements TaskInterface
+class ProcessExecutor
 {
     use ExecTrait;
     use TaskIO; // uses LoggerAwareTrait and ConfigAwareTrait
@@ -16,5 +16,9 @@ class ProcessExecutor implements TaskInterface
     {
         $this->command = $command;
         $this->logger = Robo::logger();
+    }
+
+    public function run() {
+        return $this->execute($this->getCommand());
     }
 }

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -27,7 +27,8 @@ use Robo\Result;
  * ?>
  * ```
  */
-class Exec extends BaseTask implements CommandInterface, SimulatedInterface {
+class Exec extends BaseTask implements CommandInterface, SimulatedInterface
+{
     use \Robo\Common\CommandReceiver;
     use \Robo\Common\ExecOneCommand;
 
@@ -44,7 +45,8 @@ class Exec extends BaseTask implements CommandInterface, SimulatedInterface {
     /**
      * @param string|\Robo\Contract\CommandInterface $command
      */
-    public function __construct($command) {
+    public function __construct($command)
+    {
         $this->command = $this->receiveCommand($command);
     }
 
@@ -53,7 +55,8 @@ class Exec extends BaseTask implements CommandInterface, SimulatedInterface {
      *
      * @return $this
      */
-    public function background($arg = TRUE) {
+    public function background($arg = true)
+    {
         self::$instances[] = $this;
         $this->background = $arg;
         return $this;
@@ -62,18 +65,21 @@ class Exec extends BaseTask implements CommandInterface, SimulatedInterface {
     /**
      * {@inheritdoc}
      */
-    public function getCommand() {
+    public function getCommand()
+    {
         return trim($this->command . $this->arguments);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function simulate($context) {
+    public function simulate($context)
+    {
         $this->printAction($context);
     }
 
-    public static function stopRunningJobs() {
+    public static function stopRunningJobs()
+    {
         foreach (self::$instances as $instance) {
             if ($instance) {
                 unset($instance);

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -51,6 +51,14 @@ class Exec extends BaseTask implements CommandInterface, SimulatedInterface
     }
 
     /**
+     *
+     */
+    public function __destruct()
+    {
+        $this->stop();
+    }
+
+    /**
      * Executes command in background mode (asynchronously)
      *
      * @return $this

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -86,6 +86,20 @@ class Exec extends BaseTask implements CommandInterface, SimulatedInterface
             }
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run()
+    {
+        $result_data = $this->execute($this->getCommand());
+        return new Result(
+            $this,
+            $result_data->getExitCode(),
+            $result_data->getMessage(),
+            $result_data->getData()
+        );
+    }
 }
 
 if (function_exists('pcntl_signal')) {

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -92,8 +92,7 @@ class Exec extends BaseTask implements CommandInterface, SimulatedInterface
      */
     public function run()
     {
-        $this->process = new Process($this->getCommand());
-        $result_data = $this->execute();
+        $result_data = $this->execute(new Process($this->getCommand()));
         return new Result(
             $this,
             $result_data->getExitCode(),

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -48,7 +48,6 @@ class Exec extends BaseTask implements CommandInterface, SimulatedInterface
     public function __construct($command)
     {
         $this->command = $this->receiveCommand($command);
-        $this->process = new Process($this->getCommand());
     }
 
     /**
@@ -93,6 +92,7 @@ class Exec extends BaseTask implements CommandInterface, SimulatedInterface
      */
     public function run()
     {
+        $this->process = new Process($this->getCommand());
         $result_data = $this->execute();
         return new Result(
             $this,

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -1,6 +1,7 @@
 <?php
 namespace Robo\Task\Base;
 
+use Robo\Common\ExecTrait;
 use Robo\Contract\CommandInterface;
 use Robo\Contract\PrintedInterface;
 use Robo\Contract\SimulatedInterface;
@@ -26,8 +27,7 @@ use Robo\Result;
  * ?>
  * ```
  */
-class Exec extends BaseTask implements CommandInterface, PrintedInterface, SimulatedInterface
-{
+class Exec extends BaseTask implements CommandInterface, SimulatedInterface {
     use \Robo\Common\CommandReceiver;
     use \Robo\Common\ExecOneCommand;
 
@@ -42,57 +42,10 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
     protected $command;
 
     /**
-     * @var bool
-     */
-    protected $background = false;
-
-    /**
-     * @var null|int
-     */
-    protected $timeout = null;
-
-    /**
-     * @var null|int
-     */
-    protected $idleTimeout = null;
-
-    /**
-     * @var null|array
-     */
-    protected $env = null;
-
-    /**
-     * @var Process
-     */
-    protected $process;
-
-    /**
-     * @var resource|string
-     */
-    protected $input;
-
-    /**
-     * @var boolean
-     */
-    protected $interactive;
-
-    /**
      * @param string|\Robo\Contract\CommandInterface $command
      */
-    public function __construct($command)
-    {
+    public function __construct($command) {
         $this->command = $this->receiveCommand($command);
-        if (!isset($this->interactive) && function_exists('posix_isatty')) {
-            $this->interactive = posix_isatty(STDOUT);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getCommand()
-    {
-        return trim($this->command . $this->arguments);
     }
 
     /**
@@ -100,179 +53,27 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
      *
      * @return $this
      */
-    public function background()
-    {
+    public function background($arg = TRUE) {
         self::$instances[] = $this;
-        $this->background = true;
+        $this->background = $arg;
         return $this;
-    }
-
-    /**
-     * Stop command if it runs longer then $timeout in seconds
-     *
-     * @param int $timeout
-     *
-     * @return $this
-     */
-    public function timeout($timeout)
-    {
-        $this->timeout = $timeout;
-        return $this;
-    }
-
-    /**
-     * Stops command if it does not output something for a while
-     *
-     * @param int $timeout
-     *
-     * @return $this
-     */
-    public function idleTimeout($timeout)
-    {
-        $this->idleTimeout = $timeout;
-        return $this;
-    }
-
-    /**
-     * Sets the environment variables for the command
-     *
-     * @param array $env
-     *
-     * @return $this
-     */
-    public function env(array $env)
-    {
-        $this->env = $env;
-        return $this;
-    }
-
-    /**
-     * Pass an input to the process. Can be resource created with fopen() or string
-     *
-     * @param resource|string $input
-     *
-     * @return $this
-     */
-    public function setInput($input)
-    {
-        $this->input = $input;
-        return $this;
-    }
-
-    /**
-     * Attach tty to process for interactive input
-     *
-     * @param $interactive bool
-     *
-     * @return $this
-     */
-    public function interactive($interactive)
-    {
-        $this->interactive = $interactive;
-        return $this;
-    }
-
-    public function __destruct()
-    {
-        $this->stop();
-    }
-
-    protected function stop()
-    {
-        if ($this->background && $this->process->isRunning()) {
-            $this->process->stop();
-            $this->printTaskInfo("Stopped {command}", ['command' => $this->getCommand()]);
-        }
-    }
-
-    /**
-     * @param array $context
-     */
-    protected function printAction($context = [])
-    {
-        $command = $this->getCommand();
-        $dir = $this->workingDirectory ? " in {dir}" : "";
-        $this->printTaskInfo("Running {command}$dir", ['command' => $command, 'dir' => $this->workingDirectory] + $context);
-    }
-
-    /**
-     * Gets the data array to be passed to Result().
-     *
-     * @return array
-     *   The data array passed to Result().
-     */
-    protected function getResultData()
-    {
-        if ($this->isMetadataPrinted) {
-            return ['time' => $this->getExecutionTime()];
-        }
-
-        return [];
     }
 
     /**
      * {@inheritdoc}
      */
-    public function run()
-    {
-        if ($this->isMetadataPrinted) {
-            $this->printAction();
-        }
-        $this->process = new Process($this->getCommand());
-        $this->process->setTimeout($this->timeout);
-        $this->process->setIdleTimeout($this->idleTimeout);
-        $this->process->setWorkingDirectory($this->workingDirectory);
-
-        if ($this->input) {
-            $this->process->setInput($this->input);
-        }
-
-        if ($this->interactive) {
-            $this->process->setTty(true);
-        }
-
-        if (isset($this->env)) {
-            $this->process->setEnv($this->env);
-        }
-
-        if (!$this->background and !$this->isPrinted) {
-            $this->startTimer();
-            $this->process->run();
-            $this->stopTimer();
-            return new Result($this, $this->process->getExitCode(), $this->process->getOutput(), $this->getResultData());
-        }
-
-        if (!$this->background and $this->isPrinted) {
-            $this->startTimer();
-            $this->process->run(
-                function ($type, $buffer) {
-                    $progressWasVisible = $this->hideTaskProgress();
-                    print($buffer);
-                    $this->showTaskProgress($progressWasVisible);
-                }
-            );
-            $this->stopTimer();
-            return new Result($this, $this->process->getExitCode(), $this->process->getOutput(), $this->getResultData());
-        }
-
-        try {
-            $this->process->start();
-        } catch (\Exception $e) {
-            return Result::fromException($this, $e);
-        }
-        return Result::success($this);
+    public function getCommand() {
+        return trim($this->command . $this->arguments);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function simulate($context)
-    {
+    public function simulate($context) {
         $this->printAction($context);
     }
 
-    public static function stopRunningJobs()
-    {
+    public static function stopRunningJobs() {
         foreach (self::$instances as $instance) {
             if ($instance) {
                 unset($instance);

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -27,7 +27,7 @@ use Robo\Result;
  * ?>
  * ```
  */
-class Exec extends BaseTask implements CommandInterface, SimulatedInterface
+class Exec extends BaseTask implements CommandInterface, PrintedInterface, SimulatedInterface
 {
     use \Robo\Common\CommandReceiver;
     use \Robo\Common\ExecOneCommand;

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -48,6 +48,7 @@ class Exec extends BaseTask implements CommandInterface, SimulatedInterface
     public function __construct($command)
     {
         $this->command = $this->receiveCommand($command);
+        $this->process = new Process($this->getCommand());
     }
 
     /**
@@ -92,7 +93,7 @@ class Exec extends BaseTask implements CommandInterface, SimulatedInterface
      */
     public function run()
     {
-        $result_data = $this->execute($this->getCommand());
+        $result_data = $this->execute();
         return new Result(
             $this,
             $result_data->getExitCode(),

--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -39,11 +39,6 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
     protected $test = '';
 
     /**
-     * @var string
-     */
-    protected $command;
-
-    /**
      * @param string $pathToCodeception
      *
      * @throws \Robo\Exception\TaskException

--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -39,6 +39,11 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
     protected $test = '';
 
     /**
+     * @var string
+     */
+    protected $command;
+
+    /**
      * @param string $pathToCodeception
      *
      * @throws \Robo\Exception\TaskException

--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -5,6 +5,7 @@ use Robo\Contract\PrintedInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
 use Robo\Contract\CommandInterface;
+use Symfony\Component\Process\Process;
 
 /**
  * Executes Codeception tests

--- a/tests/unit/ApplicationTest.php
+++ b/tests/unit/ApplicationTest.php
@@ -49,7 +49,7 @@ class ApplicationTest extends \Codeception\TestCase\Test
         // commandfile instance.
         $method = new ReflectionMethod($this->roboCommandFileInstance, 'task');
         $method->setAccessible(true);
-        $collectionBuilder = $method->invoke($this->roboCommandFileInstance, 'Robo\Task\Base\Exec', ['ls']);
+        $collectionBuilder = $method->invoke($this->roboCommandFileInstance, 'Robo\Task\Base\Exec', 'ls');
         verify(get_class($collectionBuilder))->equals('Robo\Collection\CollectionBuilder');
         $task = $collectionBuilder->getCollectionBuilderCurrentTask();
         verify(get_class($task))->equals('Robo\Task\Base\Exec');


### PR DESCRIPTION
* Moved process execution logic outside of ExecCommand.php and Exec.php into ExecTrait.php, which is now used by them both.
* Added ProcessExecutor, which can be used outside of collection to execute arbitrary commands. 
    * ProcessExecutor extends BaseTasks so that it is able to print messages to screen and log messages.
* Added detectInteractive() method. `$this->interactive` now defaults to false.