### PR TITLE
Remove superfluous printTaskInfo() call

### DIFF
--- a/src/Task/Docker/Base.php
+++ b/src/Task/Docker/Base.php
@@ -20,7 +20,6 @@ abstract class Base extends BaseTask implements PrintedInterface
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo('Running {command}', ['command' => $command]);
         return $this->executeCommand($command);
     }
 


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Removes the explicit call to `printTaskInfo()` inside Docker tasks since it effectively duplicates a similar call made implicitly by `ExecTrait`.

### Description
This seems to resolve consolidation/Robo#576.