### PR TITLE
Fix overzealous shebang function

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -377,6 +377,10 @@ class Runner implements ContainerAwareInterface
      */
     protected function isShebangFile($filepath)
     {
+        // Avoid trying to call $filepath on remote URLs
+        if ((strpos($filepath, '://') !== false) && (substr($filepath, 0, 7) != 'file://')) {
+            return false;
+        }
         if (!is_file($filepath)) {
             return false;
         }


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Shebang handling could throw an error, e.g. when the first parameter to a Robo function was something like `git://git.drupal.org/project/drupal.git`
