### PR TITLE
Adding display formatting to ExecStack commands.

### DIFF
--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -2,9 +2,7 @@
 
 namespace Robo\Common;
 
-use function explode;
 use Robo\ResultData;
-use function str_replace;
 use Symfony\Component\Process\Process;
 
 /**

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -2,7 +2,9 @@
 
 namespace Robo\Common;
 
+use function explode;
 use Robo\ResultData;
+use function str_replace;
 use Symfony\Component\Process\Process;
 
 /**
@@ -368,11 +370,26 @@ trait ExecTrait
     protected function printAction($context = [])
     {
         $command = $this->getCommandDescription();
+        $formatted_command = $this->formatCommandDisplay($command);
+
         $dir = $this->workingDirectory ? " in {dir}" : "";
         $this->printTaskInfo("Running {command}$dir", [
-                'command' => $command,
+                'command' => $formatted_command,
                 'dir' => $this->workingDirectory
             ] + $context);
+    }
+
+    /**
+     * @param $command
+     *
+     * @return mixed
+     */
+    protected function formatCommandDisplay($command)
+    {
+        $formatted_command = str_replace("&&", "&&\n", $command);
+        $formatted_command = str_replace("||", "||\n", $formatted_command);
+
+        return $formatted_command;
     }
 
     /**


### PR DESCRIPTION
Using `tastExecStack()` to execute multiple commands creates output like:
```
 [ExecStack] Running /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt ci:travis:init -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt ci:pipelines:init -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt acsf:init:hooks -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt setup:cloud-hooks -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt config:dump && /Users/matthew.grasmick/Sites/acquia/blt/vendor/bin/robo sniff-code --load-from /Users/matthew.grasmick/Sites/acquia/blt && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt vm --no-interaction --yes -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt validate -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/yaml-cli update:value blt/project.yml cm.strategy none && /Users/matthew.grasmick/Sites/acquia/blt/scripts/blt/ci/tick-tock.sh /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt setup --define environment=local -vvv && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt tests --define environment=local -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt tests:behat:definitions -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/drush @blted8.local config-export --root=/Users/matthew.grasmick/Sites/acquia/blt/../blted8/docroot --yes && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/yaml-cli update:value blt/project.yml cm.strategy core-only && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt setup:config-import -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/yaml-cli update:value blt/project.yml cm.strategy features && rm -rf /Users/matthew.grasmick/Sites/acquia/blt/../blted8/config/default/* && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/drush @blted8.local en features --root=/Users/matthew.grasmick/Sites/acquia/blt/../blted8/docroot --yes && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt setup:config-import -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/drush @blted8.local pm-uninstall features --root=/Users/matthew.grasmick/Sites/acquia/blt/../blted8/docroot --yes && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/yaml-cli update:value blt/project.yml cm.strategy config-split && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/drush @blted8.local en config-split --root=/Users/matthew.grasmick/Sites/acquia/blt/../blted8/docroot --yes && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/drush @blted8.local config-export --root=/Users/matthew.grasmick/Sites/acquia/blt/../blted8/docroot --yes && mv /Users/matthew.grasmick/Sites/acquia/blt/scripts/blt/ci/internal/config_split.config_split.ci.yml /Users/matthew.grasmick/Sites/acquia/blt/config/default/ && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt setup:config-import -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/drush @blted8.local pm-uninstall config-split --root=/Users/matthew.grasmick/Sites/acquia/blt/../blted8/docroot --yes && rm -rf /Users/matthew.grasmick/Sites/acquia/blt/../blted8/config/default/* && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt deploy:update -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt simplesamlphp:init -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt custom:hello -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/phpunit /Users/matthew.grasmick/Sites/acquia/blt/tests/phpunit --group blt --exclude-group deploy -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/phpunit /Users/matthew.grasmick/Sites/acquia/blt/tests/phpunit --group blted8 -c /Users/matthew.grasmick/Sites/acquia/blt/tests/phpunit/phpunit.xml -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/phpunit /Users/matthew.grasmick/Sites/acquia/blt/tests/phpunit --group blt --exclude-group deploy -v && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/blt deploy:build -vvv && /Users/matthew.grasmick/Sites/acquia/blt/../blted8/vendor/bin/phpunit /Users/matthew.grasmick/Sites/acquia/blt/tests/phpunit --group deploy -v in /Users/matthew.grasmick/Sites/acquia/blt/../blted8
```

This is very hard to read. This PR will add line breaks to output when multiple commands are joined with `&&` or `||`.