### PR TITLE
[#582] Added support for CopyDir to exclude files in subdirs.

### DIFF
--- a/docs/tasks/Filesystem.md
+++ b/docs/tasks/Filesystem.md
@@ -29,7 +29,10 @@ $this->_copyDir('dist/config', 'config');
 ```
 
 * `dirPermissions($value)`  Sets the default folder permissions for the destination if it doesn't exist
-* `exclude($exclude = null)`  List files to exclude.
+* `exclude($exclude = null)`  List files to exclude. Supported path values: 
+  - file/directory basename
+  - file/directory path relative to execution directory
+  - file/directory path relative to source directory
 * `overwrite($overwrite)`  Destination files newer than source files are overwritten.
 
 ## DeleteDir

--- a/src/Task/Filesystem/CopyDir.php
+++ b/src/Task/Filesystem/CopyDir.php
@@ -100,10 +100,11 @@ class CopyDir extends BaseDir
      *
      * @param string $src Source directory
      * @param string $dst Destination directory
+     * @param string $parent Parent directory
      *
      * @throws \Robo\Exception\TaskException
      */
-    protected function copyDir($src, $dst)
+    protected function copyDir($src, $dst, $parent = '')
     {
         $dir = @opendir($src);
         if (false === $dir) {
@@ -113,14 +114,15 @@ class CopyDir extends BaseDir
             mkdir($dst, $this->chmod, true);
         }
         while (false !== ($file = readdir($dir))) {
-            if (in_array($file, $this->exclude)) {
-                 continue;
+            // Support basename and full path exclusion.
+            if (in_array($file, $this->exclude) || in_array($parent . $file, $this->exclude) || in_array($src . DIRECTORY_SEPARATOR . $file, $this->exclude)) {
+                continue;
             }
             if (($file !== '.') && ($file !== '..')) {
                 $srcFile = $src . '/' . $file;
                 $destFile = $dst . '/' . $file;
                 if (is_dir($srcFile)) {
-                    $this->copyDir($srcFile, $destFile);
+                    $this->copyDir($srcFile, $destFile, $parent . $file . DIRECTORY_SEPARATOR);
                 } else {
                     $this->fs->copy($srcFile, $destFile, $this->overwrite);
                 }

--- a/tests/_data/claypit/some/deeply/nested/structu1.re
+++ b/tests/_data/claypit/some/deeply/nested/structu1.re
@@ -1,0 +1,1 @@
+Just a file

--- a/tests/_data/claypit/some/deeply/nested/structu2.re
+++ b/tests/_data/claypit/some/deeply/nested/structu2.re
@@ -1,0 +1,1 @@
+Just a file

--- a/tests/_data/claypit/some/deeply/nested/structu3.re
+++ b/tests/_data/claypit/some/deeply/nested/structu3.re
@@ -1,0 +1,1 @@
+Just a file

--- a/tests/_data/claypit/some/deeply/nested2/structu21.re
+++ b/tests/_data/claypit/some/deeply/nested2/structu21.re
@@ -1,0 +1,1 @@
+Just a file

--- a/tests/_data/claypit/some/deeply/nested3/nested31/structu311.re
+++ b/tests/_data/claypit/some/deeply/nested3/nested31/structu311.re
@@ -1,0 +1,1 @@
+Just a file

--- a/tests/_data/claypit/some/deeply/nested3/structu31.re
+++ b/tests/_data/claypit/some/deeply/nested3/structu31.re
@@ -1,0 +1,1 @@
+Just a file

--- a/tests/_data/claypit/some/deeply/nested3/structu32.re
+++ b/tests/_data/claypit/some/deeply/nested3/structu32.re
@@ -1,0 +1,1 @@
+Just a file

--- a/tests/_data/claypit/some/deeply/nested4/nested41/structu411.re
+++ b/tests/_data/claypit/some/deeply/nested4/nested41/structu411.re
@@ -1,0 +1,1 @@
+Just a file

--- a/tests/_data/claypit/some/deeply/nested4/nested41/structu412.re
+++ b/tests/_data/claypit/some/deeply/nested4/nested41/structu412.re
@@ -1,0 +1,1 @@
+Just a file

--- a/tests/cli/CopyDirRecursiveExcludeCept.php
+++ b/tests/cli/CopyDirRecursiveExcludeCept.php
@@ -7,6 +7,8 @@ $I->seeDirFound('some/deeply/nested');
 $I->seeDirFound('some/deeply/nested2');
 $I->seeDirFound('some/deeply/nested3');
 $I->seeDirFound('some/deeply/nested3/nested31');
+$I->seeDirFound('some/deeply/nested4');
+$I->seeDirFound('some/deeply/nested4/nested41');
 $I->seeFileFound('structu.re', 'some/deeply/nested');
 $I->seeFileFound('structu1.re', 'some/deeply/nested');
 $I->seeFileFound('structu2.re', 'some/deeply/nested');
@@ -15,6 +17,8 @@ $I->seeFileFound('structu21.re', 'some/deeply/nested2');
 $I->seeFileFound('structu31.re', 'some/deeply/nested3');
 $I->seeFileFound('structu32.re', 'some/deeply/nested3');
 $I->seeFileFound('structu311.re', 'some/deeply/nested3/nested31');
+$I->seeFileFound('structu411.re', 'some/deeply/nested4/nested41');
+$I->seeFileFound('structu412.re', 'some/deeply/nested4/nested41');
 $I->taskCopyDir(['some/deeply' => 'some_destination/deeply'])
     ->exclude([
         // Basename exclusion.
@@ -27,6 +31,8 @@ $I->taskCopyDir(['some/deeply' => 'some_destination/deeply'])
         'some/deeply/nested3/nested31',
         // Subpath within source exclusion.
         'nested3/structu31.re',
+        // File in deeper subpath within source exclusion.
+        'nested4/nested41/structu411.re',
     ])
     ->run();
 $I->seeDirFound('some_destination/deeply/nested');
@@ -39,3 +45,5 @@ $I->seeDirFound('some_destination/deeply/nested3');
 $I->cantSeeFileFound('structu31.re', 'some_destination/deeply/nested3');
 $I->canSeeFileFound('structu32.re', 'some_destination/deeply/nested3');
 $I->cantSeeFileFound('nested31', 'some_destination/deeply/nested3');
+$I->cantSeeFileFound('structu411.re', 'some_destination/deeply/nested4/nested41');
+$I->canSeeFileFound('structu412.re', 'some_destination/deeply/nested4/nested41');

--- a/tests/cli/CopyDirRecursiveExcludeCept.php
+++ b/tests/cli/CopyDirRecursiveExcludeCept.php
@@ -1,0 +1,41 @@
+<?php
+$I = new CliGuy($scenario);
+
+$I->wantTo('copy dir recursively with CopyDir task, but exclude a file');
+$I->amInPath(codecept_data_dir().'sandbox');
+$I->seeDirFound('some/deeply/nested');
+$I->seeDirFound('some/deeply/nested2');
+$I->seeDirFound('some/deeply/nested3');
+$I->seeDirFound('some/deeply/nested3/nested31');
+$I->seeFileFound('structu.re', 'some/deeply/nested');
+$I->seeFileFound('structu1.re', 'some/deeply/nested');
+$I->seeFileFound('structu2.re', 'some/deeply/nested');
+$I->seeFileFound('structu3.re', 'some/deeply/nested');
+$I->seeFileFound('structu21.re', 'some/deeply/nested2');
+$I->seeFileFound('structu31.re', 'some/deeply/nested3');
+$I->seeFileFound('structu32.re', 'some/deeply/nested3');
+$I->seeFileFound('structu311.re', 'some/deeply/nested3/nested31');
+$I->taskCopyDir(['some/deeply' => 'some_destination/deeply'])
+    ->exclude([
+        // Basename exclusion.
+        'structu1.re',
+        // File in subdir exclusion.
+        'some/deeply/nested/structu3.re',
+        // Dir exclusion.
+        'nested2',
+        // Subdir exclusion.
+        'some/deeply/nested3/nested31',
+        // Subpath within source exclusion.
+        'nested3/structu31.re',
+    ])
+    ->run();
+$I->seeDirFound('some_destination/deeply/nested');
+$I->seeFileFound('structu.re', 'some_destination/deeply/nested');
+$I->cantSeeFileFound('structu1.re', 'some_destination/deeply/nested');
+$I->canSeeFileFound('structu2.re', 'some_destination/deeply/nested');
+$I->cantSeeFileFound('structu3.re', 'some_destination/deeply/nested');
+$I->cantSeeFileFound('nested2', 'some_destination/deeply');
+$I->seeDirFound('some_destination/deeply/nested3');
+$I->cantSeeFileFound('structu31.re', 'some_destination/deeply/nested3');
+$I->canSeeFileFound('structu32.re', 'some_destination/deeply/nested3');
+$I->cantSeeFileFound('nested31', 'some_destination/deeply/nested3');


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [x] Updates documentation

### Summary
Allows to exclude files and directories in sub dirs.
Fixes https://github.com/consolidation/Robo/issues/582

### Description
Say, file exists in path `some/deeply/nested/nested_more/file.txt`and the command is called
```
$this->taskCopyDir(['some/deeply' => 'some_destination/deeply'])
```

This PR now allows to specify exclusion in 3 ways:
1. File/directory name basename: `file.txt` for file or `nested_more` for dir

2. File/directory full path from the same location were source is called: `some/deeply/nested/nested_more/file.txt` for file or `some/deeply/nested/nested_more` for dir

3. File/directory path from the same location as source items: `nested/nested_more/file.txt` for file or `nested/nested_more` for dir