### PR TITLE
Allow CommandStack to exec other tasks.

### DIFF
--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -11,6 +11,7 @@ use Robo\Exception\TaskException;
 abstract class CommandStack extends BaseTask implements CommandInterface, PrintedInterface
 {
     use ExecCommand;
+    use \Robo\Common\CommandReceiver;
 
     /**
      * @var string
@@ -34,7 +35,12 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
      */
     public function getCommand()
     {
-        return implode(' && ', $this->exec);
+        $commands = [];
+        foreach ($this->exec as $command) {
+            $commands[] = $this->receiveCommand($command);
+        }
+
+        return implode(' && ', $commands);
     }
 
     /**
@@ -49,7 +55,7 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
     }
 
     /**
-     * @param string|string[] $command
+     * @param string|string[]|CommandInterface $command
      *
      * @return $this
      */
@@ -59,8 +65,13 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
             $command = implode(' ', array_filter($command));
         }
 
-        $command      = $this->executable . ' ' . $this->stripExecutableFromCommand($command);
-        $this->exec[] = trim($command);
+        if (is_string($command)) {
+            $command = $this->executable . ' ' . $this->stripExecutableFromCommand($command);
+            $command = trim($command);
+        }
+        
+        $this->exec[] = $command;
+        
         return $this;
     }
 

--- a/tests/unit/Task/ExecTaskTest.php
+++ b/tests/unit/Task/ExecTaskTest.php
@@ -69,4 +69,13 @@ class ExecTaskTest extends \Codeception\TestCase\Test
             ->getCommand()
         )->equals('ls && cd / && cd home');
     }
+
+    public function testExecStackCommandInterface()
+    {
+        verify((new \Robo\Task\Base\ExecStack())
+            ->exec('ls')
+            ->exec((new \Robo\Task\Vcs\GitStack('git'))->add('-A')->pull())
+            ->getCommand()
+        )->equals('ls && git add -A && git pull');
+    }
 };


### PR DESCRIPTION
### Overview
This pull request: Allows tasks that extend CommandStack to exec other tasks (which implement CommandInterface).

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
The code in taskSshExec that allowed it to exec other tasks, was ported over to CommandStack.

### Description
It adds consistency with taskSshExec, which could already exec other tasks.
