### PR TITLE
Add TaskIO::setVerbosityThreshold()

### DIFF
--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -12,6 +12,7 @@ use ReflectionClass;
 use Robo\Task\BaseTask;
 use Robo\Contract\BuilderAwareInterface;
 use Robo\Contract\CommandInterface;
+use Robo\Contract\VerbosityThresholdInterface;
 
 /**
  * Creates a collection, and adds tasks to it.  The collection builder
@@ -377,9 +378,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         if ($task instanceof BuilderAwareInterface) {
             $task->setBuilder($this);
         }
-        // TODO: It would be better if we had a TaskIOInterface
-        // to go with the TaskIO trait. Perhaps in 2.0.
-        if (method_exists($task, 'setVerbosityThreshold')) {
+        if ($task instanceof VerbosityThresholdInterface) {
             $task->setVerbosityThreshold($this->verbosityThreshold());
         }
 

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -236,6 +236,18 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         return $this;
     }
 
+    public function setRequiredVerbosity($requiredVerbosity)
+    {
+        $currentTask = ($this->currentTask instanceof WrappedTaskInterface) ? $this->currentTask->original() : $this->currentTask;
+        if ($currentTask) {
+            $currentTask->setRequiredVerbosity($requiredVerbosity);
+            return $this;
+        }
+        parent::setRequiredVerbosity($requiredVerbosity);
+        return $this;
+    }
+
+
     /**
      * Return the current task for this collection builder.
      * TODO: Not needed?
@@ -257,6 +269,8 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         $collectionBuilder = new self($this->commandFile);
         $collectionBuilder->inflect($this);
         $collectionBuilder->simulated($this->isSimulated());
+        $collectionBuilder->setRequiredVerbosity($this->requiredVerbosity());
+
         return $collectionBuilder;
     }
 
@@ -362,6 +376,11 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         }
         if ($task instanceof BuilderAwareInterface) {
             $task->setBuilder($this);
+        }
+        // TODO: It would be better if we had a TaskIOInterface
+        // to go with the TaskIO trait. Perhaps in 2.0.
+        if (method_exists($task, 'setRequiredVerbosity')) {
+            $task->setRequiredVerbosity($this->requiredVerbosity());
         }
 
         // Do not wrap our wrappers.

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -236,14 +236,14 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         return $this;
     }
 
-    public function setRequiredVerbosity($requiredVerbosity)
+    public function setVerbosityThreshold($verbosityThreshold)
     {
         $currentTask = ($this->currentTask instanceof WrappedTaskInterface) ? $this->currentTask->original() : $this->currentTask;
         if ($currentTask) {
-            $currentTask->setRequiredVerbosity($requiredVerbosity);
+            $currentTask->setVerbosityThreshold($verbosityThreshold);
             return $this;
         }
-        parent::setRequiredVerbosity($requiredVerbosity);
+        parent::setVerbosityThreshold($verbosityThreshold);
         return $this;
     }
 
@@ -269,7 +269,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         $collectionBuilder = new self($this->commandFile);
         $collectionBuilder->inflect($this);
         $collectionBuilder->simulated($this->isSimulated());
-        $collectionBuilder->setRequiredVerbosity($this->requiredVerbosity());
+        $collectionBuilder->setVerbosityThreshold($this->verbosityThreshold());
 
         return $collectionBuilder;
     }
@@ -379,8 +379,8 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         }
         // TODO: It would be better if we had a TaskIOInterface
         // to go with the TaskIO trait. Perhaps in 2.0.
-        if (method_exists($task, 'setRequiredVerbosity')) {
-            $task->setRequiredVerbosity($this->requiredVerbosity());
+        if (method_exists($task, 'setVerbosityThreshold')) {
+            $task->setVerbosityThreshold($this->verbosityThreshold());
         }
 
         // Do not wrap our wrappers.

--- a/src/Common/OutputAdapter.php
+++ b/src/Common/OutputAdapter.php
@@ -1,0 +1,38 @@
+<?php
+namespace Robo\Common;
+
+use Robo\Contract\OutputAdapterInterface;
+use Robo\Contract\OutputAwareInterface;
+use Robo\Contract\VerbosityThresholdInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Adapt OutputInterface or other output function to the VerbosityThresholdInterface.
+ */
+class OutputAdapter implements OutputAdapterInterface, OutputAwareInterface
+{
+    use OutputAwareTrait;
+
+    protected $verbosityMap = [
+        VerbosityThresholdInterface::VERBOSITY_NORMAL => OutputInterface::VERBOSITY_NORMAL,
+        VerbosityThresholdInterface::VERBOSITY_VERBOSE => OutputInterface::VERBOSITY_VERBOSE,
+        VerbosityThresholdInterface::VERBOSITY_VERY_VERBOSE => OutputInterface::VERBOSITY_VERY_VERBOSE,
+        VerbosityThresholdInterface::VERBOSITY_DEBUG => OutputInterface::VERBOSITY_DEBUG,
+    ];
+
+    public function verbosityMeetsThreshold($verbosityThreshold)
+    {
+        if (!isset($this->verbosityMap[$verbosityThreshold])) {
+            return true;
+        }
+        $verbosityThreshold = $this->verbosityMap[$verbosityThreshold];
+        $verbosity = $this->output()->getVerbosity();
+
+        return $verbosity >= $verbosityThreshold;
+    }
+
+    public function writeMessage($message)
+    {
+        $this->output()->write($message);
+    }
+}

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -7,7 +7,6 @@ use Consolidation\Log\ConsoleLogLevel;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LogLevel;
 use Robo\Contract\ProgressIndicatorAwareInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Task input/output methods.  TaskIO is 'used' in BaseTask, so any
@@ -20,24 +19,7 @@ trait TaskIO
 {
     use LoggerAwareTrait;
     use ConfigAwareTrait;
-    use OutputAwareTrait;
-
-    protected $verbosityThreshold = 0;
-
-    /**
-     * Required verbocity level before any TaskIO output will be produced.
-     * e.g. OutputInterface::VERBOSITY_VERBOSE
-     */
-    public function setVerbosityThreshold($verbosityThreshold)
-    {
-        $this->verbosityThreshold = $verbosityThreshold;
-        return $this;
-    }
-
-    public function verbosityThreshold()
-    {
-        return $this->verbosityThreshold;
-    }
+    use VerbosityThresholdTrait;
 
     /**
      * @return mixed|null|\Psr\Log\LoggerInterface
@@ -154,7 +136,7 @@ trait TaskIO
      */
     protected function printTaskOutput($level, $text, $context)
     {
-        if ($this->output()->getVerbosity() < $this->verbosityThreshold()) {
+        if (!$this->verbosityMeetsThreshold()) {
             return;
         }
         $logger = $this->logger();
@@ -166,18 +148,6 @@ trait TaskIO
         $logger->log($level, $text, $this->getTaskContext($context));
         // After we have printed our log message, redraw the progress indicator.
         $this->showTaskProgress($inProgress);
-    }
-
-    /**
-     * Print a message if the selected verbosity level is over this task's
-     * verbosity threshhold.
-     */
-    protected function write($message)
-    {
-        if ($this->output()->getVerbosity() < $this->verbosityThreshold()) {
-            return;
-        }
-        $this->output()->write($message);
     }
 
     /**

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -7,6 +7,7 @@ use Consolidation\Log\ConsoleLogLevel;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LogLevel;
 use Robo\Contract\ProgressIndicatorAwareInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Task input/output methods.  TaskIO is 'used' in BaseTask, so any
@@ -19,6 +20,24 @@ trait TaskIO
 {
     use LoggerAwareTrait;
     use ConfigAwareTrait;
+    use OutputAwareTrait;
+
+    protected $requiredVerbosity = 0;
+
+    /**
+     * Required verbocity level before any TaskIO output will be produced.
+     * e.g. OutputInterface::VERBOSITY_VERBOSE
+     */
+    public function setRequiredVerbosity($requiredVerbosity)
+    {
+        $this->requiredVerbosity = $requiredVerbosity;
+        return $this;
+    }
+
+    public function requiredVerbosity()
+    {
+        return $this->requiredVerbosity;
+    }
 
     /**
      * @return mixed|null|\Psr\Log\LoggerInterface
@@ -135,6 +154,10 @@ trait TaskIO
      */
     protected function printTaskOutput($level, $text, $context)
     {
+        $verbosity = $this->output()->getVerbosity();
+        if ($verbosity < $this->requiredVerbosity()) {
+            return;
+        }
         $logger = $this->logger();
         if (!$logger) {
             return;

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -154,8 +154,7 @@ trait TaskIO
      */
     protected function printTaskOutput($level, $text, $context)
     {
-        $verbosity = $this->output()->getVerbosity();
-        if ($verbosity < $this->verbosityThreshold()) {
+        if ($this->output()->getVerbosity() < $this->verbosityThreshold()) {
             return;
         }
         $logger = $this->logger();
@@ -167,6 +166,18 @@ trait TaskIO
         $logger->log($level, $text, $this->getTaskContext($context));
         // After we have printed our log message, redraw the progress indicator.
         $this->showTaskProgress($inProgress);
+    }
+
+    /**
+     * Print a message if the selected verbosity level is over this task's
+     * verbosity threshhold.
+     */
+    protected function write($message)
+    {
+        if ($this->output()->getVerbosity() < $this->verbosityThreshold()) {
+            return;
+        }
+        $this->output()->write($message);
     }
 
     /**

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -22,21 +22,21 @@ trait TaskIO
     use ConfigAwareTrait;
     use OutputAwareTrait;
 
-    protected $requiredVerbosity = 0;
+    protected $verbosityThreshold = 0;
 
     /**
      * Required verbocity level before any TaskIO output will be produced.
      * e.g. OutputInterface::VERBOSITY_VERBOSE
      */
-    public function setRequiredVerbosity($requiredVerbosity)
+    public function setVerbosityThreshold($verbosityThreshold)
     {
-        $this->requiredVerbosity = $requiredVerbosity;
+        $this->verbosityThreshold = $verbosityThreshold;
         return $this;
     }
 
-    public function requiredVerbosity()
+    public function verbosityThreshold()
     {
-        return $this->requiredVerbosity;
+        return $this->verbosityThreshold;
     }
 
     /**
@@ -155,7 +155,7 @@ trait TaskIO
     protected function printTaskOutput($level, $text, $context)
     {
         $verbosity = $this->output()->getVerbosity();
-        if ($verbosity < $this->requiredVerbosity()) {
+        if ($verbosity < $this->verbosityThreshold()) {
             return;
         }
         $logger = $this->logger();

--- a/src/Common/VerbosityThresholdTrait.php
+++ b/src/Common/VerbosityThresholdTrait.php
@@ -1,0 +1,79 @@
+<?php
+namespace Robo\Common;
+
+use Robo\Robo;
+use Robo\TaskInfo;
+use Robo\Contract\OutputAdapterInterface;
+use Robo\Contract\VerbosityThresholdInterface;
+use Consolidation\Log\ConsoleLogLevel;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LogLevel;
+use Robo\Contract\ProgressIndicatorAwareInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Task input/output methods.  TaskIO is 'used' in BaseTask, so any
+ * task that extends this class has access to all of the methods here.
+ * printTaskInfo, printTaskSuccess, and printTaskError are the three
+ * primary output methods that tasks are encouraged to use.  Tasks should
+ * avoid using the IO trait output methods.
+ */
+trait VerbosityThresholdTrait
+{
+    /** var OutputAdapterInterface */
+    protected $outputAdapter;
+    protected $verbosityThreshold = 0;
+
+    /**
+     * Required verbocity level before any TaskIO output will be produced.
+     * e.g. OutputInterface::VERBOSITY_VERBOSE
+     */
+    public function setVerbosityThreshold($verbosityThreshold)
+    {
+        $this->verbosityThreshold = $verbosityThreshold;
+        return $this;
+    }
+
+    public function verbosityThreshold()
+    {
+        return $this->verbosityThreshold;
+    }
+
+    public function setOutputAdapter(OutputAdapterInterface $outputAdapter)
+    {
+        $this->outputAdapter = $outputAdapter;
+    }
+
+    /**
+     * @return OutputAdapterInterface
+     */
+    public function outputAdapter()
+    {
+        return $this->outputAdapter;
+    }
+
+    public function hasOutputAdapter()
+    {
+        return isset($this->outputAdapter);
+    }
+
+    public function verbosityMeetsThreshold()
+    {
+        if ($this->hasOutputAdapter()) {
+            return $this->outputAdapter()->verbosityMeetsThreshold($this->verbosityThreshold());
+        }
+        return true;
+    }
+
+    /**
+     * Print a message if the selected verbosity level is over this task's
+     * verbosity threshhold.
+     */
+    public function writeMessage($message)
+    {
+        if (!$this->verbosityMeetsThreshold()) {
+            return;
+        }
+        $this->outputAdapter()->writeMessage($message);
+    }
+}

--- a/src/Contract/OutputAdapterInterface.php
+++ b/src/Contract/OutputAdapterInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Robo\Contract;
+
+/**
+ * Adapt OutputInterface or other output function to the VerbosityThresholdInterface.
+ */
+interface OutputAdapterInterface
+{
+    public function verbosityMeetsThreshold($verbosityThreshold);
+    public function writeMessage($message);
+}

--- a/src/Contract/VerbosityThresholdInterface.php
+++ b/src/Contract/VerbosityThresholdInterface.php
@@ -1,0 +1,24 @@
+<?php
+namespace Robo\Contract;
+
+use Robo\Contract\OutputAdapterInterface;
+
+/**
+ * Record and determine whether the current verbosity level exceeds the
+ * desired threshold level to produce output.
+ */
+interface VerbosityThresholdInterface
+{
+    const VERBOSITY_NORMAL = 1;
+    const VERBOSITY_VERBOSE = 2;
+    const VERBOSITY_VERY_VERBOSE = 3;
+    const VERBOSITY_DEBUG = 4;
+
+    public function setVerbosityThreshold($verbosityThreshold);
+    public function verbosityThreshold();
+    public function setOutputAdapter(OutputAdapterInterface $outputAdapter);
+    public function outputAdapter();
+    public function hasOutputAdapter();
+    public function verbosityMeetsThreshold();
+    public function writeMessage($message);
+}

--- a/src/Log/ResultPrinter.php
+++ b/src/Log/ResultPrinter.php
@@ -4,6 +4,7 @@ namespace Robo\Log;
 use Robo\Result;
 use Robo\Contract\PrintedInterface;
 use Robo\Contract\ProgressIndicatorAwareInterface;
+use Robo\Contract\VerbosityThresholdInterface;
 use Robo\Common\ProgressIndicatorAwareTrait;
 
 use Psr\Log\LogLevel;
@@ -30,6 +31,10 @@ class ResultPrinter implements LoggerAwareInterface, ProgressIndicatorAwareInter
      */
     public function printResult(Result $result)
     {
+        $task = $result->getTask();
+        if ($task instanceof VerbosityThresholdInterface && !$task->verbosityMeetsThreshold()) {
+            return;
+        }
         if (!$result->wasSuccessful()) {
             return $this->printError($result);
         } else {

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -162,6 +162,7 @@ class Robo
         $container->share('config', $config);
         $container->share('input', $input);
         $container->share('output', $output);
+        $container->share('outputAdapter', \Robo\Common\OutputAdapter::class);
 
         // Register logging and related services.
         $container->share('logStyler', \Robo\Log\RoboLogStyle::class);
@@ -251,6 +252,8 @@ class Robo
             ->invokeMethod('setProgressIndicator', ['progressIndicator']);
         $container->inflector(\Consolidation\AnnotatedCommand\Events\CustomEventAwareInterface::class)
             ->invokeMethod('setHookManager', ['hookManager']);
+        $container->inflector(\Robo\Contract\VerbosityThresholdInterface::class)
+            ->invokeMethod('setOutputAdapter', ['outputAdapter']);
     }
 
     /**

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -247,7 +247,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
             $this->process->run(
                 function ($type, $buffer) {
                     $progressWasVisible = $this->hideTaskProgress();
-                    print($buffer);
+                    $this->write($buffer);
                     $this->showTaskProgress($progressWasVisible);
                 }
             );

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -82,9 +82,6 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
     public function __construct($command)
     {
         $this->command = $this->receiveCommand($command);
-        if (!isset($this->interactive) && function_exists('posix_isatty')) {
-            $this->interactive = posix_isatty(STDOUT);
-        }
     }
 
     /**
@@ -215,6 +212,14 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
      */
     public function run()
     {
+        // If the caller did not explicity set the 'interactive' mode,
+        // and output should be produced by this task (verbosityMeetsThreshold),
+        // then we will automatically set interactive mode based on whether
+        // or not output was redirected when robo was executed.
+        if (!isset($this->interactive) && function_exists('posix_isatty') && $this->verbosityMeetsThreshold()) {
+            $this->interactive = posix_isatty(STDOUT);
+        }
+
         if ($this->isMetadataPrinted) {
             $this->printAction();
         }
@@ -247,7 +252,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
             $this->process->run(
                 function ($type, $buffer) {
                     $progressWasVisible = $this->hideTaskProgress();
-                    $this->write($buffer);
+                    $this->writeMessage($buffer);
                     $this->showTaskProgress($progressWasVisible);
                 }
             );

--- a/src/Task/BaseTask.php
+++ b/src/Task/BaseTask.php
@@ -10,10 +10,11 @@ use Robo\Contract\ProgressIndicatorAwareInterface;
 use Robo\Common\ProgressIndicatorAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 use Psr\Log\LoggerAwareInterface;
+use Robo\Contract\OutputAwareInterface;
 
-abstract class BaseTask implements TaskInterface, LoggerAwareInterface, ConfigAwareInterface, ProgressIndicatorAwareInterface, InflectionInterface
+abstract class BaseTask implements TaskInterface, LoggerAwareInterface, OutputAwareInterface, ConfigAwareInterface, ProgressIndicatorAwareInterface, InflectionInterface
 {
-    use TaskIO; // uses LoggerAwareTrait and ConfigAwareTrait
+    use TaskIO; // uses LoggerAwareTrait, OutputAwareTrait and ConfigAwareTrait
     use ProgressIndicatorAwareTrait;
     use InflectionTrait;
 
@@ -30,6 +31,9 @@ abstract class BaseTask implements TaskInterface, LoggerAwareInterface, ConfigAw
         }
         if ($child instanceof ConfigAwareInterface && $this->getConfig()) {
             $child->setConfig($this->getConfig());
+        }
+        if ($child instanceof OutputAwareInterface && $this->output()) {
+            $child->setOutput($this->output());
         }
     }
 }

--- a/src/Task/BaseTask.php
+++ b/src/Task/BaseTask.php
@@ -7,14 +7,15 @@ use Robo\Contract\InflectionInterface;
 use Robo\Common\TaskIO;
 use Robo\Contract\TaskInterface;
 use Robo\Contract\ProgressIndicatorAwareInterface;
+use Robo\Contract\VerbosityThresholdInterface;
 use Robo\Common\ProgressIndicatorAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 use Psr\Log\LoggerAwareInterface;
 use Robo\Contract\OutputAwareInterface;
 
-abstract class BaseTask implements TaskInterface, LoggerAwareInterface, OutputAwareInterface, ConfigAwareInterface, ProgressIndicatorAwareInterface, InflectionInterface
+abstract class BaseTask implements TaskInterface, LoggerAwareInterface, VerbosityThresholdInterface, ConfigAwareInterface, ProgressIndicatorAwareInterface, InflectionInterface
 {
-    use TaskIO; // uses LoggerAwareTrait, OutputAwareTrait and ConfigAwareTrait
+    use TaskIO; // uses LoggerAwareTrait, VerbosityThresholdTrait and ConfigAwareTrait
     use ProgressIndicatorAwareTrait;
     use InflectionTrait;
 
@@ -32,8 +33,8 @@ abstract class BaseTask implements TaskInterface, LoggerAwareInterface, OutputAw
         if ($child instanceof ConfigAwareInterface && $this->getConfig()) {
             $child->setConfig($this->getConfig());
         }
-        if ($child instanceof OutputAwareInterface && $this->output()) {
-            $child->setOutput($this->output());
+        if ($child instanceof VerbosityThresholdInterface && $this->outputAdapter()) {
+            $child->setOutputAdapter($this->outputAdapter());
         }
     }
 }

--- a/tests/src/RoboFileFixture.php
+++ b/tests/src/RoboFileFixture.php
@@ -145,6 +145,21 @@ class RoboFileFixture extends \Robo\Tasks implements LoggerAwareInterface, Custo
         $this->logger->debug('This is a debug log message.');
     }
 
+    public function testVerbosityThreshold()
+    {
+        $this->output()->writeln('This command will print more information at higher verbosity levels.');
+        $this->output()->writeln('Try running with -v, -vv or -vvv');
+
+        return $this->collectionBuilder()
+            ->setVerbosityThreshold(OutputInterface::VERBOSITY_VERBOSE)
+            ->taskExec('echo verbose "or higher"')
+            ->taskExec('echo "very verbose" "or higher"')
+                ->setVerbosityThreshold(OutputInterface::VERBOSITY_VERY_VERBOSE)
+            ->taskExec('echo "always" "printed"')
+                ->setVerbosityThreshold(OutputInterface::VERBOSITY_NORMAL)
+            ->run();
+    }
+
     public function testDeploy()
     {
         $gitTask = $this->taskGitStack()

--- a/tests/src/RoboFileFixture.php
+++ b/tests/src/RoboFileFixture.php
@@ -153,9 +153,12 @@ class RoboFileFixture extends \Robo\Tasks implements LoggerAwareInterface, Custo
         return $this->collectionBuilder()
             ->setVerbosityThreshold(OutputInterface::VERBOSITY_VERBOSE)
             ->taskExec('echo verbose "or higher"')
+                ->interactive(false)
             ->taskExec('echo "very verbose" "or higher"')
+                ->interactive(false)
                 ->setVerbosityThreshold(OutputInterface::VERBOSITY_VERY_VERBOSE)
             ->taskExec('echo "always" "printed"')
+                ->interactive(false)
                 ->setVerbosityThreshold(OutputInterface::VERBOSITY_NORMAL)
             ->run();
     }

--- a/tests/src/RoboFileFixture.php
+++ b/tests/src/RoboFileFixture.php
@@ -152,12 +152,12 @@ class RoboFileFixture extends \Robo\Tasks implements LoggerAwareInterface, Custo
 
         return $this->collectionBuilder()
             ->setVerbosityThreshold(OutputInterface::VERBOSITY_VERBOSE)
-            ->taskExec("echo verbose 'or higher'")
+            ->taskExec('echo verbose or higher')
                 ->interactive(false)
-            ->taskExec("echo 'very verbose' 'or higher'")
+            ->taskExec('echo very verbose or higher')
                 ->interactive(false)
                 ->setVerbosityThreshold(OutputInterface::VERBOSITY_VERY_VERBOSE)
-            ->taskExec("echo 'always' 'printed'")
+            ->taskExec('echo always printed')
                 ->interactive(false)
                 ->setVerbosityThreshold(OutputInterface::VERBOSITY_NORMAL)
             ->run();

--- a/tests/src/RoboFileFixture.php
+++ b/tests/src/RoboFileFixture.php
@@ -7,6 +7,7 @@ use Psr\Log\LoggerAwareInterface;
 
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareInterface;
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareTrait;
+use Robo\Contract\VerbosityThresholdInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -151,15 +152,15 @@ class RoboFileFixture extends \Robo\Tasks implements LoggerAwareInterface, Custo
         $this->output()->writeln('Try running with -v, -vv or -vvv');
 
         return $this->collectionBuilder()
-            ->setVerbosityThreshold(OutputInterface::VERBOSITY_VERBOSE)
+            ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
             ->taskExec('echo verbose or higher')
                 ->interactive(false)
             ->taskExec('echo very verbose or higher')
                 ->interactive(false)
-                ->setVerbosityThreshold(OutputInterface::VERBOSITY_VERY_VERBOSE)
+                ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERY_VERBOSE)
             ->taskExec('echo always printed')
                 ->interactive(false)
-                ->setVerbosityThreshold(OutputInterface::VERBOSITY_NORMAL)
+                ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_NORMAL)
             ->run();
     }
 

--- a/tests/src/RoboFileFixture.php
+++ b/tests/src/RoboFileFixture.php
@@ -152,12 +152,12 @@ class RoboFileFixture extends \Robo\Tasks implements LoggerAwareInterface, Custo
 
         return $this->collectionBuilder()
             ->setVerbosityThreshold(OutputInterface::VERBOSITY_VERBOSE)
-            ->taskExec('echo verbose "or higher"')
+            ->taskExec("echo verbose 'or higher'")
                 ->interactive(false)
-            ->taskExec('echo "very verbose" "or higher"')
+            ->taskExec("echo 'very verbose' 'or higher'")
                 ->interactive(false)
                 ->setVerbosityThreshold(OutputInterface::VERBOSITY_VERY_VERBOSE)
-            ->taskExec('echo "always" "printed"')
+            ->taskExec("echo 'always' 'printed'")
                 ->interactive(false)
                 ->setVerbosityThreshold(OutputInterface::VERBOSITY_NORMAL)
             ->run();

--- a/tests/unit/RunnerTest.php
+++ b/tests/unit/RunnerTest.php
@@ -276,9 +276,9 @@ EOT;
         $result = $this->runner->execute($argv, null, null, $this->guy->capturedOutputStream());
 
         $this->guy->seeInOutput('This command will print more information at higher verbosity levels');
-        $this->guy->seeInOutput('Running echo verbose "or higher"');
+        $this->guy->seeInOutput("Running echo verbose 'or higher'");
         $this->guy->seeInOutput('verbose or higher');
-        $this->guy->doNotSeeInOutput('Running echo "very verbose" "or higher"');
+        $this->guy->doNotSeeInOutput("Running echo 'very verbose' 'or higher'");
         $this->guy->doNotSeeInOutput('very verbose or higher');
         $this->assertEquals(0, $result);
     }
@@ -289,9 +289,9 @@ EOT;
         $result = $this->runner->execute($argv, null, null, $this->guy->capturedOutputStream());
 
         $this->guy->seeInOutput('This command will print more information at higher verbosity levels');
-        $this->guy->seeInOutput('Running echo verbose "or higher"');
+        $this->guy->seeInOutput("Running echo verbose 'or higher'");
         $this->guy->seeInOutput('verbose or higher');
-        $this->guy->seeInOutput('Running echo "very verbose" "or higher"');
+        $this->guy->seeInOutput("Running echo 'very verbose' 'or higher'");
         $this->guy->seeInOutput('very verbose or higher');
         $this->assertEquals(0, $result);
     }

--- a/tests/unit/RunnerTest.php
+++ b/tests/unit/RunnerTest.php
@@ -277,9 +277,9 @@ EOT;
 
         $this->guy->seeInOutput('This command will print more information at higher verbosity levels');
         $this->guy->seeInOutput('Running echo verbose "or higher"');
-//        $this->guy->seeInOutput('verbose or higher');
+        $this->guy->seeInOutput('verbose or higher');
         $this->guy->doNotSeeInOutput('Running echo "very verbose" "or higher"');
-//        $this->guy->doNotSeeInOutput('very verbose or higher');
+        $this->guy->doNotSeeInOutput('very verbose or higher');
         $this->assertEquals(0, $result);
     }
 
@@ -290,9 +290,9 @@ EOT;
 
         $this->guy->seeInOutput('This command will print more information at higher verbosity levels');
         $this->guy->seeInOutput('Running echo verbose "or higher"');
-//        $this->guy->seeInOutput('verbose or higher');
+        $this->guy->seeInOutput('verbose or higher');
         $this->guy->seeInOutput('Running echo "very verbose" "or higher"');
-//        $this->guy->seeInOutput('very verbose or higher');
+        $this->guy->seeInOutput('very verbose or higher');
         $this->assertEquals(0, $result);
     }
 

--- a/tests/unit/RunnerTest.php
+++ b/tests/unit/RunnerTest.php
@@ -276,9 +276,7 @@ EOT;
         $result = $this->runner->execute($argv, null, null, $this->guy->capturedOutputStream());
 
         $this->guy->seeInOutput('This command will print more information at higher verbosity levels');
-        $this->guy->seeInOutput("Running echo verbose 'or higher'");
-        $this->guy->seeInOutput('verbose or higher');
-        $this->guy->doNotSeeInOutput("Running echo 'very verbose' 'or higher'");
+        $this->guy->seeInOutput("Running echo verbose or higher\nverbose or higher");
         $this->guy->doNotSeeInOutput('very verbose or higher');
         $this->assertEquals(0, $result);
     }
@@ -289,10 +287,8 @@ EOT;
         $result = $this->runner->execute($argv, null, null, $this->guy->capturedOutputStream());
 
         $this->guy->seeInOutput('This command will print more information at higher verbosity levels');
-        $this->guy->seeInOutput("Running echo verbose 'or higher'");
-        $this->guy->seeInOutput('verbose or higher');
-        $this->guy->seeInOutput("Running echo 'very verbose' 'or higher'");
-        $this->guy->seeInOutput('very verbose or higher');
+        $this->guy->seeInOutput("Running echo verbose or higher\nverbose or higher");
+        $this->guy->seeInOutput("Running echo very verbose or higher\nvery verbose or higher");
         $this->assertEquals(0, $result);
     }
 

--- a/tests/unit/RunnerTest.php
+++ b/tests/unit/RunnerTest.php
@@ -270,6 +270,32 @@ EOT;
         $this->assertEquals(0, $result);
     }
 
+    public function testRunnerVerbosityThresholdVerbose()
+    {
+        $argv = ['placeholder', 'test:verbosity-threshold', '-v'];
+        $result = $this->runner->execute($argv, null, null, $this->guy->capturedOutputStream());
+
+        $this->guy->seeInOutput('This command will print more information at higher verbosity levels');
+        $this->guy->seeInOutput('Running echo verbose "or higher"');
+//        $this->guy->seeInOutput('verbose or higher');
+        $this->guy->doNotSeeInOutput('Running echo "very verbose" "or higher"');
+//        $this->guy->doNotSeeInOutput('very verbose or higher');
+        $this->assertEquals(0, $result);
+    }
+
+    public function testRunnerVerbosityThresholdVeryVerbose()
+    {
+        $argv = ['placeholder', 'test:verbosity-threshold', '-vv'];
+        $result = $this->runner->execute($argv, null, null, $this->guy->capturedOutputStream());
+
+        $this->guy->seeInOutput('This command will print more information at higher verbosity levels');
+        $this->guy->seeInOutput('Running echo verbose "or higher"');
+//        $this->guy->seeInOutput('verbose or higher');
+        $this->guy->seeInOutput('Running echo "very verbose" "or higher"');
+//        $this->guy->seeInOutput('very verbose or higher');
+        $this->assertEquals(0, $result);
+    }
+
     public function testRunnerDebugOutput()
     {
         $argv = ['placeholder', 'test:verbosity', '-vvv'];


### PR DESCRIPTION
Allows commands to control the verbosity level at which different tasks will emit their progress notices et. al.

### Overview
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Commands can now call `$builder->setRequiredVerbosity(OutputInterface::VERBOSITY_VERBOSE)` (or other verbosity constant) to suppress output of tasks when command executed below a certain verbosity level.

### Description
For Robo scripts that are used from CI servers, it is important to be able to suppress the output of particularly talkative commands (e.g. `composer update`, `git add -A .` et. al.), to avoid being unable to see more interesting messages later, should the CI server truncate the output. This PR gives commands the ability to set a minimum verbosity level on a task-by-task basis, so that the lengthy command output may be easily displayed should the command fail for any reason.

For example, imagine that the `try:builder` command is modified as follows:
```
        return $this->collectionBuilder()
            ->setRequiredVerbosity(OutputInterface::VERBOSITY_VERBOSE)
            ->taskFilesystemStack()
                ->mkdir('a')
                ->touch('a/a.txt')
            ->taskFilesystemStack()
                ->setRequiredVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE)
                ->mkdir('a/b')
                ->touch('a/b/b.txt')
            ->taskFilesystemStack()
                ->mkdir('a/b/c')
                ->touch('a/b/c/c.txt')
            ->run();
```
Then:
```
$ ./robo -f examples try:builder 
$ ./robo -f examples try:builder -v
 [Filesystem\FilesystemStack] mkdir ["a"]
 [Filesystem\FilesystemStack] touch ["a/a.txt"]
 [Filesystem\FilesystemStack] mkdir ["a/b/c"]
 [Filesystem\FilesystemStack] touch ["a/b/c/c.txt"]
$ ./robo -f examples try:builder -vv
 [Filesystem\FilesystemStack] mkdir ["a"]
 [Filesystem\FilesystemStack] touch ["a/a.txt"]
 [Filesystem\FilesystemStack] mkdir ["a/b"]
 [Filesystem\FilesystemStack] touch ["a/b/b.txt"]
 [Filesystem\FilesystemStack] mkdir ["a/b/c"]
 [Filesystem\FilesystemStack] touch ["a/b/c/c.txt"]
```
Regarding backwards compatibility, everything should still continue to work for existing commands / tasks. However, if a task does **not** implement BaseTask, but **does** use TaskIO, then it must also implement OutputInterface. If it does not, the only consequence is that its output is displayed always, rather than as stipulated by `setRequiredVerbosity()`.

Some time ago, I had an aspirational goal that tasks should not depend on Symfony Console at all, so that hypothetically, a Robo tasklib could be split out and used in non-Console applications. However, I no longer think that is particularly useful to avoid Symfony Console, so this PR takes a simpler implementation and uses OutputInterface et. al. directly.

@grasmash @DavertMik Let me know if you have any feedback on naming the methods, or anything else.

Could still use some tests and documentation.