### PR TITLE
Make detectInteractive() chainable.

### DIFF
--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -86,6 +86,8 @@ trait ExecTrait
 
     /**
      * Sets $this->interactive() based on posix_isatty().
+     *
+     * @return $this
      */
     public function detectInteractive()
     {
@@ -96,6 +98,8 @@ trait ExecTrait
         if (!isset($this->interactive) && function_exists('posix_isatty') && $this->verbosityMeetsThreshold()) {
             $this->interactive = posix_isatty(STDOUT);
         }
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Make detectInteractive() chainable for taskExec().