### PR TITLE
Update README.md for OSX 10.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,15 @@
 wget http://robo.li/robo.phar
 ```
 
-To install globally put `robo.phar` in `/usr/bin`.
+To install globally put `robo.phar` in `/usr/bin`. (`/usr/local/bin/` in OSX 10.11+)
 
 ```
 chmod +x robo.phar && sudo mv robo.phar /usr/bin/robo
+```
+
+OSX 10.11+
+```
+chmod +x robo.phar && sudo mv robo.phar /usr/local/bin/robo
 ```
 
 Now you can use it just like `robo`.


### PR DESCRIPTION
Update OSX install instructions for OSX 10.11+

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
OSX 10.11+ doesn't allow user to `modify usr/bin`, `usr/local/bin` is okay

### Description
Any additional information.
