### PR TITLE
Add a method Robo::getCommandInstance.

### DIFF
--- a/src/Robo.php
+++ b/src/Robo.php
@@ -301,6 +301,49 @@ class Robo
     }
 
     /**
+     * Given the fully qualified namespace and classname of a command instance,
+     * instantiate it and store it in our container.
+     *
+     * @param string $commandClass
+     *
+     * @return null|object
+     */
+    public static function storeCommandInstance($commandClass)
+    {
+        $container = Robo::getContainer();
+
+        if (!class_exists($commandClass)) {
+            return;
+        }
+        $reflectionClass = new \ReflectionClass($commandClass);
+        if ($reflectionClass->isAbstract()) {
+            return;
+        }
+
+        $commandFileName = static::commandInstanceContainerName($commandClass);
+        $container->share($commandFileName, $commandClass);
+        return static::getCommandInstance($commandClass);
+    }
+
+    /**
+     * Given the fully qualified namespace and classname of a command instance,
+     * look it up from our container.
+     *
+     * @param string $commandClass
+     * @return object
+     */
+    public static function getCommandInstance($commandClass)
+    {
+        $commandFileName = static::commandInstanceContainerName($commandClass);
+        return static::service($commandFileName);
+    }
+
+    protected static function commandInstanceContainerName($commandClass)
+    {
+        return "{$commandClass}Commands";
+    }
+
+    /**
      * Retrieves a service from the container.
      *
      * Use this method if the desired service is not one of those with a dedicated

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -249,17 +249,10 @@ class Runner implements ContainerAwareInterface
         // If the command class is already an instantiated object, then
         // just use it exactly as it was provided to us.
         if (is_string($commandClass)) {
-            if (!class_exists($commandClass)) {
+            $commandClass = Robo::storeCommandInstance($commandClass);
+            if (!$commandClass) {
                 return;
             }
-            $reflectionClass = new \ReflectionClass($commandClass);
-            if ($reflectionClass->isAbstract()) {
-                return;
-            }
-
-            $commandFileName = "{$commandClass}Commands";
-            $container->share($commandFileName, $commandClass);
-            $commandClass = $container->get($commandFileName);
         }
         // If the command class is a Builder Aware Interface, then
         // ensure that it has a builder.  Every command class needs


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes (indirectly)

### Summary
Adds static method Robo::getCommandInstance

### Description
It is frequently a request by command authors, who, in order to implement some command `my:a` which in turn should execute other commands `my:b` and `my:c`, the desire of the author is to recover the commandfile instance for the subcommands so that the command's implementation methods may be called directly.

In general, this technique has been discouraged, because calling an implementation method directly omits any hook evaluation, so the result might not be the same as running `my:b` and `my:c` e.g. via exec. However, the advantage of having a reference to the command object is that the direct command result is available, whereas using exec or `$application->run()` all you would get is stdout.
