### PR TITLE
Add failGroup() method for Codeception run command

### DIFF
--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -247,7 +247,7 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
      */
     public function failGroup($failGroup)
     {
-        $this->option("fail-group", $failGroup);
+        $this->option('override', "settings: fail-group: {$failGroup}");
         return $this;
     }
 

--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -242,6 +242,16 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
     }
 
     /**
+     * @param string $failGroup
+     * @return $this
+     */
+    public function failGroup($failGroup)
+    {
+        $this->option("fail-group", $failGroup);
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getCommand()

--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -247,7 +247,7 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
      */
     public function failGroup($failGroup)
     {
-        $this->option('override', "settings: fail-group: {$failGroup}");
+        $this->option('override', "extensions: config: Codeception\\Extension\\RunFailed: fail-group: {$failGroup}");
         return $this;
     }
 

--- a/tests/unit/Task/CodeceptionTest.php
+++ b/tests/unit/Task/CodeceptionTest.php
@@ -50,8 +50,9 @@ class CodeceptionTest extends \Codeception\TestCase\Test
             ->xml('result.xml')
             ->html()
             ->noRebuild()
+            ->failGroup('failed1')
             ->getCommand()
-        )->equals('codecept run tests/unit/Codeception -c ~/Codeception --xml result.xml --html --no-rebuild');
+        )->equals('codecept run tests/unit/Codeception -c ~/Codeception --xml result.xml --html --no-rebuild --fail-group failed1');
 
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->debug()->getCommand())->contains(' --debug');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->silent()->getCommand())->contains(' --silent');
@@ -59,6 +60,7 @@ class CodeceptionTest extends \Codeception\TestCase\Test
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->tap()->getCommand())->contains('--tap');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->json()->getCommand())->contains('--json');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->noRebuild()->getCommand())->contains('--no-rebuild');
+        verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->failGroup('failed2')->getCommand())->contains('--fail-group failed2');
     }
 
 }

--- a/tests/unit/Task/CodeceptionTest.php
+++ b/tests/unit/Task/CodeceptionTest.php
@@ -53,7 +53,7 @@ class CodeceptionTest extends \Codeception\TestCase\Test
             ->noRebuild()
             ->failGroup($failGroupName)
             ->getCommand()
-        )->equals("codecept run tests/unit/Codeception -c ~/Codeception --xml result.xml --html --no-rebuild --override 'extensions: config: Codeception\\Extension\\RunFailed: fail-group: {$failGroupName}'");
+        )->regExp("|^codecept run tests/unit/Codeception -c ~/Codeception --xml result\\.xml --html --no-rebuild --override ['\"]extensions: config: Codeception\\\\Extension\\\\RunFailed: fail-group: {$failGroupName}['\"]$|");
 
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->debug()->getCommand())->contains(' --debug');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->silent()->getCommand())->contains(' --silent');
@@ -63,7 +63,7 @@ class CodeceptionTest extends \Codeception\TestCase\Test
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->noRebuild()->getCommand())->contains('--no-rebuild');
         $failGroupName = 'failed2';
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->failGroup($failGroupName)->getCommand())
-            ->contains("--override 'extensions: config: Codeception\\Extension\\RunFailed: fail-group: {$failGroupName}'");
+            ->regExp("|--override ['\"]extensions: config: Codeception\\\\Extension\\\\RunFailed: fail-group: {$failGroupName}['\"]|");
     }
 
 }

--- a/tests/unit/Task/CodeceptionTest.php
+++ b/tests/unit/Task/CodeceptionTest.php
@@ -53,7 +53,7 @@ class CodeceptionTest extends \Codeception\TestCase\Test
             ->noRebuild()
             ->failGroup($failGroupName)
             ->getCommand()
-        )->equals("codecept run tests/unit/Codeception -c ~/Codeception --xml result.xml --html --no-rebuild --override 'settings: fail-group: {$failGroupName}'");
+        )->equals("codecept run tests/unit/Codeception -c ~/Codeception --xml result.xml --html --no-rebuild --override 'extensions: config: Codeception\\Extension\\RunFailed: fail-group: {$failGroupName}'");
 
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->debug()->getCommand())->contains(' --debug');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->silent()->getCommand())->contains(' --silent');
@@ -62,7 +62,8 @@ class CodeceptionTest extends \Codeception\TestCase\Test
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->json()->getCommand())->contains('--json');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->noRebuild()->getCommand())->contains('--no-rebuild');
         $failGroupName = 'failed2';
-        verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->failGroup($failGroupName)->getCommand())->contains("--override 'settings: fail-group: {$failGroupName}'");
+        verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->failGroup($failGroupName)->getCommand())
+            ->contains("--override 'extensions: config: Codeception\\Extension\\RunFailed: fail-group: {$failGroupName}'");
     }
 
 }

--- a/tests/unit/Task/CodeceptionTest.php
+++ b/tests/unit/Task/CodeceptionTest.php
@@ -44,15 +44,16 @@ class CodeceptionTest extends \Codeception\TestCase\Test
             ->getCommand()
         )->equals('codecept run unit Codeception/Command --group core --env process1 --coverage');
 
+        $failGroupName = 'failed1';
         verify((new \Robo\Task\Testing\Codecept('codecept'))
             ->test('tests/unit/Codeception')
             ->configFile('~/Codeception')
             ->xml('result.xml')
             ->html()
             ->noRebuild()
-            ->failGroup('failed1')
+            ->failGroup($failGroupName)
             ->getCommand()
-        )->equals('codecept run tests/unit/Codeception -c ~/Codeception --xml result.xml --html --no-rebuild --fail-group failed1');
+        )->equals("codecept run tests/unit/Codeception -c ~/Codeception --xml result.xml --html --no-rebuild --override 'settings: fail-group: {$failGroupName}'");
 
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->debug()->getCommand())->contains(' --debug');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->silent()->getCommand())->contains(' --silent');
@@ -60,7 +61,8 @@ class CodeceptionTest extends \Codeception\TestCase\Test
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->tap()->getCommand())->contains('--tap');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->json()->getCommand())->contains('--json');
         verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->noRebuild()->getCommand())->contains('--no-rebuild');
-        verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->failGroup('failed2')->getCommand())->contains('--fail-group failed2');
+        $failGroupName = 'failed2';
+        verify((new \Robo\Task\Testing\Codecept('codecept.phar'))->failGroup($failGroupName)->getCommand())->contains("--override 'settings: fail-group: {$failGroupName}'");
     }
 
 }


### PR DESCRIPTION
### Overview
This pull request:

- [-] Fixes a bug
- [+] Adds a feature
- [-] Breaks backwards compatibility
- [+] Has tests that cover changes

### Summary
Add failGroup() method for Codeception run command

### Description
This feature is major for parallel running. Without this, codeception
puts failed tasks to the same file, each thread rewrites file. With
this config we can send fails to different files and aggregate them
later manually.
