### PR TITLE
Add overwrite argument to Filesystem\loadShortcuts.php::_rename

### DIFF
--- a/src/Task/Filesystem/loadShortcuts.php
+++ b/src/Task/Filesystem/loadShortcuts.php
@@ -48,12 +48,13 @@ trait loadShortcuts
     /**
      * @param string $from
      * @param string $to
+     * @param bool $overwrite
      *
      * @return \Robo\Result
      */
-    protected function _rename($from, $to)
+    protected function _rename($from, $to, $overwrite = false)
     {
-        return $this->taskFilesystemStack()->rename($from, $to)->run();
+        return $this->taskFilesystemStack()->rename($from, $to, $overwrite)->run();
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
I've noticed when using _rename shortcut from FS tasks, the overwrite parameter is silently ignored, even thought it's present in the task itself. Adding it as it doesn't break backwards compatibility and is potentially useful to shortcut users.
