### PR TITLE
Codecept suite and testname fix

### DIFF
--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -28,17 +28,7 @@ use Symfony\Component\Process\Process;
 class Codecept extends BaseTask implements CommandInterface, PrintedInterface
 {
     use \Robo\Common\ExecOneCommand;
-
-    /**
-     * @var string
-     */
-    protected $suite = '';
-
-    /**
-     * @var string
-     */
-    protected $test = '';
-
+    
     /**
      * @var string
      */
@@ -68,7 +58,7 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
      */
     public function suite($suite)
     {
-        $this->suite = $suite;
+        $this->option(null, $suite);
         return $this;
     }
 
@@ -79,7 +69,7 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
      */
     public function test($testName)
     {
-        $this->test = $testName;
+        $this->option(null, $testName);
         return $this;
     }
 
@@ -247,8 +237,6 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
      */
     public function getCommand()
     {
-        $this->option(null, $this->suite)
-            ->option(null, $this->test);
         return $this->command . $this->arguments;
     }
 

--- a/tests/unit/Task/CodeceptionTest.php
+++ b/tests/unit/Task/CodeceptionTest.php
@@ -42,7 +42,7 @@ class CodeceptionTest extends \Codeception\TestCase\Test
             ->env('process1')
             ->coverage()
             ->getCommand()
-        )->equals('codecept run --group core --env process1 --coverage unit Codeception/Command');
+        )->equals('codecept run unit Codeception/Command --group core --env process1 --coverage');
 
         verify((new \Robo\Task\Testing\Codecept('codecept'))
             ->test('tests/unit/Codeception')
@@ -50,7 +50,7 @@ class CodeceptionTest extends \Codeception\TestCase\Test
             ->xml('result.xml')
             ->html()
             ->getCommand()
-        )->equals('codecept run -c ~/Codeception --xml result.xml --html tests/unit/Codeception');
+        )->equals('codecept run tests/unit/Codeception -c ~/Codeception --xml result.xml --html');
 
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->debug()->getCommand())->contains(' --debug');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->silent()->getCommand())->contains(' --silent');


### PR DESCRIPTION
### Overview
This pull request:
- Fixes a bug
- Has tests that cover changes

### Summary
Changed suite and testname in codecept task command - now they are handled as simple options.

### Description
**Before fix**: suite and testname always be in the end of the command. This behaviour breaks some rawArg() , e.g. "> log", "| tee log". 
**After fix**: suite and testname are treated like simple options. 