### PR TITLE
Modify CopyDir task to leverage symfony Filesystem copy.

### DIFF
--- a/docs/tasks/Filesystem.md
+++ b/docs/tasks/Filesystem.md
@@ -30,6 +30,7 @@ $this->_copyDir('dist/config', 'config');
 
 * `dirPermissions($value)`  Sets the default folder permissions for the destination if it doesn't exist
 * `exclude($exclude = null)`  List files to exclude.
+* `overwrite(false)` Overwrite destination files newer than source files - defaults to true.
 
 ## DeleteDir
 

--- a/src/Task/Filesystem/CopyDir.php
+++ b/src/Task/Filesystem/CopyDir.php
@@ -35,17 +35,7 @@ class CopyDir extends BaseDir
     /**
      * Overwrite destination files newer than source files.
      */
-    protected $overwrite;
-
-    /**
-     * @param string|string[] $dirs
-     * @param bool $overwrite
-     */
-    public function __construct($dirs, $overwrite)
-    {
-        $this->overwrite = $overwrite;
-        parent::__construct($dirs);
-    }
+    protected $overwrite = true;
 
     /**
      * {@inheritdoc}
@@ -56,7 +46,7 @@ class CopyDir extends BaseDir
             return Result::error($this, 'Source directories are missing!');
         }
         foreach ($this->dirs as $src => $dst) {
-            $this->copyDir($src, $dst, $this->overwrite);
+            $this->copyDir($src, $dst);
             $this->printTaskInfo('Copied from {source} to {destination}', ['source' => $src, 'destination' => $dst]);
         }
         return Result::success($this);
@@ -93,16 +83,27 @@ class CopyDir extends BaseDir
     }
 
     /**
+     * Destination files newer than source files are overwritten.
+     *
+     * @param bool $overwrite
+     *
+     * @return $this
+     */
+    public function overwrite($overwrite)
+    {
+        $this->overwrite = $overwrite;
+        return $this;
+    }
+
+    /**
      * Copies a directory to another location.
      *
      * @param string $src Source directory
      * @param string $dst Destination directory
-     * @param bool   $overwrite If true, destination files newer than source files are overwritten
-     *
      *
      * @throws \Robo\Exception\TaskException
      */
-    protected function copyDir($src, $dst, $overwrite)
+    protected function copyDir($src, $dst)
     {
         $dir = @opendir($src);
         if (false === $dir) {
@@ -119,9 +120,9 @@ class CopyDir extends BaseDir
                 $srcFile = $src . '/' . $file;
                 $destFile = $dst . '/' . $file;
                 if (is_dir($srcFile)) {
-                    $this->copyDir($srcFile, $destFile, $overwrite);
+                    $this->copyDir($srcFile, $destFile);
                 } else {
-                    $this->fs->copy($srcFile, $destFile, $overwrite);
+                    $this->fs->copy($srcFile, $destFile, $this->overwrite);
                 }
             }
         }

--- a/src/Task/Filesystem/CopyDir.php
+++ b/src/Task/Filesystem/CopyDir.php
@@ -33,6 +33,21 @@ class CopyDir extends BaseDir
     protected $exclude = [];
 
     /**
+     * Overwrite destination files newer than source files.
+     */
+    protected $overwrite;
+
+    /**
+     * @param string|string[] $dirs
+     * @param bool $overwrite
+     */
+    public function __construct($dirs, $overwrite)
+    {
+        $this->overwrite = $overwrite;
+        parent::__construct($dirs);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function run()
@@ -41,7 +56,7 @@ class CopyDir extends BaseDir
             return Result::error($this, 'Source directories are missing!');
         }
         foreach ($this->dirs as $src => $dst) {
-            $this->copyDir($src, $dst);
+            $this->copyDir($src, $dst, $this->overwrite);
             $this->printTaskInfo('Copied from {source} to {destination}', ['source' => $src, 'destination' => $dst]);
         }
         return Result::success($this);
@@ -82,10 +97,12 @@ class CopyDir extends BaseDir
      *
      * @param string $src Source directory
      * @param string $dst Destination directory
+     * @param bool   $overwrite If true, destination files newer than source files are overwritten
+     *
      *
      * @throws \Robo\Exception\TaskException
      */
-    protected function copyDir($src, $dst)
+    protected function copyDir($src, $dst, $overwrite)
     {
         $dir = @opendir($src);
         if (false === $dir) {
@@ -102,9 +119,9 @@ class CopyDir extends BaseDir
                 $srcFile = $src . '/' . $file;
                 $destFile = $dst . '/' . $file;
                 if (is_dir($srcFile)) {
-                    $this->copyDir($srcFile, $destFile);
+                    $this->copyDir($srcFile, $destFile, $overwrite);
                 } else {
-                    copy($srcFile, $destFile);
+                    $this->fs->copy($srcFile, $destFile, $overwrite);
                 }
             }
         }

--- a/src/Task/Filesystem/loadTasks.php
+++ b/src/Task/Filesystem/loadTasks.php
@@ -47,13 +47,12 @@ trait loadTasks
 
     /**
      * @param string|string[] $dirs
-     * @param bool $overwrite
      *
      * @return \Robo\Task\Filesystem\CopyDir
      */
-    protected function taskCopyDir($dirs, $overwrite = true)
+    protected function taskCopyDir($dirs)
     {
-        return $this->task(CopyDir::class, $dirs, $overwrite);
+        return $this->task(CopyDir::class, $dirs);
     }
 
     /**

--- a/src/Task/Filesystem/loadTasks.php
+++ b/src/Task/Filesystem/loadTasks.php
@@ -47,12 +47,13 @@ trait loadTasks
 
     /**
      * @param string|string[] $dirs
+     * @param bool $overwrite
      *
      * @return \Robo\Task\Filesystem\CopyDir
      */
-    protected function taskCopyDir($dirs)
+    protected function taskCopyDir($dirs, $overwrite = true)
     {
-        return $this->task(CopyDir::class, $dirs);
+        return $this->task(CopyDir::class, $dirs, $overwrite);
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Currently, the `CopyDir` task does not allow a user to specify whether or not destination files should be overwritten in the event that they are newer than the source files (a la the `overwrite` option provided in [Phing's copy task](https://www.phing.info/docs/guide/trunk/CopyTask.html). This pull request adds in an optional `$overwrite` parameter to the `CopyDir` task that defaults to `true` to ensure backwards compatibility (could consider changing the default to `false` for a major release).

### Description
To achieve the above behavior, `CopyDir` was modified to use the existing symfony `fs` object's `copy` method instead of what it is currently using - php's built in `copy` method.
