### PR TITLE
Add stdout and stderr to background task ResultData.

### DIFF
--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -345,7 +345,10 @@ trait ExecTrait
                 $this->getResultData()
             );
         }
-        return new ResultData($this->process->getExitCode());
+        return new ResultData($this->process->getExitCode(), '', [
+            'stdout' => $process->getOutput(),
+            'stderr' => $process->getErrorOutput(),
+        ]);
     }
 
     /**


### PR DESCRIPTION
Presently, there is no mechanism for getting the output of a taskExec() call that uses background(TRUE). Therefore, if the task fails, the user cannot be informed of the reason for the failure.

This pull request adds the stdout and stderr output from the background task to the task's ResultData. This prevents it from being printed to screen, but makes it accessible via $result->getData().

I'd be open to other approaches, but this seemed simple and backwards compatible.