### PR TITLE
Fixes #574: In 'stopOnFail' mode in CommandStack with a single command.

### DIFF
--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -98,7 +98,7 @@ trait ExecTrait
         if (!isset($this->interactive) && function_exists('posix_isatty') && $this->verbosityMeetsThreshold()) {
             $this->interactive = posix_isatty(STDOUT);
         }
-        
+
         return $this;
     }
 

--- a/src/ResultData.php
+++ b/src/ResultData.php
@@ -131,6 +131,25 @@ class ResultData extends \ArrayObject implements ExitCodeInterface, OutputDataIn
     }
 
     /**
+     * Merge another result into this result.  Data already
+     * existing in this result takes precedence over the
+     * data in the Result being merged.
+     *
+     * $data['message'] is handled specially, and is appended
+     * to $this->message if set.
+     *
+     * @param array $data
+     *
+     * @return array
+     */
+    public function mergeData(array $data)
+    {
+        $mergedData = $this->getArrayCopy() + $data;
+        $this->exchangeArray($mergedData);
+        return $mergedData;
+    }
+
+    /**
      * @return bool
      */
     public function hasExecutionTime()
@@ -147,5 +166,30 @@ class ResultData extends \ArrayObject implements ExitCodeInterface, OutputDataIn
             return null;
         }
         return $this['time'];
+    }
+
+    /**
+     * Accumulate execution time
+     */
+    public function accumulateExecutionTime($duration)
+    {
+        // Convert data arrays to scalar
+        if (is_array($duration)) {
+            $duration = isset($duration['time']) ? $duration['time'] : 0;
+        }
+        $this['time'] = $this->getExecutionTime() + $duration;
+        return $this->getExecutionTime();
+    }
+
+    /**
+     * Accumulate the message.
+     */
+    public function accumulateMessage($message)
+    {
+        if (!empty($this->message)) {
+            $this->message .= "\n";
+        }
+        $this->message .= $message;
+        return $this->getMessage();
     }
 }

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -117,6 +117,7 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
         // losing the output from all successful commands.
         $data = [];
         $message = '';
+        $result = null;
         foreach ($this->exec as $command) {
             $this->printTaskInfo("Executing {command}", ['command' => $command]);
             $result = $this->executeCommand($command);

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -104,11 +104,17 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
         if (empty($this->exec)) {
             throw new TaskException($this, 'You must add at least one command');
         }
-        if (!$this->stopOnFail) {
+        // If 'stopOnFail' is not set, or if there is only one command to run,
+        // then execute the single command to run.
+        if (!$this->stopOnFail || (count($this->exec) == 1)) {
             $this->printTaskInfo('{command}', ['command' => $this->getCommand()]);
             return $this->executeCommand($this->getCommand());
         }
 
+        // When executing multiple commands in 'stopOnFail' mode, run them
+        // one at a time so that the result will have the exact command
+        // that failed available to the caller. This is at the expense of
+        // losing the output from all successful commands.
         foreach ($this->exec as $command) {
             $this->printTaskInfo("Executing {command}", ['command' => $command]);
             $result = $this->executeCommand($command);

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -115,14 +115,19 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
         // one at a time so that the result will have the exact command
         // that failed available to the caller. This is at the expense of
         // losing the output from all successful commands.
+        $data = [];
+        $message = '';
         foreach ($this->exec as $command) {
             $this->printTaskInfo("Executing {command}", ['command' => $command]);
             $result = $this->executeCommand($command);
+            $result->accumulateExecutionTime($data);
+            $message = $result->accumulateMessage($message);
+            $data = $result->mergeData($data);
             if (!$result->wasSuccessful()) {
                 return $result;
             }
         }
 
-        return Result::success($this);
+        return $result;
     }
 }

--- a/tests/_helpers/SeeInOutputTrait.php
+++ b/tests/_helpers/SeeInOutputTrait.php
@@ -44,18 +44,33 @@ trait SeeInOutputTrait
     public function seeInOutput($value)
     {
         $output = $this->accumulate();
+        $output = $this->simplify($output);
         $this->assertContains($value, $output);
     }
 
     public function doNotSeeInOutput($value)
     {
         $output = $this->accumulate();
+        $output = $this->simplify($output);
         $this->assertNotContains($value, $output);
     }
 
     public function seeOutputEquals($value)
     {
         $output = $this->accumulate();
+        $output = $this->simplify($output);
         $this->assertEquals($value, $output);
+    }
+
+    /**
+     * Make our output comparisons more platform-agnostic by converting
+     * CRLF (Windows) or raw CR (confused output) to a LF (unix/Mac).
+     */
+    protected function simplify($output)
+    {
+        $output = str_replace("\r\n", "\n", $output);
+        $output = str_replace("\r", "\n", $output);
+
+        return $output;
     }
 }


### PR DESCRIPTION
Ensures the output from said command is returned in the exec result.

### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
If a CommandStack has only a single command, always return the result of that command with its output.

### Description
The CommandStack throws away command output when it runs multiple commands individually in `stopOnFail` mode. Commands are run individually in this mode so that the exact command that failed is identified in the result when there is a failure. The results from the command are discarded when doing this because it is inconvenient to merge together multiple Result objects under the current implementation. Result objects print a result message in their constructor, which is a poor time to be printing output; however, the implementation of progress output was easier that way, and there is a focus on keeping things both simple and easy for tasks. Also, command stacks were not intended to be used for collecting command output; the presumption was that a lower-level function (`exec`, Symfony Process component, etc.) would be used for information collection, and CommandStack would be used for running commands that changed the state of the system.

This shortcoming could potentially be solved with additional work; however, in most cases, if the output from a command is desired, it should probably be run individually so that its output is not intermixed with the output of the other commands in the command stack, so this simple fix is probably sufficient.
