### PR TITLE
Add IO::confirmDefault() method

### DIFF
--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -134,6 +134,18 @@ trait IO
     }
 
     /**
+     * @param string $question
+     * @param bool $default
+     *
+     * @return string
+     */
+    protected function confirmDefault($question, $default)
+    {
+        $formatted_question = $this->formatQuestion(sprintf('%s (y/n) [%s]', $question, $default ? 'y' : 'n'));
+        return $this->doAsk(new ConfirmationQuestion($formatted_question, $default));
+    }
+
+    /**
      * @param \Symfony\Component\Console\Question\Question $question
      *
      * @return string


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Add a `confirmDefault()` method to `\Robo\Common\IO`.

### Description
I was looking for such a function today. I expected it to be present as a matter of symmetry with `ask()`/`askDefault()`.
