### PR TITLE
Add factory methods for CollectionBuilder and ProcessExecutor.

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -158,6 +158,7 @@ use League\Container\ContainerAwareTrait;
 use Symfony\Component\Console\Output\NullOutput;
 use Robo\TaskAccessor;
 use Robo\Robo;
+use Robo\Collection\CollectionBuilder;
 
 class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwareInterface
 {
@@ -176,7 +177,7 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwa
     public function collectionBuilder()
     {
         $emptyRobofile = new \Robo\Tasks;
-        return $this->getContainer()->get('collectionBuilder', [$emptyRobofile]);
+        return CollectionBuilder::create($this->getContainer(), $emptyRobofile);
     }
 
     public function testYesIsAssumed()

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -72,6 +72,18 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         $this->commandFile = $commandFile;
     }
 
+    public static function create($container, $commandFile)
+    {
+        $builder = new self($commandFile);
+
+        $builder->setLogger($container->get('logger'));
+        $builder->setProgressIndicator($container->get('progressIndicator'));
+        $builder->setConfig($container->get('config'));
+        $builder->setOutputAdapter($container->get('outputAdapter'));
+
+        return $builder;
+    }
+
     /**
      * @param bool $simulated
      *

--- a/src/Common/ProcessExecutor.php
+++ b/src/Common/ProcessExecutor.php
@@ -24,9 +24,9 @@ class ProcessExecutor implements ConfigAwareInterface, LoggerAwareInterface, Out
         $this->process = $process;
     }
 
-    public static function create($container)
+    public static function create($container, $process)
     {
-        $processExecutor = new self($commandFile);
+        $processExecutor = new self($process);
 
         $processExecutor->setLogger($container->get('logger'));
         $processExecutor->setProgressIndicator($container->get('progressIndicator'));

--- a/src/Common/ProcessExecutor.php
+++ b/src/Common/ProcessExecutor.php
@@ -15,9 +15,25 @@ class ProcessExecutor implements ConfigAwareInterface, LoggerAwareInterface, Out
     use ProgressIndicatorAwareTrait;
     use OutputAwareTrait;
 
+    /**
+     * @param Process $process
+     * @return type
+     */
     public function __construct(Process $process)
     {
         $this->process = $process;
+    }
+
+    public static function create($container)
+    {
+        $processExecutor = new self($commandFile);
+
+        $processExecutor->setLogger($container->get('logger'));
+        $processExecutor->setProgressIndicator($container->get('progressIndicator'));
+        $processExecutor->setConfig($container->get('config'));
+        $processExecutor->setOutputAdapter($container->get('outputAdapter'));
+
+        return $processExecutor;
     }
 
     /**

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -209,7 +209,9 @@ class Robo
         $container->share('commandFactory', \Consolidation\AnnotatedCommand\AnnotatedCommandFactory::class)
             ->withMethodCall('setCommandProcessor', ['commandProcessor']);
         $container->add('collection', \Robo\Collection\Collection::class);
+        // Deprecated: use CollectionBuilder::create() instead.
         $container->add('collectionBuilder', \Robo\Collection\CollectionBuilder::class);
+        // Deprecated: use ProcessExecutor::create() or Robo::process() instead
         $container->add('processExecutor', ProcessExecutor::class);
 
         static::addInflectors($container);
@@ -349,6 +351,6 @@ class Robo
 
     public static function process(Process $process)
     {
-        return static::getContainer()->get('processExecutor', [$process]);
+        return ProcessExecutor::create(static::getContainer(), $process);
     }
 }

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -208,11 +208,12 @@ class Robo
             );
         $container->share('commandFactory', \Consolidation\AnnotatedCommand\AnnotatedCommandFactory::class)
             ->withMethodCall('setCommandProcessor', ['commandProcessor']);
+
+        // Deprecated: favor using collection builders to direct use of collections.
         $container->add('collection', \Robo\Collection\Collection::class);
-        // Deprecated: use CollectionBuilder::create() instead.
+        // Deprecated: use CollectionBuilder::create() instead -- or, better
+        // yet, BuilderAwareInterface::collectionBuilder() if available.
         $container->add('collectionBuilder', \Robo\Collection\CollectionBuilder::class);
-        // Deprecated: use ProcessExecutor::create() or Robo::process() instead
-        $container->add('processExecutor', ProcessExecutor::class);
 
         static::addInflectors($container);
 

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -4,6 +4,7 @@ namespace Robo;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\StringInput;
 use Robo\Contract\BuilderAwareInterface;
+use Robo\Collection\CollectionBuilder;
 use Robo\Common\IO;
 use Robo\Exception\TaskExitException;
 use League\Container\ContainerAwareInterface;
@@ -234,7 +235,7 @@ class Runner implements ContainerAwareInterface
         // ensure that it has a builder.  Every command class needs
         // its own collection builder, as they have references to each other.
         if ($commandClass instanceof BuilderAwareInterface) {
-            $builder = $container->get('collectionBuilder', [$commandClass]);
+            $builder = CollectionBuilder::create($container, $commandClass);
             $commandClass->setBuilder($builder);
         }
         if ($commandClass instanceof ContainerAwareInterface) {

--- a/tests/_helpers/CliHelper.php
+++ b/tests/_helpers/CliHelper.php
@@ -2,6 +2,7 @@
 namespace Codeception\Module;
 
 use Robo\Robo;
+use Robo\Collection\CollectionBuilder;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 use League\Container\ContainerAwareInterface;
@@ -38,7 +39,7 @@ class CliHelper extends \Codeception\Module implements ContainerAwareInterface
     public function collectionBuilder()
     {
         $tasks = new \Robo\Tasks();
-        $builder = $this->getContainer()->get('collectionBuilder', [$tasks]);
+        $builder = CollectionBuilder::create($this->getContainer(), $tasks);
         $tasks->setBuilder($builder);
         return $builder;
     }

--- a/tests/unit/ApplicationTest.php
+++ b/tests/unit/ApplicationTest.php
@@ -3,6 +3,7 @@ require_once codecept_data_dir() . 'TestedRoboFile.php';
 
 use Robo\Robo;
 use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Robo\Collection\CollectionBuilder;
 
 class ApplicationTest extends \Codeception\TestCase\Test
 {
@@ -34,7 +35,7 @@ class ApplicationTest extends \Codeception\TestCase\Test
         $config = $container->get('config');
         $this->commandFactory = $container->get('commandFactory');
         $this->roboCommandFileInstance = new TestedRoboFile;
-        $builder = $container->get('collectionBuilder', [$this->roboCommandFileInstance]);
+        $builder = CollectionBuilder::create($container, $this->roboCommandFileInstance);
         $this->roboCommandFileInstance->setBuilder($builder);
         $commandList = $this->commandFactory->createCommandsFromClass($this->roboCommandFileInstance);
         foreach ($commandList as $command) {


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Remove call to undocumented two-parameter `$container->get('ref', [$arg]);`

### Description
League/Container allows objects to be fetched from the container using a two-parameter 'get' method. For objects that are not shared, this method will construct a new object using the parameters provided. However, this method is undocumented, and PSR-11 does not allow clients of the container to provide parameters for object construction, all of which are presumed to be provided from the container.