### PR TITLE
Fixes #611: Issue-611: Fix robo.yml loader by exporting processor instead of loader

### DIFF
--- a/src/Robo.php
+++ b/src/Robo.php
@@ -113,7 +113,7 @@ class Robo
         foreach ($paths as $path) {
             $processor->extend($loader->load($path));
         }
-        $config->import($loader->export());
+        $config->import($processor->export());
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug (#611)
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Changed variable being used to export config

### Description
The `$loader` variable only contains the last `yml` configuration file loaded, while the `$processor` variable contains them all. By changing `$loader->export()` to `$processor->export()` all of the loaded configuration files are loaded into the configuration object instead of just the last one.
