### PR TITLE
Enhance SemVer task so that it can be used with files or strings.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "pre-install-cmd": [
           "Robo\\composer\\ScriptHandler::checkDependencies"
         ],
-        "cs": "/robo sniff",
+        "cs": "./robo sniff",
         "test": "./robo test"
     },
     "extra": {

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -567,6 +567,8 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
                 // the incremental results, if they wish.
                 $key = Result::isUnnamed($taskName) ? $name : $taskName;
                 $result->accumulate($key, $taskResult);
+                // The result message will be the message of the last task executed.
+                $result->setMessage($taskResult->getMessage());
             }
         } catch (TaskExitException $exitException) {
             $this->fail();

--- a/src/Result.php
+++ b/src/Result.php
@@ -69,7 +69,7 @@ class Result extends ResultData
         $resultPrinter = Robo::resultPrinter();
         if ($resultPrinter) {
             if ($resultPrinter->printResult($this)) {
-                $this->data['already-printed'] = true;
+                $this->alreadyPrinted();
             }
         }
     }

--- a/src/ResultData.php
+++ b/src/ResultData.php
@@ -71,9 +71,25 @@ class ResultData extends Data implements ExitCodeInterface, OutputDataInterface
      */
     public function getOutputData()
     {
-        if (!empty($this->message) && !isset($this['already-printed'])) {
+        if (!empty($this->message) && !isset($this['already-printed']) && isset($this['provide-outputdata'])) {
             return $this->message;
         }
+    }
+
+    /**
+     * Indicate that the message in this data has already been displayed.
+     */
+    public function alreadyPrinted()
+    {
+        $this['already-printed'] = true;
+    }
+
+    /**
+     * Opt-in to providing the result message as the output data
+     */
+    public function provideOutputdata()
+    {
+        $this['provide-outputdata'] = true;
     }
 
     /**

--- a/src/State/Data.php
+++ b/src/State/Data.php
@@ -40,6 +40,14 @@ class Data extends \ArrayObject
     }
 
     /**
+     * @param string message
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+    }
+
+    /**
      * Merge another result into this result.  Data already
      * existing in this result takes precedence over the
      * data in the Result being merged.


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Allow semver task to be used with strings. Just exercising the CollectionBuilder on a task that does not implement BaseTask.
