### PR TITLE
Load option default values from $input for all options…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ branches:
 matrix:
   include:
     - php: 7.1
-      env: dependencies=highest
-      env: DO_POST_BUILD_ACTIONS=1
+      env: dependencies=highest DO_POST_BUILD_ACTIONS=1
     - php: 7.0.11
     - php: 5.6
     - php: 5.5

--- a/composer.lock
+++ b/composer.lock
@@ -59,16 +59,16 @@
         },
         {
             "name": "consolidation/config",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/config.git",
-                "reference": "a57ff3a302aac6f7e6fc0d81fe0778550a0fe9aa"
+                "reference": "b59a3b9ea750c21397f26a68fd2e04d9580af42e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/config/zipball/a57ff3a302aac6f7e6fc0d81fe0778550a0fe9aa",
-                "reference": "a57ff3a302aac6f7e6fc0d81fe0778550a0fe9aa",
+                "url": "https://api.github.com/repos/consolidation/config/zipball/b59a3b9ea750c21397f26a68fd2e04d9580af42e",
+                "reference": "b59a3b9ea750c21397f26a68fd2e04d9580af42e",
                 "shasum": ""
             },
             "require": {
@@ -104,7 +104,7 @@
                 }
             ],
             "description": "Provide configuration services for a commandline tool.",
-            "time": "2017-10-17T17:09:36+00:00"
+            "time": "2017-10-25T05:50:10+00:00"
         },
         {
             "name": "consolidation/log",

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -3,13 +3,13 @@ namespace Robo\Config;
 
 class Config extends \Consolidation\Config\Config implements GlobalOptionDefaultValuesInterface
 {
-    const PROGRESS_BAR_AUTO_DISPLAY_INTERVAL = 'progress-delay';
+    const PROGRESS_BAR_AUTO_DISPLAY_INTERVAL = 'options.progress-delay';
     const DEFAULT_PROGRESS_DELAY = 2;
-    const SIMULATE = 'simulate';
+    const SIMULATE = 'options.simulate';
 
     // Read-only configuration properties; changing these has no effect.
-    const INTERACTIVE = 'interactive';
-    const DECORATED = 'decorated';
+    const INTERACTIVE = 'options.interactive';
+    const DECORATED = 'options.decorated';
 
     /**
      * Create a new configuration object, and initialize it with
@@ -34,8 +34,20 @@ class Config extends \Consolidation\Config\Config implements GlobalOptionDefault
             self::PROGRESS_BAR_AUTO_DISPLAY_INTERVAL => self::DEFAULT_PROGRESS_DELAY,
             self::SIMULATE => false,
         ];
+        return $this->trimPrefixFromGlobalOptions($globalOptions);
+    }
 
-        return $globalOptions;
+    /**
+     * Remove the 'options.' prefix from the global options list.
+     */
+    protected function trimPrefixFromGlobalOptions($globalOptions)
+    {
+        $result = [];
+        foreach ($globalOptions as $option => $value) {
+            $option = str_replace('options.', '', $option);
+            $result[$option] = $value;
+        }
+        return $result;
     }
 
     /**

--- a/src/Config/GlobalOptionDefaultValuesInterface.php
+++ b/src/Config/GlobalOptionDefaultValuesInterface.php
@@ -12,10 +12,6 @@ namespace Robo\Config;
  *
  * etc.
  */
-interface GlobalOptionDefaultValuesInterface
+interface GlobalOptionDefaultValuesInterface extends \Consolidation\Config\GlobalOptionDefaultValuesInterface
 {
-    /**
-     * Return an associative array of option-key => default-value
-     */
-    public function getGlobalOptionDefaultValues();
 }

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -210,7 +210,8 @@ class Robo
             ->withArgument('output');
         $container->share('resultPrinter', \Robo\Log\ResultPrinter::class);
         $container->add('simulator', \Robo\Task\Simulator::class);
-        $container->share('globalOptionsEventListener', \Robo\GlobalOptionsEventListener::class);
+        $container->share('globalOptionsEventListener', \Robo\GlobalOptionsEventListener::class)
+            ->withMethodCall('setApplication', ['application']);
         $container->share('injectConfigEventListener', \Consolidation\Config\Inject\ConfigForCommand::class)
             ->withArgument('config')
             ->withMethodCall('setApplication', ['application']);

--- a/tests/src/RoboFileFixture.php
+++ b/tests/src/RoboFileFixture.php
@@ -117,6 +117,7 @@ class RoboFileFixture extends \Robo\Tasks implements LoggerAwareInterface, Custo
      */
     public function testError()
     {
+        $this->io()->text(var_export(\Robo\Robo::config()->export(), true));
         return $this->taskExec('ls xyzzy' . date('U'))->dir('/tmp')->run();
     }
 

--- a/tests/unit/Task/PHPServerTest.php
+++ b/tests/unit/Task/PHPServerTest.php
@@ -41,7 +41,10 @@ class PHPServerTest extends \Codeception\TestCase\Test
 
     public function testServerCommand()
     {
-        $cmd = stripos(PHP_OS, 'WIN') === 0 ? 'php -S 127.0.0.1:8000 -t web' : 'exec php -S 127.0.0.1:8000 -t web';
+        // There is an 'exec ' at the beginning of the command here when
+        // running on Linux. Windows and MacOS do not have this prefix.
+        $cmd = stripos(PHP_OS, 'linux') === false ? '' : 'exec ';
+        $cmd .= 'php -S 127.0.0.1:8000 -t web';
 
         verify(
             (new \Robo\Task\Development\PhpServer('8000'))


### PR DESCRIPTION
…  defined in the Application's input definition. Related bugfix: store global options in 'options.' namespace rather than at the top level of config.

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Note
Backwards compatibility preserved if APIs are always used. May break b/c for code that directly calls e.g. `$config->get('simulate')`.