### PR TITLE
Fix the signature of the addCode() wrapper so that we can name a task.

### DIFF
--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -139,9 +139,9 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         return $this;
     }
 
-    public function addCode(callable $code)
+    public function addCode(callable $code, $name)
     {
-        $this->getCollection()->addCode($code);
+        $this->getCollection()->addCode($code, $name);
         return $this;
     }
 

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -43,6 +43,13 @@ use Robo\Contract\VerbosityThresholdInterface;
  */
 class CollectionBuilder extends BaseTask implements NestedCollectionInterface, WrappedTaskInterface, CommandInterface
 {
+
+    /**
+     * @see \Robo\Collection\CollectionInterface::UNNAMEDTASK
+     * @var int
+     */
+    const UNNAMEDTASK = 0;
+
     /**
      * @var \Robo\Tasks
      */
@@ -139,7 +146,16 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         return $this;
     }
 
-    public function addCode(callable $code, $name)
+  /**
+   * Add arbitrary code to execute as a task.
+   *
+   * @see \Robo\Collection\CollectionInterface::addCode
+   *
+   * @param callable $code
+   * @param int|string $name
+   * @return $this
+   */
+    public function addCode(callable $code, $name = self::UNNAMEDTASK)
     {
         $this->getCollection()->addCode($code, $name);
         return $this;

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -45,12 +45,6 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
 {
 
     /**
-     * @see \Robo\Collection\CollectionInterface::UNNAMEDTASK
-     * @var int
-     */
-    const UNNAMEDTASK = 0;
-
-    /**
      * @var \Robo\Tasks
      */
     protected $commandFile;
@@ -155,7 +149,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
    * @param int|string $name
    * @return $this
    */
-    public function addCode(callable $code, $name = self::UNNAMEDTASK)
+    public function addCode(callable $code, $name = \Robo\Collection\CollectionInterface::UNNAMEDTASK)
     {
         $this->getCollection()->addCode($code, $name);
         return $this;


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Make it possible to name a task by providing a second argument to `collectionBuilder::addCode()`.

### Description
See https://github.com/consolidation/Robo/issues/540

```
$ robo  sniff src/Collection/CollectionBuilder.php
 [Exec] Running ./vendor/bin/phpcs --standard=PSR2 -n src/Collection/CollectionBuilder.php
 [Exec] Done in 0.143s
```