### PR TITLE
Remove superfluous printTaskInfo() call

### DIFF
--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -426,7 +426,6 @@ class Rsync extends BaseTask implements CommandInterface
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo("Running {command}", ['command' => $command]);
 
         return $this->executeCommand($command);
     }


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
 
Removes the explicit call to printTaskInfo() inside Docker tasks since it effectively duplicates a similar call made implicitly by ExecTrait.

### Description
Similar to #576 and #577
