### PR TITLE
Correct Doxygen in \Robo\Task\Composer\loadTasks.

### DIFF
--- a/src/Task/Composer/loadTasks.php
+++ b/src/Task/Composer/loadTasks.php
@@ -46,7 +46,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return Init
+     * @return Config
      */
     protected function taskComposerConfig($pathToComposer = null)
     {
@@ -76,7 +76,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return Remove
+     * @return RequireDependency
      */
     protected function taskComposerRequire($pathToComposer = null)
     {
@@ -86,7 +86,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return Remove
+     * @return CreateProject
      */
     protected function taskComposerCreateProject($pathToComposer = null)
     {


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
There are a few incorrect `@return` values in `\Robo\Task\Composer\loadTasks`.