### PR TITLE
Fix double escape when specifying a remoteShell with rsync. Add test.

### DIFF
--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -415,7 +415,7 @@ class Rsync extends BaseTask implements CommandInterface
      */
     public function remoteShell($command)
     {
-        $this->option('rsh', "'$command'");
+        $this->option('rsh', "$command");
 
         return $this;
     }

--- a/tests/unit/Task/RsyncTest.php
+++ b/tests/unit/Task/RsyncTest.php
@@ -64,5 +64,22 @@ class RsyncTest extends \Codeception\TestCase\Test
                 ->toPath('/var/path/with/a space')
                 ->getCommand()
         )->equals($cmd);
+
+        $linuxCmd = 'rsync --rsh \'ssh -i ~/.ssh/id_rsa\' src/foo \'dev@localhost:/var/path\'';
+
+        $winCmd = 'rsync --rsh "ssh -i ~/.ssh/id_rsa" src/foo "dev@localhost:/var/path"';
+
+        $cmd = stripos(PHP_OS, 'WIN') === 0 ? $winCmd : $linuxCmd;
+
+        // rsync with a remoteShell specified
+        verify(
+            (new \Robo\Task\Remote\Rsync())
+                ->fromPath('src/foo')
+                ->toHost('localhost')
+                ->toUser('dev')
+                ->toPath('/var/path')
+                ->remoteShell('ssh -i ~/.ssh/id_rsa')
+                ->getCommand()
+        )->equals($cmd);
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
When specifying remoteShell() option with rsync, the result is double-escaped. For example:

```
            $this->taskRsync()
                ->fromPath('.')
                ->toHost($server)
                ->toUser('user')
                ->toPath('/var/www')
                ->remoteShell('ssh -i /home/user/.ssh/deploy')
                ->run();
```

Generates:

```
Running rsync --rsh ''\''ssh -i /home/user/.ssh/deploy'\''' . 'user@192.168.1.1:/var/www'
```

This changeset fixes the double escape and adds a test:

```
Running rsync --rsh 'ssh -i /home/user/.ssh/deploy' . 'user@192.168.1.1:/var/www'
```

### Description
Did not test on Windows (do not have the ability to do so easily).