### PR TITLE
Allow for aborting completions or rollbacks.

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -113,6 +113,8 @@ Any task may also implement \Robo\Contract\RollbackInterface; if this is done, t
 
 Use `addAsCompletion($collection)` in place of `addAsRollback($collection)`, or implement \Robo\Contract\CompletionInterface. Completions otherwise work exactly like rollbacks.
 
+By default, rollbacks and completions tasks or callbacks continue even if errors occur. If you would like to explicitly cancel or abort the rollback or completion, you may throw the `\Robo\Exception\ForcedException` exception.
+
 ### Rollback and Completion Callbacks
 
 You may also provide arbitrary methods as `callable`s to serve as rollback or completion functions, as shown below:

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -113,7 +113,7 @@ Any task may also implement \Robo\Contract\RollbackInterface; if this is done, t
 
 Use `addAsCompletion($collection)` in place of `addAsRollback($collection)`, or implement \Robo\Contract\CompletionInterface. Completions otherwise work exactly like rollbacks.
 
-By default, rollbacks and completions tasks or callbacks continue even if errors occur. If you would like to explicitly cancel or abort the rollback or completion, you may throw the `\Robo\Exception\ForcedException` exception.
+By default, rollbacks and completions tasks or callbacks continue even if errors occur. If you would like to explicitly cancel or abort the rollback or completion, you may throw the `\Robo\Exception\AbortTasksException` exception.
 
 ### Rollback and Completion Callbacks
 

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -1,6 +1,7 @@
 <?php
 namespace Robo\Collection;
 
+use Robo\Exception\ForcedException;
 use Robo\Result;
 use Robo\State\Data;
 use Psr\Log\LogLevel;
@@ -254,6 +255,8 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
                 $message = $result->getMessage();
                 $data = $result->getData();
                 $data['exitcode'] = $result->getExitCode();
+            } catch (ForcedException $forcedException) {
+                throw $forcedException;
             } catch (\Exception $e) {
                 $message = $e->getMessage();
             }
@@ -735,6 +738,10 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
 
     /**
      * Run all of the tasks in a provided list, ignoring failures.
+     *
+     * You may force a failure by throwing a ForcedException in your rollback or
+     * completion task or callback.
+     *
      * This is used to roll back or complete.
      *
      * @param TaskInterface[] $taskList
@@ -744,6 +751,12 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
         foreach ($taskList as $task) {
             try {
                 $this->runSubtask($task);
+            } catch (ForcedException $forcedException) {
+                // If there's a forced exception, end the loop of tasks.
+                if ($message = $forcedException->getMessage()) {
+                    $this->logger()->notice($message);
+                }
+                break;
             } catch (\Exception $e) {
                 // Ignore rollback failures.
             }

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -1,7 +1,7 @@
 <?php
 namespace Robo\Collection;
 
-use Robo\Exception\ForcedException;
+use Robo\Exception\AbortTasksException;
 use Robo\Result;
 use Robo\State\Data;
 use Psr\Log\LogLevel;
@@ -255,8 +255,8 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
                 $message = $result->getMessage();
                 $data = $result->getData();
                 $data['exitcode'] = $result->getExitCode();
-            } catch (ForcedException $forcedException) {
-                throw $forcedException;
+            } catch (AbortTasksException $abortTasksException) {
+                throw $abortTasksException;
             } catch (\Exception $e) {
                 $message = $e->getMessage();
             }
@@ -751,9 +751,9 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
         foreach ($taskList as $task) {
             try {
                 $this->runSubtask($task);
-            } catch (ForcedException $forcedException) {
+            } catch (AbortTasksException $abortTasksException) {
                 // If there's a forced exception, end the loop of tasks.
-                if ($message = $forcedException->getMessage()) {
+                if ($message = $abortTasksException->getMessage()) {
                     $this->logger()->notice($message);
                 }
                 break;

--- a/src/Exception/AbortTasksException.php
+++ b/src/Exception/AbortTasksException.php
@@ -1,0 +1,13 @@
+<?php
+namespace Robo\Exception;
+
+/**
+ * By default, rollbacks and completions tasks or callbacks continue even if
+ * errors occur. If you would like to explicitly cancel or abort the rollback or
+ * completion, you may throw this exception to abort the subsequent tasks in the
+ * rollback or completion task list.
+ */
+class AbortTasksException extends \Exception
+{
+
+}

--- a/src/Exception/ForcedException.php
+++ b/src/Exception/ForcedException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Robo\Exception;
+
+class ForcedException extends \Exception
+{
+
+}

--- a/src/Exception/ForcedException.php
+++ b/src/Exception/ForcedException.php
@@ -1,7 +1,0 @@
-<?php
-namespace Robo\Exception;
-
-class ForcedException extends \Exception
-{
-
-}

--- a/tests/cli/CollectionCest.php
+++ b/tests/cli/CollectionCest.php
@@ -4,7 +4,7 @@ namespace Robo;
 use \CliGuy;
 
 use Robo\Collection\Temporary;
-use Robo\Exception\ForcedException;
+use Robo\Exception\AbortTasksException;
 
 class CollectionCest
 {
@@ -123,7 +123,7 @@ class CollectionCest
                 $I->taskDeleteDir('j')
             )
             ->rollbackCode(function () {
-                throw new ForcedException('Aborting rollback.');
+                throw new AbortTasksException('Aborting rollback.');
             })
             ->taskFilesystemStack()
             ->mkdir('j/k')


### PR DESCRIPTION
### Overview
This pull request:

- [X] Adds a feature
- [X] Has tests that cover changes

### Summary
Adds a new exception `ForcedException` for forcefully aborting a rollback or completion.
