### PR TITLE
Fix Robo\Task\Docker\Base to implement CommandInterface

### DIFF
--- a/src/Task/Docker/Base.php
+++ b/src/Task/Docker/Base.php
@@ -2,10 +2,11 @@
 namespace Robo\Task\Docker;
 
 use Robo\Common\ExecOneCommand;
+use Robo\Contract\CommandInterface;
 use Robo\Contract\PrintedInterface;
 use Robo\Task\BaseTask;
 
-abstract class Base extends BaseTask implements PrintedInterface
+abstract class Base extends BaseTask implements CommandInterface, PrintedInterface
 {
     use ExecOneCommand;
 


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Fix Robo\Task\Docker\Base to implement CommandInterface as it is already an implementation of the above. With the fix you can use Docker commands in SshExec tasks and other tasks expecting a CommandInterface or a string command let's say if you plan to proxy a docker command execution to a remote machine