### PR TITLE
Make implementation of task configuration keys consistent with docs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
   #Install PHP per https://blog.wyrihaximus.net/2016/11/running-php-unit-tests-on-windows-using-appveyor-and-chocolatey/
   - ps: appveyor-retry cinst --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $Env:php_ver_target | Select-Object -first 1) -replace '[php|]','')
-  - cd c:\tools\php
+  - cd c:\tools\php70
   - copy php.ini-production php.ini
 
   - echo extension_dir=ext >> php.ini
@@ -43,7 +43,7 @@ install:
   - echo extension=php_pdo_sqlite.dll >> php.ini
   - echo extension=php_pgsql.dll >> php.ini
   - echo extension=php_gd2.dll >> php.ini
-  - SET PATH=C:\tools\php;%PATH%
+  - SET PATH=C:\tools\php70;%PATH%
   #Install Composer
   - cd %APPVEYOR_BUILD_FOLDER%
   #- appveyor DownloadFile https://getcomposer.org/composer.phar

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -400,19 +400,22 @@ You could instead remove the setter methods and move the parameter values to a c
 $this->taskComposerInstall()
   ->run();
 ```
-The corresponding configuration file would appear as follows:
+Then, presuming that `taskMyOperation` was implemented in a class \MyOrg\Task\TaskGroup\MyOperation`, then the corresponding configuration file would appear as follows:
 ```
 task:
-  MyOperation:
-    settings:
-      dir: /my/path
-      extrapolated: false
+  TaskGroup:
+    MyOperation:
+      settings:
+        dir: /my/path
+        extrapolated: false
 ```
-The key for configuration-injected settings is `task.CLASSNAME.settings.key`.
+The key for configuration-injected settings is `task.PARTIAL_NAMESPACE.CLASSNAME.settings.key`. PARTIAL_NAMESPACE is the namespace for the class, with each `\` replaced with a `.`, and with each component of the namespace up to and including `Task` removed.
 
 ### Accessing Configuration Directly
 
-In a RoboFile, use `Robo::Config()->get('task.MyOperation.settings.dir');` to fetch the `dir` configuration option from the previous example.
+In a RoboFile, use `Robo::Config()->get('task.TaskGroup.MyOperation.settings.dir');` to fetch the `dir` configuration option from the previous example.
+
+In the implementation of `taskMyOperation()` itself, it is in general not necessary to access configuration values directly, as it is preferable to allow Robo to inject configuration as described above. However, if desired, configuration may be accessed from within the method of any task that extends `\Robo\Task\BaseTask` (or otherwise uses `ConfigAwareTrait`) may do so via `static::getConfigValue('key', 'default');`.
 
 ### Providing Default Configuration
 
@@ -426,7 +429,7 @@ class RoboFile
     }
 }
 ```
-If `task.Ssh.remoteDir` is set to some other value in the robo.yml configuration file in the current directory, then the value from the configuration file will take precedence.
+If `task.Remote.Ssh.remoteDir` is set to some other value in the robo.yml configuration file in the current directory, then the value from the configuration file will take precedence.
 
 ### Loading Configuration From Another Source
 

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -481,7 +481,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
      */
     protected function configureTask($taskClass, $task)
     {
-        $taskClass = $this->classNameWithoutNamespace($taskClass);
+        $taskClass = static::configClassIdentifier($taskClass);
         $configurationKey = "task.{$taskClass}.settings";
         $this->getConfig()->applyConfiguration($task, $configurationKey);
 
@@ -492,20 +492,6 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         // TODO: If the builder knew what the current command name was,
         // then we could also search for task configuration under
         // command-specific keys such as "command.{$commandname}.task.{$taskClass}.settings".
-    }
-
-    /**
-     * Strip the namespace off of the fully-qualified classname
-     * @param string $classname
-     * @return string
-     */
-    protected function classNameWithoutNamespace($classname)
-    {
-        $pos = strrpos($classname, '\\');
-        if ($pos === false) {
-            return $classname;
-        }
-        return substr($classname, $pos + 1);
     }
 
     /**

--- a/src/Common/ConfigAwareTrait.php
+++ b/src/Common/ConfigAwareTrait.php
@@ -43,13 +43,25 @@ trait ConfigAwareTrait
     /**
      * Any class that uses ConfigAwareTrait SHOULD override this method
      * , and define a prefix for its configuration items. This is usually
-     * done in a base class; see BaseTask::configPrefix(). It is not
-     * necessary to override this method for classes that have no configuration
-     * items of their own.
+     * done in a base class. When used, this method should return a string
+     * that ends with a "."; see BaseTask::configPrefix().
      *
      * @return string
      */
     protected static function configPrefix()
+    {
+        return '';
+    }
+
+    protected static function configClassIdentifier($classname)
+    {
+        $configIdentifier = strtr($classname, '\\', '.');
+        $configIdentifier = preg_replace('#^(.*\.Task\.|\.)#', '', $configIdentifier);
+
+        return $configIdentifier;
+    }
+
+    protected static function configPostfix()
     {
         return '';
     }
@@ -61,7 +73,11 @@ trait ConfigAwareTrait
      */
     private static function getClassKey($key)
     {
-        return sprintf('%s%s.%s', static::configPrefix(), get_called_class(), $key);
+        $configPrefix = static::configPrefix();                            // task.
+        $configClass = static::configClassIdentifier(get_called_class());  // PARTIAL_NAMESPACE.CLASSNAME
+        $configPostFix = static::configPostfix();                          // .settings
+
+        return sprintf('%s%s%s.%s', $configPrefix, $configClass, $configPostFix, $key);
     }
 
     /**

--- a/src/Task/BaseTask.php
+++ b/src/Task/BaseTask.php
@@ -22,11 +22,21 @@ abstract class BaseTask implements TaskInterface, LoggerAwareInterface, Verbosit
     /**
      * ConfigAwareInterface uses this to decide where configuration
      * items come from. Default is this prefix + class name + key,
-     * e.g. `task.Ssh.remoteDir`.
+     * e.g. `task.Remote.Ssh.remoteDir`.
      */
     protected static function configPrefix()
     {
         return 'task.';
+    }
+
+    /**
+     * ConfigAwareInterface uses this to decide where configuration
+     * items come from. Default is this prefix + class name + key,
+     * e.g. `task.Ssh.remoteDir`.
+     */
+    protected static function configPostfix()
+    {
+        return '.settings';
     }
 
     /**

--- a/tests/_data/robo.yml
+++ b/tests/_data/robo.yml
@@ -5,6 +5,7 @@ command:
         a: '12'
         b: '13'
 task:
-  Exec:
-    settings:
-      dir: /some/dir
+  Base:
+    Exec:
+      settings:
+        dir: /some/dir

--- a/tests/unit/ConfigurationInjectionTest.php
+++ b/tests/unit/ConfigurationInjectionTest.php
@@ -130,7 +130,7 @@ class ConfigurationInjectionTest extends \Codeception\TestCase\Test
         $argv = ['placeholder', 'test:exec', '--simulate'];
         $result = $this->runner->execute($argv, null, null, $this->guy->capturedOutputStream());
 
-        // `task.Exec.settings.dir` is defined in loaded robo.yml configuration file.
+        // `task.Base.Exec.settings.dir` is defined in loaded robo.yml configuration file.
         $this->guy->seeInOutput("->dir('/some/dir')");
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [X] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
The documentation on `Robo\Task\Remote\Ssh::configure` was inconsistent with the implementation, which did not match up with how the container builder was injecting task configuration. 

### Description
This breaks b/c, but only for the config system, which is still experimental (b/c breaking changes may happen until 1.1.0).