### PR TITLE
Introduce printTaskNotice method and refactor usages of printTaskInfo…

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -135,9 +135,9 @@ To use the tasks you define in a RoboFile, use its `loadTasks` trait as explaine
 
 To allow tasks access IO, use the `Robo\Common\TaskIO` trait, or inherit your task class from `Robo\Task\BaseTask` (recommended).
 
-Inside tasks you should print process details with `printTaskInfo`, `printTaskSuccess`, and `printTaskError`.
+Inside tasks you should print process details with `printTaskNotice`, `printTaskInfo`, `printTaskSuccess`, and `printTaskError`.
 ```
-$this->printTaskInfo('Processing...');
+$this->printTaskNotice('Processing...');
 ```
 The Task IO methods send all output through a PSR-3 logger. Tasks should use task IO exclusively; methods such as 'say' and 'ask' should reside in the command method. This allows tasks to be usable in any context that has a PSR-3 logger, including background or server processes where it is not possible to directly query the user.
 

--- a/src/Collection/TaskForEach.php
+++ b/src/Collection/TaskForEach.php
@@ -74,7 +74,7 @@ class TaskForEach extends BaseTask implements NestedCollectionInterface, Builder
             $context = ['key' => $key, 'value' => $value];
             $context += $this->context;
             $context += TaskInfo::getTaskContext($this);
-            $this->printTaskInfo($this->message, $context);
+            $this->printTaskNotice($this->message, $context);
         }
     }
 

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -76,6 +76,7 @@ trait ExecTrait
      */
     abstract public function hideTaskProgress();
     abstract public function showTaskProgress($inProgress);
+    abstract public function printTaskNotice($text, $context = null);
     abstract public function printTaskInfo($text, $context = null);
 
     /**
@@ -355,7 +356,7 @@ trait ExecTrait
     {
         if ($this->background && isset($this->process) && $this->process->isRunning()) {
             $this->process->stop();
-            $this->printTaskInfo(
+            $this->printTaskNotice(
                 "Stopped {command}",
                 ['command' => $this->getCommandDescription()]
             );
@@ -369,7 +370,7 @@ trait ExecTrait
     {
         $command = $this->getCommandDescription();
         $dir = $this->workingDirectory ? " in {dir}" : "";
-        $this->printTaskInfo("Running {command}$dir", [
+        $this->printTaskNotice("Running {command}$dir", [
                 'command' => $command,
                 'dir' => $this->workingDirectory
             ] + $context);

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -46,7 +46,7 @@ trait TaskIO
     }
 
     /**
-     * Print information about a task in progress.
+     * Print ordinary output about a task in progress.
      *
      * With the Symfony Console logger, NOTICE is displayed at VERBOSITY_VERBOSE
      * and INFO is displayed at VERBOSITY_VERY_VERBOSE.
@@ -54,8 +54,31 @@ trait TaskIO
      * Robo overrides the default such that NOTICE is displayed at
      * VERBOSITY_NORMAL and INFO is displayed at VERBOSITY_VERBOSE.
      *
-     * n.b. We should probably have printTaskNotice for our ordinary
-     * output, and use printTaskInfo for less interesting messages.
+     * Use printTaskNotice for ordinary output, and printTaskInfo for less
+     * interesting messages.
+     *
+     * @param string $text
+     * @param null|array $context
+     */
+    protected function printTaskNotice($text, $context = null)
+    {
+        // The 'note' style is used for both 'notice' and 'info' log levels;
+        // However, 'notice' is printed at VERBOSITY_NORMAL, whereas 'info'
+        // is only printed at VERBOSITY_VERBOSE.
+        $this->printTaskOutput(LogLevel::NOTICE, $text, $this->getTaskContext($context));
+    }
+
+    /**
+     * Print more detailed information about a task in progress.
+     *
+     * With the Symfony Console logger, NOTICE is displayed at VERBOSITY_VERBOSE
+     * and INFO is displayed at VERBOSITY_VERY_VERBOSE.
+     *
+     * Robo overrides the default such that NOTICE is displayed at
+     * VERBOSITY_NORMAL and INFO is displayed at VERBOSITY_VERBOSE.
+     *
+     * Use printTaskNotice for ordinary output, and printTaskInfo for less
+     * interesting messages.
      *
      * @param string $text
      * @param null|array $context
@@ -65,7 +88,7 @@ trait TaskIO
         // The 'note' style is used for both 'notice' and 'info' log levels;
         // However, 'notice' is printed at VERBOSITY_NORMAL, whereas 'info'
         // is only printed at VERBOSITY_VERBOSE.
-        $this->printTaskOutput(LogLevel::NOTICE, $text, $this->getTaskContext($context));
+        $this->printTaskOutput(LogLevel::INFO, $text, $this->getTaskContext($context));
     }
 
     /**

--- a/src/Common/VerbosityThresholdTrait.php
+++ b/src/Common/VerbosityThresholdTrait.php
@@ -14,8 +14,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Task input/output methods.  TaskIO is 'used' in BaseTask, so any
  * task that extends this class has access to all of the methods here.
- * printTaskInfo, printTaskSuccess, and printTaskError are the three
- * primary output methods that tasks are encouraged to use.  Tasks should
+ * printTaskNotice, printTaskInfo, printTaskSuccess, and printTaskError are the
+ * four primary output methods that tasks are encouraged to use.  Tasks should
  * avoid using the IO trait output methods.
  */
 trait VerbosityThresholdTrait

--- a/src/Task/ApiGen/ApiGen.php
+++ b/src/Task/ApiGen/ApiGen.php
@@ -512,7 +512,7 @@ class ApiGen extends BaseTask implements CommandInterface
      */
     public function run()
     {
-        $this->printTaskInfo('Running ApiGen {args}', ['args' => $this->arguments]);
+        $this->printTaskNotice('Running ApiGen {args}', ['args' => $this->arguments]);
         return $this->executeCommand($this->getCommand());
     }
 }

--- a/src/Task/Archive/Extract.php
+++ b/src/Task/Archive/Extract.php
@@ -106,11 +106,11 @@ class Extract extends BaseTask implements BuilderAwareInterface
 
         $this->startTimer();
 
-        $this->printTaskInfo("Extracting {filename}", ['filename' => $this->filename]);
+        $this->printTaskNotice("Extracting {filename}", ['filename' => $this->filename]);
 
         $result = $this->extractAppropriateType($mimetype, $extractLocation);
         if ($result->wasSuccessful()) {
-            $this->printTaskInfo("{filename} extracted", ['filename' => $this->filename]);
+            $this->printTaskNotice("{filename} extracted", ['filename' => $this->filename]);
             // Now, we want to move the extracted files to $this->to. There
             // are two possibilities that we must consider:
             //

--- a/src/Task/Archive/Pack.php
+++ b/src/Task/Archive/Pack.php
@@ -151,7 +151,7 @@ class Pack extends BaseTask implements PrintedInterface
 
         try {
             // Inform the user which archive we are creating
-            $this->printTaskInfo("Creating archive {filename}", ['filename' => $this->archiveFile]);
+            $this->printTaskNotice("Creating archive {filename}", ['filename' => $this->archiveFile]);
             if ($extension == 'zip') {
                 $result = $this->archiveZip($this->archiveFile, $this->items);
             } else {

--- a/src/Task/Assets/ImageMinify.php
+++ b/src/Task/Assets/ImageMinify.php
@@ -305,7 +305,7 @@ class ImageMinify extends BaseTask
                 $files[$file->getRealpath()] = $this->getTarget($file->getRealPath(), $to);
             }
             $fileNoun = count($finder) == 1 ? ' file' : ' files';
-            $this->printTaskInfo("Found {filecount} $fileNoun in {dir}", ['filecount' => count($finder), 'dir' => $dir]);
+            $this->printTaskNotice("Found {filecount} $fileNoun in {dir}", ['filecount' => count($finder), 'dir' => $dir]);
         }
 
         return $files;
@@ -385,7 +385,7 @@ class ImageMinify extends BaseTask
             }
 
             // launch the command
-            $this->printTaskInfo('Minifying {filepath} with {minifier}', ['filepath' => $from, 'minifier' => $minifier]);
+            $this->printTaskNotice('Minifying {filepath} with {minifier}', ['filepath' => $from, 'minifier' => $minifier]);
             $result = $this->executeCommand($command);
 
             // check the return code
@@ -404,7 +404,7 @@ class ImageMinify extends BaseTask
                                 $command = $this->{$minifier}($from, $to);
                             }
                             // launch the command
-                            $this->printTaskInfo('Minifying {filepath} with {minifier}', ['filepath' => $from, 'minifier' => $minifier]);
+                            $this->printTaskNotice('Minifying {filepath} with {minifier}', ['filepath' => $from, 'minifier' => $minifier]);
                             $result = $this->executeCommand($command);
                         } else {
                             $this->printTaskError($result->getMessage());
@@ -489,7 +489,7 @@ class ImageMinify extends BaseTask
 
             return Result::error($this, $message);
         }
-        $this->printTaskInfo('Downloading the {executable} executable from the imagemin repository', ['executable' => $executable]);
+        $this->printTaskNotice('Downloading the {executable} executable from the imagemin repository', ['executable' => $executable]);
 
         $os = $this->getOS();
         $url = $this->imageminRepos[$executable].'/blob/master/vendor/'.$os.'/'.$executable.'?raw=true';

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -126,7 +126,7 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
             $process->setIdleTimeout($this->idleTimeout);
             $process->setTimeout($this->timeout);
             $process->start();
-            $this->printTaskInfo($process->getCommandLine());
+            $this->printTaskNotice($process->getCommandLine());
         }
 
         $this->startProgressIndicator();
@@ -141,7 +141,7 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
                 if (!$process->isRunning()) {
                     $this->advanceProgressIndicator();
                     if ($this->isPrinted) {
-                        $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $process->getOutput(), '_style' => ['command' => 'fg=white;bg=magenta']]);
+                        $this->printTaskNotice("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $process->getOutput(), '_style' => ['command' => 'fg=white;bg=magenta']]);
                         $errorOutput = $process->getErrorOutput();
                         if ($errorOutput) {
                             $this->printTaskError(rtrim($errorOutput));

--- a/src/Task/Base/SymfonyCommand.php
+++ b/src/Task/Base/SymfonyCommand.php
@@ -66,7 +66,7 @@ class SymfonyCommand extends BaseTask
      */
     public function run()
     {
-        $this->printTaskInfo('Running command {command}', ['command' => $this->command->getName()]);
+        $this->printTaskNotice('Running command {command}', ['command' => $this->command->getName()]);
         return new Result(
             $this,
             $this->command->run(new ArrayInput($this->input), Robo::output())

--- a/src/Task/Base/Watch.php
+++ b/src/Task/Base/Watch.php
@@ -78,7 +78,7 @@ class Watch extends BaseTask
             $closure->bindTo($this->bindTo);
             foreach ($monitor[0] as $i => $dir) {
                 $watcher->track("fs.$k.$i", $dir, FilesystemEvent::MODIFY);
-                $this->printTaskInfo('Watching {dir} for changes...', ['dir' => $dir]);
+                $this->printTaskNotice('Watching {dir} for changes...', ['dir' => $dir]);
                 $watcher->addListener("fs.$k.$i", $closure);
             }
         }

--- a/src/Task/Bower/Install.php
+++ b/src/Task/Bower/Install.php
@@ -30,7 +30,7 @@ class Install extends Base implements CommandInterface
      */
     public function run()
     {
-        $this->printTaskInfo('Install Bower packages: {arguments}', ['arguments' => $this->arguments]);
+        $this->printTaskNotice('Install Bower packages: {arguments}', ['arguments' => $this->arguments]);
         return $this->executeCommand($this->getCommand());
     }
 }

--- a/src/Task/Bower/Update.php
+++ b/src/Task/Bower/Update.php
@@ -28,7 +28,7 @@ class Update extends Base
      */
     public function run()
     {
-        $this->printTaskInfo('Update Bower packages: {arguments}', ['arguments' => $this->arguments]);
+        $this->printTaskNotice('Update Bower packages: {arguments}', ['arguments' => $this->arguments]);
         return $this->executeCommand($this->getCommand());
     }
 }

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -107,7 +107,7 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
         // If 'stopOnFail' is not set, or if there is only one command to run,
         // then execute the single command to run.
         if (!$this->stopOnFail || (count($this->exec) == 1)) {
-            $this->printTaskInfo('{command}', ['command' => $this->getCommand()]);
+            $this->printTaskNotice('{command}', ['command' => $this->getCommand()]);
             return $this->executeCommand($this->getCommand());
         }
 
@@ -119,7 +119,7 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
         $message = '';
         $result = null;
         foreach ($this->exec as $command) {
-            $this->printTaskInfo("Executing {command}", ['command' => $command]);
+            $this->printTaskNotice("Executing {command}", ['command' => $command]);
             $result = $this->executeCommand($command);
             $result->accumulateExecutionTime($data);
             $message = $result->accumulateMessage($message);

--- a/src/Task/Composer/Config.php
+++ b/src/Task/Composer/Config.php
@@ -87,7 +87,7 @@ class Config extends Base
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo('Configuring composer.json: {command}', ['command' => $command]);
+        $this->printTaskNotice('Configuring composer.json: {command}', ['command' => $command]);
         return $this->executeCommand($command);
     }
 }

--- a/src/Task/Composer/CreateProject.php
+++ b/src/Task/Composer/CreateProject.php
@@ -106,7 +106,7 @@ class CreateProject extends Base
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo('Creating project: {command}', ['command' => $command]);
+        $this->printTaskNotice('Creating project: {command}', ['command' => $command]);
         return $this->executeCommand($command);
     }
 }

--- a/src/Task/Composer/DumpAutoload.php
+++ b/src/Task/Composer/DumpAutoload.php
@@ -56,7 +56,7 @@ class DumpAutoload extends Base
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo('Dumping Autoloader: {command}', ['command' => $command]);
+        $this->printTaskNotice('Dumping Autoloader: {command}', ['command' => $command]);
         return $this->executeCommand($command);
     }
 }

--- a/src/Task/Composer/Init.php
+++ b/src/Task/Composer/Init.php
@@ -109,7 +109,7 @@ class Init extends Base
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo('Creating composer.json: {command}', ['command' => $command]);
+        $this->printTaskNotice('Creating composer.json: {command}', ['command' => $command]);
         return $this->executeCommand($command);
     }
 }

--- a/src/Task/Composer/Install.php
+++ b/src/Task/Composer/Install.php
@@ -34,7 +34,7 @@ class Install extends Base
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo('Installing Packages: {command}', ['command' => $command]);
+        $this->printTaskNotice('Installing Packages: {command}', ['command' => $command]);
         return $this->executeCommand($command);
     }
 }

--- a/src/Task/Composer/Remove.php
+++ b/src/Task/Composer/Remove.php
@@ -79,7 +79,7 @@ class Remove extends Base
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo('Removing packages: {command}', ['command' => $command]);
+        $this->printTaskNotice('Removing packages: {command}', ['command' => $command]);
         return $this->executeCommand($command);
     }
 }

--- a/src/Task/Composer/RequireDependency.php
+++ b/src/Task/Composer/RequireDependency.php
@@ -44,7 +44,7 @@ class RequireDependency extends Base
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo('Requiring packages: {command}', ['command' => $command]);
+        $this->printTaskNotice('Requiring packages: {command}', ['command' => $command]);
         return $this->executeCommand($command);
     }
 }

--- a/src/Task/Composer/Update.php
+++ b/src/Task/Composer/Update.php
@@ -34,7 +34,7 @@ class Update extends Base
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo('Updating Packages: {command}', ['command' => $command]);
+        $this->printTaskNotice('Updating Packages: {command}', ['command' => $command]);
         return $this->executeCommand($command);
     }
 }

--- a/src/Task/Composer/Validate.php
+++ b/src/Task/Composer/Validate.php
@@ -79,7 +79,7 @@ class Validate extends Base
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo('Validating composer.json: {command}', ['command' => $command]);
+        $this->printTaskNotice('Validating composer.json: {command}', ['command' => $command]);
         return $this->executeCommand($command);
     }
 }

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -158,7 +158,7 @@ class Changelog extends BaseTask implements BuilderAwareInterface
         $text = $ver . $text;
 
         if (!file_exists($this->filename)) {
-            $this->printTaskInfo('Creating {filename}', ['filename' => $this->filename]);
+            $this->printTaskNotice('Creating {filename}', ['filename' => $this->filename]);
             $res = file_put_contents($this->filename, $this->anchor);
             if ($res === false) {
                 return Result::error($this, "File {filename} cant be created", ['filename' => $this->filename]);

--- a/src/Task/Development/GenerateMarkdownDoc.php
+++ b/src/Task/Development/GenerateMarkdownDoc.php
@@ -439,12 +439,12 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     public function run()
     {
         foreach ($this->docClass as $class) {
-            $this->printTaskInfo("Processing {class}", ['class' => $class]);
+            $this->printTaskNotice("Processing {class}", ['class' => $class]);
             $this->textForClass[$class] = $this->documentClass($class);
         }
 
         if (is_callable($this->reorder)) {
-            $this->printTaskInfo("Applying reorder function");
+            $this->printTaskNotice("Applying reorder function");
             call_user_func_array($this->reorder, [$this->textForClass]);
         }
 

--- a/src/Task/Development/GitHub.php
+++ b/src/Task/Development/GitHub.php
@@ -108,8 +108,8 @@ abstract class GitHub extends BaseTask
 
         $ch = curl_init();
         $url = sprintf('%s/repos/%s/%s', self::GITHUB_URL, $this->getUri(), $uri);
-        $this->printTaskInfo($url);
-        $this->printTaskInfo('{method} {url}', ['method' => $method, 'url' => $url]);
+        $this->printTaskNotice($url);
+        $this->printTaskNotice('{method} {url}', ['method' => $method, 'url' => $url]);
 
         if (!empty($this->user)) {
             curl_setopt($ch, CURLOPT_USERPWD, $this->user . ':' . $this->password);
@@ -131,7 +131,7 @@ abstract class GitHub extends BaseTask
         $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $response = json_decode($output);
 
-        $this->printTaskInfo($output);
+        $this->printTaskNotice($output);
         return [$code, $response];
     }
 }

--- a/src/Task/Development/GitHubRelease.php
+++ b/src/Task/Development/GitHubRelease.php
@@ -183,7 +183,7 @@ class GitHubRelease extends GitHub
      */
     public function run()
     {
-        $this->printTaskInfo('Releasing {tag}', ['tag' => $this->tag]);
+        $this->printTaskNotice('Releasing {tag}', ['tag' => $this->tag]);
         $this->startTimer();
         list($code, $data) = $this->sendRequest(
             'releases',

--- a/src/Task/Development/OpenBrowser.php
+++ b/src/Task/Development/OpenBrowser.php
@@ -51,7 +51,7 @@ class OpenBrowser extends BaseTask
 
         foreach ($this->urls as $url) {
             passthru(sprintf($openCommand, ProcessUtils::escapeArgument($url)));
-            $this->printTaskInfo('Opened {url}', ['url' => $url]);
+            $this->printTaskNotice('Opened {url}', ['url' => $url]);
         }
 
         return Result::success($this);

--- a/src/Task/Development/PackPhar.php
+++ b/src/Task/Development/PackPhar.php
@@ -137,11 +137,11 @@ EOF;
      */
     public function run()
     {
-        $this->printTaskInfo('Creating {filename}', ['filename' => $this->filename]);
+        $this->printTaskNotice('Creating {filename}', ['filename' => $this->filename]);
         $this->phar->setSignatureAlgorithm(\Phar::SHA1);
         $this->phar->startBuffering();
 
-        $this->printTaskInfo('Packing {file-count} files into phar', ['file-count' => count($this->files)]);
+        $this->printTaskNotice('Packing {file-count} files into phar', ['file-count' => count($this->files)]);
 
         $this->startProgressIndicator();
         foreach ($this->files as $path => $content) {
@@ -153,9 +153,9 @@ EOF;
 
         if ($this->compress and in_array('GZ', \Phar::getSupportedCompression())) {
             if (count($this->files) > 1000) {
-                $this->printTaskInfo('Too many files. Compression DISABLED');
+                $this->printTaskNotice('Too many files. Compression DISABLED');
             } else {
-                $this->printTaskInfo('{filename} compressed', ['filename' => $this->filename]);
+                $this->printTaskNotice('{filename} compressed', ['filename' => $this->filename]);
                 $this->phar = $this->phar->compressFiles(\Phar::GZ);
             }
         }

--- a/src/Task/File/Concat.php
+++ b/src/Task/File/Concat.php
@@ -84,7 +84,7 @@ class Concat extends BaseTask
             }
         }
 
-        $this->printTaskInfo('Writing {destination}', ['destination' => $this->dst]);
+        $this->printTaskNotice('Writing {destination}', ['destination' => $this->dst]);
 
         $dst = $this->dst . '.part';
         $write_result = file_put_contents($dst, $dump);

--- a/src/Task/File/Replace.php
+++ b/src/Task/File/Replace.php
@@ -134,7 +134,7 @@ class Replace extends BaseTask
             }
             $this->printTaskSuccess("{filename} updated. {count} items replaced", ['filename' => $this->filename, 'count' => $count]);
         } else {
-            $this->printTaskInfo("{filename} unchanged. {count} items replaced", ['filename' => $this->filename, 'count' => $count]);
+            $this->printTaskNotice("{filename} unchanged. {count} items replaced", ['filename' => $this->filename, 'count' => $count]);
         }
         return Result::success($this, '', ['replaced' => $count]);
     }

--- a/src/Task/File/Write.php
+++ b/src/Task/File/Write.php
@@ -312,7 +312,7 @@ class Write extends BaseTask
      */
     public function run()
     {
-        $this->printTaskInfo("Writing to {filename}.", ['filename' => $this->filename]);
+        $this->printTaskNotice("Writing to {filename}.", ['filename' => $this->filename]);
         $contents = $this->getContentsToWrite();
         if (!file_exists(dirname($this->filename))) {
             mkdir(dirname($this->filename), 0777, true);

--- a/src/Task/Filesystem/CleanDir.php
+++ b/src/Task/Filesystem/CleanDir.php
@@ -29,7 +29,7 @@ class CleanDir extends BaseDir
         }
         foreach ($this->dirs as $dir) {
             $this->emptyDir($dir);
-            $this->printTaskInfo("Cleaned {dir}", ['dir' => $dir]);
+            $this->printTaskNotice("Cleaned {dir}", ['dir' => $dir]);
         }
         return Result::success($this);
     }

--- a/src/Task/Filesystem/CopyDir.php
+++ b/src/Task/Filesystem/CopyDir.php
@@ -56,7 +56,7 @@ class CopyDir extends BaseDir
         }
         foreach ($this->dirs as $src => $dst) {
             $this->copyDir($src, $dst);
-            $this->printTaskInfo('Copied from {source} to {destination}', ['source' => $src, 'destination' => $dst]);
+            $this->printTaskNotice('Copied from {source} to {destination}', ['source' => $src, 'destination' => $dst]);
         }
         return Result::success($this);
     }

--- a/src/Task/Filesystem/DeleteDir.php
+++ b/src/Task/Filesystem/DeleteDir.php
@@ -29,7 +29,7 @@ class DeleteDir extends BaseDir
         }
         foreach ($this->dirs as $dir) {
             $this->fs->remove($dir);
-            $this->printTaskInfo("Deleted {dir}...", ['dir' => $dir]);
+            $this->printTaskNotice("Deleted {dir}...", ['dir' => $dir]);
         }
         return Result::success($this);
     }

--- a/src/Task/Filesystem/FlattenDir.php
+++ b/src/Task/Filesystem/FlattenDir.php
@@ -246,7 +246,7 @@ class FlattenDir extends BaseDir
                 $files[$file->getRealpath()] = $this->getTarget($file->getRealPath(), $to);
             }
             $fileNoun = count($files) == 1 ? ' file' : ' files';
-            $this->printTaskInfo("Found {count} $fileNoun in {dir}", ['count' => count($files), 'dir' => $dir]);
+            $this->printTaskNotice("Found {count} $fileNoun in {dir}", ['count' => count($files), 'dir' => $dir]);
         }
 
         return $files;

--- a/src/Task/Filesystem/MirrorDir.php
+++ b/src/Task/Filesystem/MirrorDir.php
@@ -33,7 +33,7 @@ class MirrorDir extends BaseDir
                     'delete' => true
                 ]
             );
-            $this->printTaskInfo("Mirrored from {source} to {destination}", ['source' => $src, 'destination' => $dst]);
+            $this->printTaskNotice("Mirrored from {source} to {destination}", ['source' => $src, 'destination' => $dst]);
         }
         return Result::success($this);
     }

--- a/src/Task/Filesystem/TmpDir.php
+++ b/src/Task/Filesystem/TmpDir.php
@@ -121,7 +121,7 @@ class TmpDir extends BaseDir implements CompletionInterface
         $this->savedWorkingDirectory = getcwd();
         foreach ($this->dirs as $dir) {
             $this->fs->mkdir($dir);
-            $this->printTaskInfo("Created {dir}...", ['dir' => $dir]);
+            $this->printTaskNotice("Created {dir}...", ['dir' => $dir]);
 
             // Change the current working directory, if requested
             if ($this->cwd) {

--- a/src/Task/Gulp/Run.php
+++ b/src/Task/Gulp/Run.php
@@ -26,9 +26,9 @@ class Run extends Base implements CommandInterface
     public function run()
     {
         if (strlen($this->arguments)) {
-            $this->printTaskInfo('Running Gulp task: {gulp_task} with arguments: {arguments}', ['gulp_task' => $this->task, 'arguments' => $this->arguments]);
+            $this->printTaskNotice('Running Gulp task: {gulp_task} with arguments: {arguments}', ['gulp_task' => $this->task, 'arguments' => $this->arguments]);
         } else {
-            $this->printTaskInfo('Running Gulp task: {gulp_task} without arguments', ['gulp_task' => $this->task]);
+            $this->printTaskNotice('Running Gulp task: {gulp_task} without arguments', ['gulp_task' => $this->task]);
         }
         return $this->executeCommand($this->getCommand());
     }

--- a/src/Task/Npm/Install.php
+++ b/src/Task/Npm/Install.php
@@ -30,7 +30,7 @@ class Install extends Base implements CommandInterface
      */
     public function run()
     {
-        $this->printTaskInfo('Install Npm packages: {arguments}', ['arguments' => $this->arguments]);
+        $this->printTaskNotice('Install Npm packages: {arguments}', ['arguments' => $this->arguments]);
         return $this->executeCommand($this->getCommand());
     }
 }

--- a/src/Task/Npm/Update.php
+++ b/src/Task/Npm/Update.php
@@ -28,7 +28,7 @@ class Update extends Base
      */
     public function run()
     {
-        $this->printTaskInfo('Update Npm packages: {arguments}', ['arguments' => $this->arguments]);
+        $this->printTaskNotice('Update Npm packages: {arguments}', ['arguments' => $this->arguments]);
         return $this->executeCommand($this->getCommand());
     }
 }

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -426,7 +426,7 @@ class Rsync extends BaseTask implements CommandInterface
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo("Running {command}", ['command' => $command]);
+        $this->printTaskNotice("Running {command}", ['command' => $command]);
 
         return $this->executeCommand($command);
     }

--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -239,7 +239,7 @@ class Ssh extends BaseTask implements CommandInterface, SimulatedInterface
     public function simulate($context)
     {
         $command = $this->getCommand();
-        $this->printTaskInfo("Running {command}", ['command' => $command] + $context);
+        $this->printTaskNotice("Running {command}", ['command' => $command] + $context);
     }
 
     protected function validateParameters()

--- a/src/Task/Simulator.php
+++ b/src/Task/Simulator.php
@@ -73,7 +73,7 @@ class Simulator extends BaseTask implements CommandInterface
         );
 
         // RoboLogLevel::SIMULATED_ACTION
-        $this->printTaskInfo(
+        $this->printTaskNotice(
             "Simulating {simulated}({parameters})$callchain",
             $context
         );

--- a/src/Task/StackBasedTask.php
+++ b/src/Task/StackBasedTask.php
@@ -114,7 +114,7 @@ abstract class StackBasedTask extends BaseTask
      */
     protected function printTaskProgress($command, $action)
     {
-        $this->printTaskInfo('{command} {action}', ['command' => "{$command[1]}", 'action' => json_encode($action, JSON_UNESCAPED_SLASHES)]);
+        $this->printTaskNotice('{command} {action}', ['command' => "{$command[1]}", 'action' => json_encode($action, JSON_UNESCAPED_SLASHES)]);
     }
 
     /**

--- a/src/Task/Testing/Atoum.php
+++ b/src/Task/Testing/Atoum.php
@@ -177,7 +177,7 @@ class Atoum extends BaseTask implements CommandInterface, PrintedInterface
      */
     public function run()
     {
-        $this->printTaskInfo('Running atoum ' . $this->arguments);
+        $this->printTaskNotice('Running atoum ' . $this->arguments);
 
         return $this->executeCommand($this->getCommand());
     }

--- a/src/Task/Testing/Behat.php
+++ b/src/Task/Testing/Behat.php
@@ -157,7 +157,7 @@ class Behat extends BaseTask implements CommandInterface, PrintedInterface
      */
     public function run()
     {
-        $this->printTaskInfo('Running behat {arguments}', ['arguments' => $this->arguments]);
+        $this->printTaskNotice('Running behat {arguments}', ['arguments' => $this->arguments]);
         return $this->executeCommand($this->getCommand());
     }
 }

--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -246,7 +246,7 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo('Executing {command}', ['command' => $command]);
+        $this->printTaskNotice('Executing {command}', ['command' => $command]);
         return $this->executeCommand($command);
     }
 }

--- a/src/Task/Testing/PHPUnit.php
+++ b/src/Task/Testing/PHPUnit.php
@@ -193,7 +193,7 @@ class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
      */
     public function run()
     {
-        $this->printTaskInfo('Running PHPUnit {arguments}', ['arguments' => $this->arguments]);
+        $this->printTaskNotice('Running PHPUnit {arguments}', ['arguments' => $this->arguments]);
         return $this->executeCommand($this->getCommand());
     }
 }

--- a/src/Task/Testing/Phpspec.php
+++ b/src/Task/Testing/Phpspec.php
@@ -110,7 +110,7 @@ class Phpspec extends BaseTask implements CommandInterface, PrintedInterface
 
     public function run()
     {
-        $this->printTaskInfo('Running phpspec {arguments}', ['arguments' => $this->arguments]);
+        $this->printTaskNotice('Running phpspec {arguments}', ['arguments' => $this->arguments]);
         return $this->executeCommand($this->getCommand());
     }
 }

--- a/src/Task/Vcs/GitStack.php
+++ b/src/Task/Vcs/GitStack.php
@@ -151,7 +151,7 @@ class GitStack extends CommandStack
      */
     public function run()
     {
-        $this->printTaskInfo("Running git commands...");
+        $this->printTaskNotice("Running git commands...");
         return parent::run();
     }
 }

--- a/src/Task/Vcs/HgStack.php
+++ b/src/Task/Vcs/HgStack.php
@@ -147,7 +147,7 @@ class HgStack extends CommandStack
      */
     public function run()
     {
-        $this->printTaskInfo('Running hg commands...');
+        $this->printTaskNotice('Running hg commands...');
         return parent::run();
     }
 }


### PR DESCRIPTION
… to use it.

### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [x] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Addressing the following comment in the comment block from `printTaskInfo`:
```
* n.b. We should probably have printTaskNotice for our ordinary
* output, and use printTaskInfo for less interesting messages.
```

### Description
Introducing a `printTaskNotice` method that functions the way the `printTaskInfo` method always has. `printTaskInfo` is modified to only print when the verbosity level is verbose. All calls to `printTaskInfo` have been replaced with calls to `printTaskNotice` to make the switch seamless. This stemmed from a desire to print different levels of information when commands are output to the console. Chained commands currently look pretty messy, so my hope is to introduce an additional PR to clean up full command output (maybe by printing each individual command to a new line) and use `printTaskInfo` to print it. `printTaskNotice` can maybe print an abbreviated version or something else that is less verbose (suggestions/thoughts are more than welcome).
