### PR TITLE
Default apigen operation to 'generate'

### DIFF
--- a/src/Task/ApiGen/ApiGen.php
+++ b/src/Task/ApiGen/ApiGen.php
@@ -12,7 +12,8 @@ use Traversable;
  * ``` php
  * <?php
  * // ApiGen Command
- * $this->taskApiGen('./apigen.neon')
+ * $this->taskApiGen('./vendor/apigen/apigen.phar')
+ *      ->config('./apigen.neon')
  *      ->templateConfig('vendor/apigen/apigen/templates/bootstrap/config.neon')
  *      ->wipeout(true)
  *       ->run();
@@ -77,7 +78,7 @@ class ApiGen extends BaseTask implements CommandInterface
             }
             return $arg;
         }, $args);
-		$args = array_filter($args);
+        $args = array_filter($args);
         $this->arguments .= ' ' . implode(' ', array_map('static::escape', $args));
         return $this;
     }

--- a/src/Task/ApiGen/ApiGen.php
+++ b/src/Task/ApiGen/ApiGen.php
@@ -71,8 +71,8 @@ class ApiGen extends BaseTask implements CommandInterface
             $args = func_get_args();
         }
         $args = \array_map(function($arg) {
-            if (\preg_match('/^\w+$/', $arg) === 1) {
-                $this->operation = $arg;
+            if (\preg_match('/^\w+$/', trim($arg)) === 1) {
+                $this->operation = " $arg";
                 return;
             }
             return $arg;

--- a/src/Task/ApiGen/ApiGen.php
+++ b/src/Task/ApiGen/ApiGen.php
@@ -30,6 +30,7 @@ class ApiGen extends BaseTask implements CommandInterface
      * @var string
      */
     protected $command;
+	protected $operation = ' generate';
 
     /**
      * @param null|string $pathToApiGen
@@ -39,6 +40,15 @@ class ApiGen extends BaseTask implements CommandInterface
     public function __construct($pathToApiGen = null)
     {
         $this->command = $pathToApiGen;
+		$command_parts = [];
+		preg_match('/((?:.+)?apigen(?:\.phar)?)( \w+)?(.+)?/', $this->command, $command_parts);
+		if (count($command_parts) === 3) {
+			list($full_command, $this->command, $this->operation) = $command_parts;
+		}
+		if (count($command_parts) === 4) {
+			list($full_command, $this->command, $this->operation, $arg) = $command_parts;
+			$this->arg($arg);
+		}
         if (!$this->command) {
             $this->command = $this->findExecutablePhar('apigen');
         }
@@ -468,7 +478,7 @@ class ApiGen extends BaseTask implements CommandInterface
      */
     public function getCommand()
     {
-        return $this->command . $this->arguments;
+        return $this->command . $this->operation . $this->arguments;
     }
 
     /**

--- a/src/Task/ApiGen/ApiGen.php
+++ b/src/Task/ApiGen/ApiGen.php
@@ -31,7 +31,7 @@ class ApiGen extends BaseTask implements CommandInterface
      * @var string
      */
     protected $command;
-    protected $operation = ' generate';
+    protected $operation = 'generate';
 
     /**
      * @param null|string $pathToApiGen
@@ -42,7 +42,7 @@ class ApiGen extends BaseTask implements CommandInterface
     {
         $this->command = $pathToApiGen;
         $command_parts = [];
-        preg_match('/((?:.+)?apigen(?:\.phar)?)( \w+)? ?(.+)?/', $this->command, $command_parts);
+        preg_match('/((?:.+)?apigen(?:\.phar)?) ?( \w+)? ?(.+)?/', $this->command, $command_parts);
         if (count($command_parts) === 3) {
             list(, $this->command, $this->operation) = $command_parts;
         }
@@ -73,7 +73,7 @@ class ApiGen extends BaseTask implements CommandInterface
         }
         $args = array_map(function ($arg) {
             if (preg_match('/^\w+$/', trim($arg)) === 1) {
-                $this->operation = " $arg";
+                $this->operation = $arg;
                 return null;
             }
             return $arg;
@@ -504,7 +504,7 @@ class ApiGen extends BaseTask implements CommandInterface
      */
     public function getCommand()
     {
-        return $this->command . $this->operation . $this->arguments;
+        return "$this->command $this->operation $this->arguments";
     }
 
     /**

--- a/src/Task/ApiGen/ApiGen.php
+++ b/src/Task/ApiGen/ApiGen.php
@@ -504,7 +504,7 @@ class ApiGen extends BaseTask implements CommandInterface
      */
     public function getCommand()
     {
-        return "$this->command $this->operation $this->arguments";
+        return "$this->command $this->operation$this->arguments";
     }
 
     /**

--- a/src/Task/ApiGen/ApiGen.php
+++ b/src/Task/ApiGen/ApiGen.php
@@ -70,13 +70,14 @@ class ApiGen extends BaseTask implements CommandInterface
         if (!is_array($args)) {
             $args = func_get_args();
         }
-        $args = \array_map(function($arg) {
-            if (\preg_match('/^\w+$/', trim($arg)) === 1) {
+        $args = array_map(function($arg) {
+            if (preg_match('/^\w+$/', trim($arg)) === 1) {
                 $this->operation = " $arg";
-                return;
+                return null;
             }
             return $arg;
         }, $args);
+		$args = array_filter($args);
         $this->arguments .= ' ' . implode(' ', array_map('static::escape', $args));
         return $this;
     }

--- a/src/Task/ApiGen/ApiGen.php
+++ b/src/Task/ApiGen/ApiGen.php
@@ -58,6 +58,30 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
+     * Pass methods parameters as arguments to executable. Argument values
+     * are automatically escaped.
+     *
+     * @param string|string[] $args
+     *
+     * @return $this
+     */
+    public function args($args)
+    {
+        if (!is_array($args)) {
+            $args = func_get_args();
+        }
+        $args = \array_map(function($arg) {
+            if (\preg_match('/^\w+$/', $arg) === 1) {
+                $this->operation = $arg;
+                return;
+            }
+            return $arg;
+        }, $args);
+        $this->arguments .= ' ' . implode(' ', array_map('static::escape', $args));
+        return $this;
+    }
+
+    /**
      * @param array|Traversable|string $arg a single object or something traversable
      *
      * @return array|Traversable the provided argument if it was already traversable, or the given

--- a/src/Task/ApiGen/ApiGen.php
+++ b/src/Task/ApiGen/ApiGen.php
@@ -44,10 +44,10 @@ class ApiGen extends BaseTask implements CommandInterface
 		$command_parts = [];
 		preg_match('/((?:.+)?apigen(?:\.phar)?)( \w+)?(.+)?/', $this->command, $command_parts);
 		if (count($command_parts) === 3) {
-			list($full_command, $this->command, $this->operation) = $command_parts;
+			list(, $this->command, $this->operation) = $command_parts;
 		}
 		if (count($command_parts) === 4) {
-			list($full_command, $this->command, $this->operation, $arg) = $command_parts;
+			list(, $this->command, $this->operation, $arg) = $command_parts;
 			$this->arg($arg);
 		}
         if (!$this->command) {

--- a/tests/unit/Task/ApiGenTest.php
+++ b/tests/unit/Task/ApiGenTest.php
@@ -43,9 +43,9 @@ class ApiGenTest extends \Codeception\TestCase\Test
             ->tree('Y') // boolean as string
             ->debug('n');
 
-        $linuxCmd = 'apigen --config ./apigen.neon --source src --extensions php --exclude test --exclude tmp --skip-doc-path a --skip-doc-path b --charset \'utf8,iso88591\' --internal no --php yes --tree yes --debug no';
+        $linuxCmd = 'apigen generate --config ./apigen.neon --source src --extensions php --exclude test --exclude tmp --skip-doc-path a --skip-doc-path b --charset \'utf8,iso88591\' --internal no --php yes --tree yes --debug no';
 
-        $winCmd = 'apigen --config ./apigen.neon --source src --extensions php --exclude test --exclude tmp --skip-doc-path a --skip-doc-path b --charset "utf8,iso88591" --internal no --php yes --tree yes --debug no';
+        $winCmd = 'apigen generate --config ./apigen.neon --source src --extensions php --exclude test --exclude tmp --skip-doc-path a --skip-doc-path b --charset "utf8,iso88591" --internal no --php yes --tree yes --debug no';
 
         $cmd = (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') ? $winCmd : $linuxCmd;
 


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Allows users to run `apigen generate` more simply

### Description
If a user passes no operation to the constructor, this change will default to generate. Passing an operation (and optionally arguments) will now separate these out into the appropriate class variables. If a user passes an operation to `arg()` or `args()`, it will overwrite the current operation so that only one will be assembled into the final command.
