### PR TITLE
Correctly parameterize the app name in the self:update command help t…

### DIFF
--- a/src/SelfUpdateCommand.php
+++ b/src/SelfUpdateCommand.php
@@ -24,11 +24,11 @@ class SelfUpdateCommand extends Command
 
     public function __construct($applicationName = null, $currentVersion = null, $gitHubRepository = null)
     {
-        parent::__construct(self::SELF_UPDATE_COMMAND_NAME);
-
         $this->applicationName = $applicationName;
         $this->currentVersion = $currentVersion;
         $this->gitHubRepository = $gitHubRepository;
+
+        parent::__construct(self::SELF_UPDATE_COMMAND_NAME);
     }
 
     /**
@@ -36,13 +36,15 @@ class SelfUpdateCommand extends Command
      */
     protected function configure()
     {
+        $app = $this->applicationName;
+
         $this
             ->setAliases(array('update'))
-            ->setDescription('Updates the robo.phar to the latest version.')
+            ->setDescription("Updates $app to the latest version.")
             ->setHelp(
                 <<<EOT
 The <info>self-update</info> command checks github for newer
-versions of robo and if found, installs the latest.
+versions of $app and if found, installs the latest.
 EOT
             );
     }


### PR DESCRIPTION
…ext.

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
self:update was using a hardcoded 'Robo' instead of the parameterized app name.