### PR TITLE
Add configuration fallback feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 1.0.9 tbd
+
+* Configuration for multiple commands or multiple tasks may now be shared by attaching the configuration values to the task namespace or the command group. #597
+* *Breaking* Task configuration taken from property `task.PARTIAL_NAMESPACE.CLASSNAME.settings` instead of `task.CLASSNAME.settings`. Breaks backwards compatibility only with experimental configuration features introduced in version 1.0.6. Config will be stable in 1.1.0. #596
+
 ### 1.0.8 06/02/2017
 
 * Fix regression in 1.0.7: Allow tasks to return results of types other than \Robo\Result. #585

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -386,6 +386,18 @@ command:
 
 If you run this command, then it will print `Hello, world`. If the `--who` option is provided on the command line, that value will take precidence over the value stored in configuration. Thus, `hello --who=everyone` will print `Hello, everyone`.
 
+Command groups may also share configuration options. For example, if you have commands `foo:bar`, `foo:baz` and `foo:boz`, all of which share a common option `color`, then the following configuration will provide the value `blue` to `foo:bar` and `foo:baz`, and the value `green` to `foo:boz`:
+
+```
+command:
+  foo:
+    options:
+      color: blue
+    boz:
+      options:
+        color: green
+```
+
 ### Configuration for Task Settings
 
 Robo will automatically configure tasks with values from configuration. For example, given the following task definition:
@@ -400,7 +412,7 @@ You could instead remove the setter methods and move the parameter values to a c
 $this->taskComposerInstall()
   ->run();
 ```
-Then, presuming that `taskMyOperation` was implemented in a class \MyOrg\Task\TaskGroup\MyOperation`, then the corresponding configuration file would appear as follows:
+Then, presuming that `taskMyOperation` was implemented in a class `\MyOrg\Task\TaskGroup\MyOperation`, then the corresponding configuration file would appear as follows:
 ```
 task:
   TaskGroup:
@@ -411,13 +423,22 @@ task:
 ```
 The key for configuration-injected settings is `task.PARTIAL_NAMESPACE.CLASSNAME.settings.key`. PARTIAL_NAMESPACE is the namespace for the class, with each `\` replaced with a `.`, and with each component of the namespace up to and including `Task` removed.
 
+Tasks in the same namespace may also share configuration-injected settings. For example, the configuration below will set the `dir` option of any task implemented by a class in the `*\TaskGroup\MyOperation` namespace, unless the task has a more specific configuration value stored with its classname:
+```
+task:
+  TaskGroup:
+    settings:
+      dir: /my/path
+      extrapolated: false
+```
+
 ### Accessing Configuration Directly
 
 In a RoboFile, use `Robo::Config()->get('task.TaskGroup.MyOperation.settings.dir');` to fetch the `dir` configuration option from the previous example.
 
 In the implementation of `taskMyOperation()` itself, it is in general not necessary to access configuration values directly, as it is preferable to allow Robo to inject configuration as described above. However, if desired, configuration may be accessed from within the method of any task that extends `\Robo\Task\BaseTask` (or otherwise uses `ConfigAwareTrait`) may do so via `static::getConfigValue('key', 'default');`.
 
-### Providing Default Configuration
+### Providing Default Configuration in Code
 
 RoboFiles that wish to provide default configuration values that can be overridden via robo.yml values or commandline options may do so in the class' constructor method.  The example below demonstrates how to set up a default value for the `task.Ssh.remoteDir` configuration property in code:
 ```

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -482,8 +482,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     protected function configureTask($taskClass, $task)
     {
         $taskClass = static::configClassIdentifier($taskClass);
-        $configurationKey = "task.{$taskClass}.settings";
-        $this->getConfig()->applyConfiguration($task, $configurationKey);
+        $this->getConfig()->applyConfiguration($task, 'settings', $taskClass, 'task.');
 
         // TODO: If we counted each instance of $taskClass that was called from
         // this builder, then we could also apply configuration from

--- a/src/InjectConfigEventListener.php
+++ b/src/InjectConfigEventListener.php
@@ -29,7 +29,6 @@ class InjectConfigEventListener implements EventSubscriberInterface, ConfigAware
     public function injectConfiguration(ConsoleCommandEvent $event)
     {
         $config = $this->getConfig();
-
         $command = $event->getCommand();
         $commandName = $command->getName();
         $commandName = str_replace(':', '.', $commandName);
@@ -37,9 +36,9 @@ class InjectConfigEventListener implements EventSubscriberInterface, ConfigAware
         $options = $definition->getOptions();
         foreach ($options as $option => $inputOption) {
             $key = str_replace('.', '-', $option);
-            $configKey = "command.{$commandName}.options.{$key}";
-            if ($config->has($configKey)) {
-                $inputOption->setDefault($config->get($configKey));
+            $value = $config->getWithFallback($key, $commandName, 'command.', '.options.');
+            if ($value !== null) {
+                $inputOption->setDefault($value);
             }
         }
     }

--- a/tests/_data/falback-task-config-robo.yml
+++ b/tests/_data/falback-task-config-robo.yml
@@ -1,0 +1,4 @@
+task:
+  Base:
+    settings:
+      dir: /some/other/dir

--- a/tests/unit/ConfigurationInjectionTest.php
+++ b/tests/unit/ConfigurationInjectionTest.php
@@ -65,6 +65,18 @@ class ConfigurationInjectionTest extends \Codeception\TestCase\Test
         $this->guy->seeInOutput("b: '6'");
     }
 
+    public function testWithConfigurationFallbacks()
+    {
+        \Robo\Robo::config()->set('command.test.simple-list.options.a', '4');
+        \Robo\Robo::config()->set('command.test.options.b', '7');
+
+        $argv = ['placeholder', 'test:simple-list'];
+        $result = $this->runner->execute($argv, null, null, $this->guy->capturedOutputStream());
+
+        $this->guy->seeInOutput("a: '4'");
+        $this->guy->seeInOutput("b: '7'");
+    }
+
     public function testSettingConfigurationFromCommandOptions()
     {
         $argv = ['placeholder', 'test:simple-list', '-D', 'config.key=value'];
@@ -132,5 +144,19 @@ class ConfigurationInjectionTest extends \Codeception\TestCase\Test
 
         // `task.Base.Exec.settings.dir` is defined in loaded robo.yml configuration file.
         $this->guy->seeInOutput("->dir('/some/dir')");
+    }
+
+    public function testCommandWithFallbackTaskConfiguration()
+    {
+        $loader = new YamlConfigLoader();
+        $loader->load(dirname(__DIR__) . '/_data/falback-task-config-robo.yml');
+
+        \Robo\Robo::config()->import($loader->export());
+
+        $argv = ['placeholder', 'test:exec', '--simulate'];
+        $result = $this->runner->execute($argv, null, null, $this->guy->capturedOutputStream());
+
+        // `task.Base.settings.dir` is defined in loaded robo.yml configuration file.
+        $this->guy->seeInOutput("->dir('/some/other/dir')");
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Adds 'configuration fallback' feature that allows commands and tasks to share configuration.

### Description
Example from documentation:

Command groups may also share configuration options. For example, if you have commands `foo:bar`, `foo:baz` and `foo:boz`, all of which share a common option `color`, then the following configuration will provide the value `blue` to `foo:bar` and `foo:baz`, and the value `green` to `foo:boz`:

```
command:
  foo:
    options:
      color: blue
    boz:
      options:
        color: green
```
