### PR TITLE
Support incremental output of parallel jobs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.x-dev",
+            "dev-incremental-parallel": "1.x-dev",
             "dev-state": "1.x-dev"
         }
     },

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -175,17 +175,32 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
                 }
                 if (!$process->isRunning()) {
                     $this->advanceProgressIndicator();
-                    if ($this->isPrinted && $this->isWaitToFinishPrinted) {
-                        $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $process->getOutput(), '_style' => ['command' => 'fg=white;bg=magenta']]);
-                        $errorOutput = $process->getErrorOutput();
-                        if ($errorOutput) {
-                            $this->printTaskError(rtrim($errorOutput));
+                    if ($this->isPrinted) {
+                        if ($this->isWaitToFinishPrinted) {
+                            $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $process->getOutput(), '_style' => ['command' => 'fg=white;bg=magenta']]);
+                            $errorOutput = $process->getErrorOutput();
+                            if ($errorOutput) {
+                                $this->printTaskError(rtrim($errorOutput));
+                            }
+                        }
+                        else {
+                            if ($output = $process->getIncrementalOutput()) {
+                                $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $output, '_style' => ['command' => 'fg=white;bg=magenta']]);
+                            }
+                            if ($error = $process->getIncrementalErrorOutput()) {
+                                $this->printTaskInfo("Error for {command}:\n\n{error}", ['command' => $process->getCommandLine(), 'error' => $output, '_style' => ['command' => 'fg=white;bg=magenta']]);
+                            }
                         }
                     }
                     unset($running[$k]);
                 }
-                elseif ($this->isPrinted && !$this->isWaitToFinishPrinted && $output = $process->getIncrementalOutput()) {
-                    $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $output, '_style' => ['command' => 'fg=white;bg=magenta']]);
+                elseif ($this->isPrinted && !$this->isWaitToFinishPrinted) {
+                    if ($output = $process->getIncrementalOutput()) {
+                        $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $output, '_style' => ['command' => 'fg=white;bg=magenta']]);
+                    }
+                    if ($error = $process->getIncrementalErrorOutput()) {
+                        $this->printTaskInfo("Error for {command}:\n\n{error}", ['command' => $process->getCommandLine(), 'error' => $output, '_style' => ['command' => 'fg=white;bg=magenta']]);
+                    }
                 }
             }
             if (empty($running) && empty($queue)) {

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -184,22 +184,22 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
                             }
                         }
                         else {
-                            if ($output = $process->getIncrementalOutput()) {
+                            if ($output = rtrim($process->getIncrementalOutput())) {
                                 $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $output, '_style' => ['command' => 'fg=white;bg=magenta']]);
                             }
-                            if ($error = $process->getIncrementalErrorOutput()) {
-                                $this->printTaskInfo("Error for {command}:\n\n{error}", ['command' => $process->getCommandLine(), 'error' => $output, '_style' => ['command' => 'fg=white;bg=magenta']]);
+                            if ($error = rtrim($process->getIncrementalErrorOutput())) {
+                                $this->printTaskInfo("Error for {command}:\n\n{error}", ['command' => $process->getCommandLine(), 'error' => $error, '_style' => ['command' => 'fg=white;bg=magenta']]);
                             }
                         }
                     }
                     unset($running[$k]);
                 }
                 elseif ($this->isPrinted && !$this->isWaitToFinishPrinted) {
-                    if ($output = $process->getIncrementalOutput()) {
+                    if ($output = rtrim($process->getIncrementalOutput())) {
                         $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $output, '_style' => ['command' => 'fg=white;bg=magenta']]);
                     }
-                    if ($error = $process->getIncrementalErrorOutput()) {
-                        $this->printTaskInfo("Error for {command}:\n\n{error}", ['command' => $process->getCommandLine(), 'error' => $output, '_style' => ['command' => 'fg=white;bg=magenta']]);
+                    if ($error = rtrim($process->getIncrementalErrorOutput())) {
+                        $this->printTaskInfo("Error for {command}:\n\n{error}", ['command' => $process->getCommandLine(), 'error' => $error, '_style' => ['command' => 'fg=white;bg=magenta']]);
                     }
                 }
             }

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -184,8 +184,8 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
                     }
                     unset($running[$k]);
                 }
-                elseif ($this->isPrinted && !$this->isWaitToFinishPrinted) {
-                    $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $process->getIncrementalOutput(), '_style' => ['command' => 'fg=white;bg=magenta']]);
+                elseif ($this->isPrinted && !$this->isWaitToFinishPrinted && $output = $process->getIncrementalOutput()) {
+                    $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $output, '_style' => ['command' => 'fg=white;bg=magenta']]);
                 }
             }
             if (empty($running) && empty($queue)) {


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Adds an option to show interleaved parallel exec task output instead of batching it for the end.

### Description

Many CI tools will kill jobs if they have no output for some period of time. For example, CircleCI ends jobs after 10 minutes. If no parallel task completes in 10 minutes, then no output is shown and jobs can be killed. This is especially common with migrations or import tasks, where progress messages are shown but the actual command may take hours to complete.

This PR adds an additional flag on `printed` which prints messages as they arrive. It's off by default to preserve the existing behaviour and to ensure that callers know that output may be mixed up during execution.

If this looks like it's a good approach, I will add tests and then do some cleanups to refactor.