### PR TITLE
Setting $this->interactive to NULL by default.

### DIFF
--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -44,7 +44,7 @@ trait ExecTrait
     /**
      * @var boolean
      */
-    protected $interactive = false;
+    protected $interactive = null;
 
     /**
      * @var bool

--- a/tests/cli/ExecCest.php
+++ b/tests/cli/ExecCest.php
@@ -6,7 +6,7 @@ class ExecCest
     public function toExecLsCommand(CliGuy $I)
     {
         $command = strncasecmp(PHP_OS, 'WIN', 3) == 0 ? 'dir' : 'ls';
-        $res = $I->taskExec($command)->run();
+        $res = $I->taskExec($command)->interactive(false)->run();
         verify($res->getMessage())->contains('src');
         verify($res->getMessage())->contains('codeception.yml');
     }


### PR DESCRIPTION
Currently, `detectInteractive()` does not work as intended because its check for `isset($this->interactive)` will always be return true.

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes