### PR TITLE
Events as third parameter in watch function

### DIFF
--- a/docs/tasks/Base.md
+++ b/docs/tasks/Base.md
@@ -115,8 +115,7 @@ $this->taskWatch()
         $this->taskExec('phpunit')->run();
     },
     \Lurker\Event\FilesystemEvent::ALL
-)
-->monitor(
+)->monitor(
     'migrations',
     function() {
         //do something
@@ -125,8 +124,7 @@ $this->taskWatch()
         \Lurker\Event\FilesystemEvent::CREATE,
         \Lurker\Event\FilesystemEvent::DELETE
     ]
-)
-->run();
+)->run();
 ?>
 ```
 

--- a/docs/tasks/Base.md
+++ b/docs/tasks/Base.md
@@ -97,7 +97,7 @@ $this->taskSymfonyCommand(new ModelGeneratorCommand())
 
 Runs task when specified file or dir was changed.
 Uses Lurker library.
-Third parameter takes Lurker filesystem events constants to watch.
+Monitor third parameter takes Lurker filesystem events types to watch.
 By default its set to MODIFY event.
 
 

--- a/docs/tasks/Base.md
+++ b/docs/tasks/Base.md
@@ -97,17 +97,41 @@ $this->taskSymfonyCommand(new ModelGeneratorCommand())
 
 Runs task when specified file or dir was changed.
 Uses Lurker library.
+Third parameter takes Lurker filesystem events constants to watch.
+By default its set to MODIFY event.
+
 
 ``` php
 <?php
 $this->taskWatch()
- ->monitor('composer.json', function() {
-     $this->taskComposerUpdate()->run();
-})->monitor('src', function() {
-     $this->taskExec('phpunit')->run();
-})->run();
+    ->monitor(
+    'composer.json',
+    function() {
+        $this->taskComposerUpdate()->run();
+    }
+)->monitor(
+    'src',
+    function() {
+        $this->taskExec('phpunit')->run();
+    },
+    \Lurker\Event\FilesystemEvent::ALL
+)
+->monitor(
+    'migrations',
+    function() {
+        //do something
+    },
+    [
+        \Lurker\Event\FilesystemEvent::CREATE,
+        \Lurker\Event\FilesystemEvent::DELETE
+    ]
+)
+->run();
 ?>
 ```
 
-* `monitor($paths, $callable)`   * `param string|string[]` $paths
+* `monitor($paths, $callable, $event = \Lurker\Event\FilesystemEvent::MODIFY)`
+    * `param string|string[]` $paths
+    * `param \Closure` $callable
+    * `param int|int[]` $events - Lurker filesystem events (CREATE, DELETE, MODIFY, ALL)
 

--- a/src/Task/Base/Watch.php
+++ b/src/Task/Base/Watch.php
@@ -55,15 +55,7 @@ class Watch extends BaseTask
      */
     public function monitor($paths, \Closure $callable, $events = FilesystemEvent::MODIFY)
     {
-        if (!is_array($paths)) {
-            $paths = [$paths];
-        }
-
-        if (!is_array($events)) {
-            $events = [$events];
-        }
-
-        $this->monitor[] = [$paths, $callable, $events];
+        $this->monitor[] = [(array)$paths, $callable, (array)$events];
         return $this;
     }
 

--- a/src/Task/Base/Watch.php
+++ b/src/Task/Base/Watch.php
@@ -1,7 +1,6 @@
 <?php
 namespace Robo\Task\Base;
 
-use Lurker\Event\FilesystemEvent;
 use Lurker\ResourceWatcher;
 use Robo\Result;
 use Robo\Task\BaseTask;
@@ -71,7 +70,7 @@ class Watch extends BaseTask
      *
      * @return $this
      */
-    public function monitor($paths, \Closure $callable, $events = FilesystemEvent::MODIFY)
+    public function monitor($paths, \Closure $callable, $events = 2)
     {
         $this->monitor[] = [(array)$paths, $callable, (array)$events];
         return $this;

--- a/src/Task/Base/Watch.php
+++ b/src/Task/Base/Watch.php
@@ -9,15 +9,33 @@ use Robo\Task\BaseTask;
 /**
  * Runs task when specified file or dir was changed.
  * Uses Lurker library.
+ * Monitor third parameter takes Lurker filesystem events types to watch.
+ * By default its set to MODIFY event.
  *
  * ``` php
  * <?php
  * $this->taskWatch()
- *  ->monitor('composer.json', function() {
- *      $this->taskComposerUpdate()->run();
- * })->monitor('src', function() {
- *      $this->taskExec('phpunit')->run();
- * })->run();
+ *      ->monitor(
+ *          'composer.json',
+ *          function() {
+ *              $this->taskComposerUpdate()->run();
+ *          }
+ *      )->monitor(
+ *          'src',
+ *          function() {
+ *              $this->taskExec('phpunit')->run();
+ *          },
+ *          \Lurker\Event\FilesystemEvent::ALL
+ *      )->monitor(
+ *          'migrations',
+ *          function() {
+ *              //do something
+ *          },
+ *          [
+ *              \Lurker\Event\FilesystemEvent::CREATE,
+ *              \Lurker\Event\FilesystemEvent::DELETE
+ *          ]
+ *      )->run();
  * ?>
  * ```
  */

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -8,5 +8,6 @@ $kernel->init([
         __DIR__.'/../src',
         __DIR__.'/../vendor/symfony/process',
         __DIR__.'/../vendor/symfony/console',
+        __DIR__.'/../vendor/henrikbjorn/lurker/src',
     ]
 ]);

--- a/tests/unit/Task/WatchTest.php
+++ b/tests/unit/Task/WatchTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace Tests\Unit\Task;
+
 use AspectMock\Test as test;
 
 class WatchTest extends \Codeception\TestCase\Test
 {
     /**
-     * @var AspectMock\Proxy\AnythingClassProxy
+     * @var \AspectMock\Proxy\AnythingClassProxy
      */
     protected $resourceWatcher;
 
@@ -34,7 +36,7 @@ class WatchTest extends \Codeception\TestCase\Test
 
     public function testMonitorWithOneEvent()
     {
-        $task = new Robo\Task\Base\Watch($this);
+        $task = new \Robo\Task\Base\Watch($this);
 
         $task->monitor(
             'src',
@@ -49,7 +51,7 @@ class WatchTest extends \Codeception\TestCase\Test
 
     public function testMonitorWithTwoEvents()
     {
-        $task = new Robo\Task\Base\Watch($this);
+        $task = new \Robo\Task\Base\Watch($this);
 
         $task->monitor(
             'src',

--- a/tests/unit/Task/WatchTest.php
+++ b/tests/unit/Task/WatchTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use AspectMock\Test as test;
+
+class WatchTest extends \Codeception\TestCase\Test
+{
+    /**
+     * @var AspectMock\Proxy\AnythingClassProxy
+     */
+    protected $resourceWatcher;
+
+    public function _before()
+    {
+        if (!class_exists('Lurker\\ResourceWatcher')) {
+            $this->resourceWatcher = test::spec(
+                'Lurker\ResourceWatcher',
+                [
+                    'start' => true,
+                    'track' => true,
+                    'addListener' => true
+                ]
+            )->make();
+        } else {
+            $this->resourceWatcher = test::double(
+                'Lurker\ResourceWatcher',
+                [
+                    'start' => true,
+                    'track' => true,
+                    'addListener' => true
+                ]
+            );
+        }
+    }
+
+    public function testMonitorWithOneEvent()
+    {
+        $task = new Robo\Task\Base\Watch($this);
+
+        $task->monitor(
+            'src',
+            function () {
+                //do nothing
+            },
+            1 // CREATE
+        )->run();
+
+        $this->resourceWatcher->verifyInvokedOnce('track');
+    }
+
+    public function testMonitorWithTwoEvents()
+    {
+        $task = new Robo\Task\Base\Watch($this);
+
+        $task->monitor(
+            'src',
+            function () {
+                //do nothing
+            },
+            [
+                1, //CREATE
+                4, //DELETE
+            ]
+        )->run();
+
+        $this->resourceWatcher->verifyInvokedMultipleTimes('track', 2);
+    }
+}


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Adds ability to set multiple events to file/dirs.

### Description
Robo has hard coded watching for modification event only which is not firing when files are added or removed. To give possibility to react on this kind of changes monitor function now can take third argument which stands for events. Like in paths it can be array or single value. To maintain backward compatibility default event was set to modify event. This PR is related to #650.

Usage:
```php
<?php

$this->taskWatch()
  ->monitor(
    'src', 
    function() {
      $this->taskExec('phpunit')->run();
    },
    \Lurker\Event\FilesystemEvent::CREATE
)->run();

$this->taskWatch()
  ->monitor(
    'src', 
    function() {
      $this->taskExec('phpunit')->run();
    },
    [
      \Lurker\Event\FilesystemEvent::CREATE, 
      \Lurker\Event\FilesystemEvent::DELETE
    ]
)->run();
```
