### PR TITLE
Implement the example RoboFile as a Robo plugin.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "autoload-dev":{
         "psr-4":{
-            "Robo\\":"tests/src"
+            "Robo\\":"tests/src",
+            "RoboExample\\":"examples/src"
         }
     },
     "bin":["robo"],

--- a/examples/src/Robo/Plugin/Commands/ExampleCommands.php
+++ b/examples/src/Robo/Plugin/Commands/ExampleCommands.php
@@ -1,4 +1,6 @@
 <?php
+namespace RoboExample\Robo\Plugin\Commands;
+
 use Robo\Result;
 
 use Consolidation\AnnotatedCommand\CommandData;
@@ -8,19 +10,25 @@ use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Symfony\Component\Console\Input\InputOption;
 
 /**
- * Example RoboFile.
+ * Example Robo Plugin Commands.
  *
- * To test:
+ * To create a Robo Plugin, create a standard Composer project. The
+ * namespace for your commands must end Robo\Plugin\Commands, and
+ * this suffix must immediately follow some namespace in your composer.json
+ * file's autoload section.
  *
- * $ cd ROBO_PROJECT/examples
- * $ ../robo try:success
+ * For example:
  *
- *   - or -
+ * "autoload": {
+ *         "psr-4": {
+ *             "RoboExample\\": "src"
+ *         }
+ *     },
  *
- * $ cd ROBO_PROJECT
- * $ ./robo -f examples try:formatters
+ * In this instance, the namespace for your plugin commands must be
+ * RoboExample\Robo\Plugin\Commands.
  */
-class RoboFile extends \Robo\Tasks
+class ExampleCommands extends \Robo\Tasks
 {
     /**
      * Watch a file.


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Description
Continuation of #671.

Implements Robo examples as a plugin. With this implementation, examples are available from a git checkout of Robo, but are not available in the phar.