### PR TITLE
Fix the main Robo script entrypoint to work as a phar.

### DIFF
--- a/robo
+++ b/robo
@@ -1,20 +1,23 @@
 #!/usr/bin/env php
 <?php
 /**
- * if we're running from phar load the phar autoload,
+ * If we're running from phar load the phar autoload,
  * else let the script 'robo' search for the autoloader.
- * If we cannot find a vendor/autoload.php file, then
- * we will go ahead and try the phar.
  */
-$pharPath = \Phar::running(true);
-if ($pharPath) {
-    $autoloaderPath = "$pharPath/vendor/autoload.php";
-} else {
-    if (file_exists(__DIR__.'/vendor/autoload.php')) {
-        $autoloaderPath = __DIR__.'/vendor/autoload.php';
-    } elseif (file_exists(__DIR__.'/../../autoload.php')) {
-        $autoloaderPath = __DIR__ . '/../../autoload.php';
+$candidates = [
+    'phar://robo.phar/vendor/autoload.php', // phar path
+    __DIR__.'/vendor/autoload.php',
+    __DIR__.'/../../autoload.php',
+];
+$autoloaderPath = false;
+foreach ($candidates as $candidate) {
+    if (file_exists($candidate)) {
+        $autoloaderPath = $candidate;
+        break;
     }
+}
+if (!$autoloaderPath) {
+  die("Could not find autoloader. Run 'composer install'.");
 }
 $classLoader = require $autoloaderPath;
 $configFilePath = getenv('ROBO_CONFIG') ?: getenv('HOME') . '/.robo/robo.yml';


### PR DESCRIPTION
\Phar::running() is documented to return nothing in the stub. This method DOES
work when the phar is built with https://github.com/humbug/box, but it behaves
as documented when Robo builds its phar with the standard Phar APIs (which is
to say that it returns an empty string).

When running as a phar, __FILE__ will return whatever the current filename for
the phar is, so the documentation's suggestion to use __FILE__ in place of
\Phar::running() also does not work. However, the path that we compiled the
phar with, 'phar://robo.phar/...' always works.  We therefore use that first
if it exists.

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
The phar was broken in 1.3.2. This fixes it.