### PR TITLE
Fixes #584: allow tasks to return results of types other than \Robo\R…

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -254,6 +254,8 @@ $this->_copy('config/env.example.yml','config/env.yml');
 
 Each task must return an instance of `Robo\Result`. A Robo Result contains the task instance, exit code, message, and any variable data that the task may wish to return.
 
+*Note*: A task may also return `NULL` or an array as a shortcut for a successful result. In this instance, Robo will convert the value into a `Robo\Result`, and will apply the provided array values, if any, to the result's variable data. This practice is supported, but not recommended.
+
 The `run` method of `CompileAssets` class may look like this:
 
 ```

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -652,6 +652,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
         }
         $this->doDeferredInitialization($original);
         $taskResult = $task->run();
+        $taskResult = Result::ensureResult($task, $taskResult);
         $this->doStateUpdates($original, $taskResult);
         return $taskResult;
     }

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -15,6 +15,7 @@ use Robo\Contract\CommandInterface;
 use Robo\Contract\VerbosityThresholdInterface;
 use Robo\State\StateAwareInterface;
 use Robo\State\StateAwareTrait;
+use Robo\Result;
 
 /**
  * Creates a collection, and adds tasks to it.  The collection builder
@@ -531,7 +532,8 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     protected function runTasks()
     {
         if (!$this->collection && $this->currentTask) {
-            return $this->currentTask->run();
+            $result = $this->currentTask->run();
+            return Result::ensureResult($this->currentTask, $result);
         }
         return $this->getCollection()->run();
     }

--- a/src/Result.php
+++ b/src/Result.php
@@ -3,6 +3,7 @@ namespace Robo;
 
 use Robo\Contract\TaskInterface;
 use Robo\Exception\TaskExitException;
+use Robo\State\Data;
 
 class Result extends ResultData
 {
@@ -31,6 +32,30 @@ class Result extends ResultData
         if (self::$stopOnFail) {
             $this->stopOnFail();
         }
+    }
+
+    /**
+     * Tasks should always return a Result. However, they are also
+     * allowed to return NULL or an array to indicate success.
+     */
+    public static function ensureResult($task, $result)
+    {
+        if ($result instanceof Result) {
+            return $result;
+        }
+        if (!isset($result)) {
+            return static::success($task);
+        }
+        if ($result instanceof Data) {
+            return static::success($task, $result->getMessage(), $result->getData());
+        }
+        if ($result instanceof ResultData) {
+            return new Result($task, $result->getExitCode(), $result->getMessage(), $result->getData());
+        }
+        if (is_array($result)) {
+            return static::success($task, '', $result);
+        }
+        throw new \Exception(sprintf('Task %s returned a %s instead of a \Robo\Result.', get_class($task), get_class($result)));
     }
 
     protected function printResult()


### PR DESCRIPTION
…esult.

### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Preserve backwards compatibility with undocumented feature of Robo 1.0.6 and earlier that allowed tasks to return a data type other than \Robo\Result.

