### PR TITLE
Add php71 to test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ branches:
 
 matrix:
   include:
-    - php: 7.0
+    - php: 7.1
       env: dependencies=highest
+    - php: 7.0
     - php: 5.6
     - php: 5.5
     - php: 5.5


### PR DESCRIPTION
### Disposition
This pull request:

- [X] Adds a new version of PHP to the text matrix
- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Add phpunit 7.1 to test matrix.
