### PR TITLE
Fixed invalid call to Robo\Task\Development\SemVer::inflect() when executing task

### DIFF
--- a/src/Task/Development/SemVer.php
+++ b/src/Task/Development/SemVer.php
@@ -2,6 +2,7 @@
 namespace Robo\Task\Development;
 
 use Robo\Result;
+use Robo\Task\BaseTask;
 use Robo\Contract\TaskInterface;
 use Robo\Exception\TaskException;
 
@@ -17,7 +18,7 @@ use Robo\Exception\TaskException;
  * ```
  *
  */
-class SemVer implements TaskInterface
+class SemVer extends BaseTask
 {
     const SEMVER = "---\n:major: %d\n:minor: %d\n:patch: %d\n:special: '%s'\n:metadata: '%s'";
 


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
When i try to execute the task i receive the following error message:

```sh
ERROR: Call to undefined method Robo\Task\Development\SemVer::inflect() 
in /Users/wagnert/Workspace/import-cli-simple/vendor/consolidation/robo/src/Collection/CollectionBuilder.php:369
```

Seems, that the task doesn't implement the necessary `inflect()` method. Let the task extend the `BaskTask` class fixes the error.

### Description
No additional information necessary.
