### PR TITLE
Remove unnecessary string formatting for sshCommand

### DIFF
--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -268,6 +268,6 @@ class Ssh extends BaseTask implements CommandInterface, SimulatedInterface
             $hostSpec = $this->user . '@' . $hostSpec;
         }
 
-        return sprintf("ssh{$sshOptions} {$hostSpec} '{$command}'");
+        return "ssh{$sshOptions} {$hostSpec} '{$command}'";
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [x] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
SshCommand is using sprintf to return a formatted command, but it's not actually sing any variables and basically just relies on inline variable interpolation. I think it is redundant and it's creating some other issues with string formatting, as now you have to escape your % characters in your options.

### Description
Please see the following usage scenario:
```
$this->taskSshExec('company.com', 'user')
  ->option('-o', 'ProxyCommand ssh -A -q user@bastion.company.com nc %h %p');
```
If you use sprintf, you will have to escape all % chars with another %. But since sprintf is not doing any formatting now, I propose to replace it with string interpolation.


**Possible breaking change:**
This may be a breaking change for someone who already relied on sshCommand and was already escaping the '%' character, they may end up with `%%` in their custom code
