### PR TITLE
Add noRebuild() method for Codeception run command

### DIFF
--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -233,6 +233,15 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
     }
 
     /**
+     * @return $this
+     */
+    public function noRebuild()
+    {
+        $this->option("no-rebuild");
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getCommand()

--- a/tests/unit/Task/CodeceptionTest.php
+++ b/tests/unit/Task/CodeceptionTest.php
@@ -49,14 +49,16 @@ class CodeceptionTest extends \Codeception\TestCase\Test
             ->configFile('~/Codeception')
             ->xml('result.xml')
             ->html()
+            ->noRebuild()
             ->getCommand()
-        )->equals('codecept run tests/unit/Codeception -c ~/Codeception --xml result.xml --html');
+        )->equals('codecept run tests/unit/Codeception -c ~/Codeception --xml result.xml --html --no-rebuild');
 
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->debug()->getCommand())->contains(' --debug');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->silent()->getCommand())->contains(' --silent');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->excludeGroup('g')->getCommand())->contains(' --skip-group g');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->tap()->getCommand())->contains('--tap');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->json()->getCommand())->contains('--json');
+        verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->noRebuild()->getCommand())->contains('--no-rebuild');
     }
 
 }


### PR DESCRIPTION
### Overview
This pull request:

- [+] Fixes a bug
- [+] Adds a feature
- [-] Breaks backwards compatibility
- [+] Has tests that cover changes

### Summary
This feature is critical for parallel running. Without this, codeception
rebuilds some generated files in each sub-process. This affects to
concurrent writing to the same files the same content. Run fails.

### Description
To this topic there are several bugs in neighbor repos:
First mention at https://github.com/Codeception/Codeception/issues/2054
Then comes here https://github.com/Codeception/robo-paracept/issues/28
And here https://github.com/Codeception/Codeception/pull/4148 but this is not a fix for the problem, just workaround.

My solution adds codeception functionality to Codeception task at Robo project. Using it, we will stop getting errors.

But you should remember, that using flag `--no-rebuild` you should build run `codecept build` manual.
