### PR TITLE
Fixes #502: Do not print dire messages about Robo bootstrap problems …

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -34,6 +34,11 @@ class Runner implements ContainerAwareInterface
     protected $dir;
 
     /**
+     * @var string[]
+     */
+    protected $errorConditions = [];
+
+    /**
      * Class Constructor
      *
      * @param null|string $roboClass
@@ -45,6 +50,11 @@ class Runner implements ContainerAwareInterface
         $this->roboClass = $roboClass ? $roboClass : self::ROBOCLASS ;
         $this->roboFile  = $roboFile ? $roboFile : self::ROBOFILE;
         $this->dir = getcwd();
+    }
+
+    protected function errorCondtion($msg, $errorType)
+    {
+        $this->errorConditions[$msg] = $errorType;
     }
 
     /**
@@ -67,7 +77,7 @@ class Runner implements ContainerAwareInterface
             return true;
         }
         if (!file_exists($this->dir)) {
-            $output->writeln("<error>Path `{$this->dir}` is invalid; please provide a valid absolute path to the Robofile to load.</error>");
+            $this->errorCondtion("Path `{$this->dir}` is invalid; please provide a valid absolute path to the Robofile to load.", 'red');
             return false;
         }
 
@@ -76,13 +86,14 @@ class Runner implements ContainerAwareInterface
         $roboFilePath = $realDir . DIRECTORY_SEPARATOR . $this->roboFile;
         if (!file_exists($roboFilePath)) {
             $requestedRoboFilePath = $this->dir . DIRECTORY_SEPARATOR . $this->roboFile;
-            $output->writeln("<error>Requested RoboFile `$requestedRoboFilePath` is invalid, please provide valid absolute path to load Robofile</error>");
+            $this->errorCondtion("Requested RoboFile `$requestedRoboFilePath` is invalid, please provide valid absolute path to load Robofile.", 'red');
             return false;
         }
         require_once $roboFilePath;
 
         if (!class_exists($this->roboClass)) {
             $output->writeln("<error>Class ".$this->roboClass." was not loaded</error>");
+            $this->errorCondtion("Class {$this->roboClass} was not loaded.", 'red');
             return false;
         }
         return true;
@@ -145,7 +156,7 @@ class Runner implements ContainerAwareInterface
             $app = Robo::application();
         }
         if (!isset($commandFiles)) {
-            $this->yell("Robo is not initialized here. Please run `robo init` to create a new RoboFile", 40, 'yellow');
+            $this->errorCondtion("Robo is not initialized here. Please run `robo init` to create a new RoboFile.", 'yellow');
             $app->addInitRoboFileCommand($this->roboFile, $this->roboClass);
             $commandFiles = [];
         }
@@ -155,6 +166,15 @@ class Runner implements ContainerAwareInterface
             $statusCode = $app->run($input, $output);
         } catch (TaskExitException $e) {
             $statusCode = $e->getCode() ?: 1;
+        }
+
+        // If there were any error conditions in bootstrapping Robo,
+        // print them only if the requested command did not complete
+        // successfully.
+        if ($statusCode) {
+            foreach ($this->errorConditions as $msg => $color) {
+                $this->yell($msg, 40, $color);
+            }
         }
         return $statusCode;
     }

--- a/tests/unit/RunnerTest.php
+++ b/tests/unit/RunnerTest.php
@@ -161,7 +161,7 @@ EOT;
     {
         $runnerWithNoRoboFile = new \Robo\Runner();
 
-        $argv = ['placeholder', 'list', '-f', 'no-such-directory'];
+        $argv = ['placeholder', 'no-such-command', '-f', 'no-such-directory'];
         $result = $runnerWithNoRoboFile->execute($argv, null, null, $this->guy->capturedOutputStream());
 
         $this->guy->seeInOutput('Path `no-such-directory` is invalid; please provide a valid absolute path to the Robofile to load.');


### PR DESCRIPTION
…when a valid command (e.g. help, list, init, --version) runs.

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Previously, if a user ran `robo init`, Robo would still print some scary warning messages about errors that happened during the bootstrap. These errors are not relevant if the user has run a valid command, so we will only print them if there is an error running the command the user selected.
