### PR TITLE
Block printing of result inside Result constructor

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -27,7 +27,7 @@ class Result extends ResultData
     {
         parent::__construct($exitCode, $message, $data);
         $this->task = $task;
-        $this->printResult();
+        // $this->printResult();
 
         if (self::$stopOnFail) {
             $this->stopOnFail();


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [x] Breaks backwards compatibility
- [ ] Has tests that cover changes

I know we can't just block all output like this, but I figured I'd get it how I need it to be and figure out a way to work backward from there.

### Summary
I can't stop error messages from printing (along with that [CompletionWrapper] class indicator) in Provision ~tasks~ steps. 

When I run `provision verify` and it fails it looks like this:
![screenshot from 2018-04-17 15-45-59](https://user-images.githubusercontent.com/106420/38892866-776dbc90-4256-11e8-9ec1-5905d61f28d0.png)

If I add Robo with this PR (commenting out printResult()) I get this (which is what I want):
![screenshot from 2018-04-17 15-46-49](https://user-images.githubusercontent.com/106420/38892897-93cbd34a-4256-11e8-983d-984062550364.png)

It's really important for user experience. With this patch, the checkboxes [ ]  turn into :x: as the steps complete, it's really nice.

I tried everything, ->silent(), printOutput(), everything I could find, but I guess since it is hard coded into the constructor it's not affected by these.

Thoughts?