### PR TITLE
Add an option to wait an interval of time between parallel processes

### DIFF
--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -41,6 +41,11 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
     protected $idleTimeout = null;
 
     /**
+     * @var null|int
+     */
+    protected $waitInterval = null;
+
+    /**
      * @var bool
      */
     protected $isPrinted = false;
@@ -102,6 +107,20 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
     }
 
     /**
+     * Parallel processing will wait `$waitInterval` seconds after launching each process and before
+     * the next one.
+     *
+     * @param int $waitInterval
+     *
+     * @return $this
+     */
+    public function waitInterval($waitInterval)
+    {
+        $this->waitInterval = $waitInterval;
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getCommand()
@@ -127,6 +146,9 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
             $process->setTimeout($this->timeout);
             $process->start();
             $this->printTaskInfo($process->getCommandLine());
+            if ($this->waitInterval) {
+                sleep($this->waitInterval);
+            }
         }
 
         $this->startProgressIndicator();

--- a/tests/unit/Task/ParallelExecTest.php
+++ b/tests/unit/Task/ParallelExecTest.php
@@ -39,4 +39,20 @@ class ParallelExecTest extends \Codeception\TestCase\Test
         verify($result->getExitCode())->equals(0);
         $this->guy->seeInOutput("3 processes finished");
     }
+
+    public function testParallelExecWithWaitInterval()
+    {
+        $task = new \Robo\Task\Base\ParallelExec();
+        $task->setLogger($this->guy->logger());
+
+        $result = $task
+            ->process('ls 1')
+            ->process('ls 2')
+            ->process('ls 3')
+            ->waitInterval(1)
+            ->run();
+        $this->process->verifyInvokedMultipleTimes('start', 3);
+        verify($result->getExitCode())->equals(0);
+        $this->guy->seeInOutput("3 processes finished");
+    }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Add an option to parallelExec to wait for a period of time (in seconds) after starting one process and before the next one.

### Description
An example usage would be:
```
$this->taskParallelExec()
    ->process($this->taskCodecept(...))
    ->process($this->taskCodecept(...))
    ->waitInterval(5)
    ->run();
```