### PR TITLE
Always return exec output (even when printed)

### DIFF
--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -415,7 +415,7 @@ class Rsync extends BaseTask implements CommandInterface
      */
     public function remoteShell($command)
     {
-        $this->option('rsh', "'$command'");
+        $this->option('rsh', "$command");
 
         return $this;
     }

--- a/tests/unit/Task/RsyncTest.php
+++ b/tests/unit/Task/RsyncTest.php
@@ -64,5 +64,22 @@ class RsyncTest extends \Codeception\TestCase\Test
                 ->toPath('/var/path/with/a space')
                 ->getCommand()
         )->equals($cmd);
+
+        $linuxCmd = 'rsync --rsh \'ssh -i ~/.ssh/id_rsa\' src/foo \'dev@localhost:/var/path\'';
+
+        $winCmd = 'rsync --rsh "ssh -i ~/.ssh/id_rsa" src/foo "dev@localhost:/var/path"';
+
+        $cmd = stripos(PHP_OS, 'WIN') === 0 ? $winCmd : $linuxCmd;
+
+        // rsync with a remoteShell specified
+        verify(
+            (new \Robo\Task\Remote\Rsync())
+                ->fromPath('src/foo')
+                ->toHost('localhost')
+                ->toUser('dev')
+                ->toPath('/var/path')
+                ->remoteShell('ssh -i ~/.ssh/id_rsa')
+                ->getCommand()
+        )->equals($cmd);
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Keep a copy of the output when printed so it can be returned as part of the result object

### Description
When printing the Process output and using a buffer function, the Process::getOutput() returns nothing. This patch keeps a copy of the output (via the buffer function) so it can return it in the end.
