### PR TITLE
Improved param injection

### DIFF
--- a/.scenarios.lock/symfony2/composer.json
+++ b/.scenarios.lock/symfony2/composer.json
@@ -25,17 +25,17 @@
     "require": {
         "symfony/console": "^2.8",
         "php": ">=5.5.0",
-        "league/container": "^2.2",
-        "consolidation/log": "~1",
+        "consolidation/annotated-command": "dev-improved-param-injection",
         "consolidation/config": "^1.0.10",
-        "consolidation/annotated-command": "^2.10.2",
+        "consolidation/log": "~1",
         "consolidation/output-formatters": "^3.1.13",
         "consolidation/self-update": "^1",
         "grasmash/yaml-expander": "^1.3",
-        "symfony/finder": "^2.5|^3|^4",
-        "symfony/process": "^2.5|^3|^4",
+        "league/container": "^2.2",
+        "symfony/event-dispatcher": "^2.5|^3|^4",
         "symfony/filesystem": "^2.5|^3|^4",
-        "symfony/event-dispatcher": "^2.5|^3|^4"
+        "symfony/finder": "^2.5|^3|^4",
+        "symfony/process": "^2.5|^3|^4"
     },
     "require-dev": {
         "g1a/composer-test-scenarios": "^3",

--- a/.scenarios.lock/symfony2/composer.json
+++ b/.scenarios.lock/symfony2/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "symfony/console": "^2.8",
         "php": ">=5.5.0",
-        "consolidation/annotated-command": "dev-improved-param-injection",
+        "consolidation/annotated-command": "^2.11.0",
         "consolidation/config": "^1.0.10",
         "consolidation/log": "~1",
         "consolidation/output-formatters": "^3.1.13",

--- a/.scenarios.lock/symfony2/composer.json
+++ b/.scenarios.lock/symfony2/composer.json
@@ -27,7 +27,7 @@
         "php": ">=5.5.0",
         "consolidation/annotated-command": "^2.11.0",
         "consolidation/config": "^1.0.10",
-        "consolidation/log": "~1",
+        "consolidation/log": "^1.1.1",
         "consolidation/output-formatters": "^3.1.13",
         "consolidation/self-update": "^1",
         "grasmash/yaml-expander": "^1.3",

--- a/.scenarios.lock/symfony4/composer.json
+++ b/.scenarios.lock/symfony4/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "symfony/console": "^4",
         "php": ">=5.5.0",
-        "consolidation/annotated-command": "dev-improved-param-injection",
+        "consolidation/annotated-command": "^2.11.0",
         "consolidation/config": "^1.0.10",
         "consolidation/log": "~1",
         "consolidation/output-formatters": "^3.1.13",

--- a/.scenarios.lock/symfony4/composer.json
+++ b/.scenarios.lock/symfony4/composer.json
@@ -27,7 +27,7 @@
         "php": ">=5.5.0",
         "consolidation/annotated-command": "^2.11.0",
         "consolidation/config": "^1.0.10",
-        "consolidation/log": "~1",
+        "consolidation/log": "^1.1.1",
         "consolidation/output-formatters": "^3.1.13",
         "consolidation/self-update": "^1",
         "grasmash/yaml-expander": "^1.3",

--- a/.scenarios.lock/symfony4/composer.json
+++ b/.scenarios.lock/symfony4/composer.json
@@ -25,17 +25,17 @@
     "require": {
         "symfony/console": "^4",
         "php": ">=5.5.0",
-        "league/container": "^2.2",
-        "consolidation/log": "~1",
+        "consolidation/annotated-command": "dev-improved-param-injection",
         "consolidation/config": "^1.0.10",
-        "consolidation/annotated-command": "^2.10.2",
+        "consolidation/log": "~1",
         "consolidation/output-formatters": "^3.1.13",
         "consolidation/self-update": "^1",
         "grasmash/yaml-expander": "^1.3",
-        "symfony/finder": "^2.5|^3|^4",
-        "symfony/process": "^2.5|^3|^4",
+        "league/container": "^2.2",
+        "symfony/event-dispatcher": "^2.5|^3|^4",
         "symfony/filesystem": "^2.5|^3|^4",
-        "symfony/event-dispatcher": "^2.5|^3|^4"
+        "symfony/finder": "^2.5|^3|^4",
+        "symfony/process": "^2.5|^3|^4"
     },
     "require-dev": {
         "g1a/composer-test-scenarios": "^3",

--- a/.scenarios.lock/symfony4/composer.lock
+++ b/.scenarios.lock/symfony4/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0eb36908b27d39e31e0e1b92c79138c",
+    "content-hash": "cc2aeecd32da50a06310e17d472df8d3",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "dev-improved-param-injection",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "ac3ec8c1c97f2c007afba364d693cab480c4718c"
+                "reference": "edea407f57104ed518cc3c3b47d5b84403ee267a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/ac3ec8c1c97f2c007afba364d693cab480c4718c",
-                "reference": "ac3ec8c1c97f2c007afba364d693cab480c4718c",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/edea407f57104ed518cc3c3b47d5b84403ee267a",
+                "reference": "edea407f57104ed518cc3c3b47d5b84403ee267a",
                 "shasum": ""
             },
             "require": {
@@ -100,7 +100,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2018-12-28T02:29:34+00:00"
+            "time": "2018-12-29T04:43:17+00:00"
         },
         {
             "name": "consolidation/config",
@@ -158,31 +158,72 @@
         },
         {
             "name": "consolidation/log",
-            "version": "1.0.6",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/log.git",
-                "reference": "dfd8189a771fe047bf3cd669111b2de5f1c79395"
+                "reference": "44c65cb5861d8bbb01c185e49cd2807ed4405a75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/log/zipball/dfd8189a771fe047bf3cd669111b2de5f1c79395",
-                "reference": "dfd8189a771fe047bf3cd669111b2de5f1c79395",
+                "url": "https://api.github.com/repos/consolidation/log/zipball/44c65cb5861d8bbb01c185e49cd2807ed4405a75",
+                "reference": "44c65cb5861d8bbb01c185e49cd2807ed4405a75",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.0",
-                "psr/log": "~1.0",
+                "php": ">=5.4.5",
+                "psr/log": "^1.0",
                 "symfony/console": "^2.8|^3|^4"
             },
             "require-dev": {
-                "g1a/composer-test-scenarios": "^1",
-                "phpunit/phpunit": "4.*",
-                "satooshi/php-coveralls": "^2",
-                "squizlabs/php_codesniffer": "2.*"
+                "g1a/composer-test-scenarios": "^3",
+                "php-coveralls/php-coveralls": "^1",
+                "phpunit/phpunit": "^6",
+                "squizlabs/php_codesniffer": "^2"
             },
             "type": "library",
             "extra": {
+                "scenarios": {
+                    "symfony4": {
+                        "require": {
+                            "symfony/console": "^4.0"
+                        },
+                        "config": {
+                            "platform": {
+                                "php": "7.1.3"
+                            }
+                        }
+                    },
+                    "symfony2": {
+                        "require": {
+                            "symfony/console": "^2.8"
+                        },
+                        "require-dev": {
+                            "phpunit/phpunit": "^4.8.36"
+                        },
+                        "remove": [
+                            "php-coveralls/php-coveralls"
+                        ],
+                        "config": {
+                            "platform": {
+                                "php": "5.4.8"
+                            }
+                        }
+                    },
+                    "phpunit4": {
+                        "require-dev": {
+                            "phpunit/phpunit": "^4.8.36"
+                        },
+                        "remove": [
+                            "php-coveralls/php-coveralls"
+                        ],
+                        "config": {
+                            "platform": {
+                                "php": "5.4.8"
+                            }
+                        }
+                    }
+                },
                 "branch-alias": {
                     "dev-master": "1.x-dev"
                 }
@@ -203,7 +244,7 @@
                 }
             ],
             "description": "Improved Psr-3 / Psr\\Log logger based on Symfony Console components.",
-            "time": "2018-05-25T18:14:39+00:00"
+            "time": "2018-12-29T18:54:58+00:00"
         },
         {
             "name": "consolidation/output-formatters",
@@ -4131,9 +4172,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "consolidation/annotated-command": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/.scenarios.lock/symfony4/composer.lock
+++ b/.scenarios.lock/symfony4/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f152a6c19524f672f3900c4d4fe623d6",
+    "content-hash": "a0eb36908b27d39e31e0e1b92c79138c",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "2.10.2",
+            "version": "dev-improved-param-injection",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "5cbb8c320e0d3d2e6905374d56dc3610b7443f7b"
+                "reference": "ac3ec8c1c97f2c007afba364d693cab480c4718c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/5cbb8c320e0d3d2e6905374d56dc3610b7443f7b",
-                "reference": "5cbb8c320e0d3d2e6905374d56dc3610b7443f7b",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/ac3ec8c1c97f2c007afba364d693cab480c4718c",
+                "reference": "ac3ec8c1c97f2c007afba364d693cab480c4718c",
                 "shasum": ""
             },
             "require": {
@@ -100,7 +100,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2018-12-21T03:50:15+00:00"
+            "time": "2018-12-28T02:29:34+00:00"
         },
         {
             "name": "consolidation/config",
@@ -4079,20 +4079,21 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -4125,12 +4126,14 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "consolidation/annotated-command": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/.scenarios.lock/symfony4/composer.lock
+++ b/.scenarios.lock/symfony4/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc2aeecd32da50a06310e17d472df8d3",
+    "content-hash": "8ef0fbf15c7ab6e6a7e91096f1e1ed60",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -158,16 +158,16 @@
         },
         {
             "name": "consolidation/log",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/log.git",
-                "reference": "44c65cb5861d8bbb01c185e49cd2807ed4405a75"
+                "reference": "b2e887325ee90abc96b0a8b7b474cd9e7c896e3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/log/zipball/44c65cb5861d8bbb01c185e49cd2807ed4405a75",
-                "reference": "44c65cb5861d8bbb01c185e49cd2807ed4405a75",
+                "url": "https://api.github.com/repos/consolidation/log/zipball/b2e887325ee90abc96b0a8b7b474cd9e7c896e3a",
+                "reference": "b2e887325ee90abc96b0a8b7b474cd9e7c896e3a",
                 "shasum": ""
             },
             "require": {
@@ -244,7 +244,7 @@
                 }
             ],
             "description": "Improved Psr-3 / Psr\\Log logger based on Symfony Console components.",
-            "time": "2018-12-29T18:54:58+00:00"
+            "time": "2019-01-01T17:30:51+00:00"
         },
         {
             "name": "consolidation/output-formatters",
@@ -1419,21 +1419,21 @@
         },
         {
             "name": "codeception/phpunit-wrapper",
-            "version": "6.0.12",
+            "version": "6.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/phpunit-wrapper.git",
-                "reference": "de922c760dfddf8a33c4a066efcd0cd93576d957"
+                "reference": "d25db254173582bc27aa8c37cb04ce2481675bcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/de922c760dfddf8a33c4a066efcd0cd93576d957",
-                "reference": "de922c760dfddf8a33c4a066efcd0cd93576d957",
+                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/d25db254173582bc27aa8c37cb04ce2481675bcd",
+                "reference": "d25db254173582bc27aa8c37cb04ce2481675bcd",
                 "shasum": ""
             },
             "require": {
                 "phpunit/php-code-coverage": ">=4.0.4 <6.0",
-                "phpunit/phpunit": ">=5.7.27 <7.0",
+                "phpunit/phpunit": ">=5.7.27 <6.5.13",
                 "sebastian/comparator": ">=1.2.4 <3.0",
                 "sebastian/diff": ">=1.4 <4.0"
             },
@@ -1461,7 +1461,7 @@
                 }
             ],
             "description": "PHPUnit classes used by Codeception",
-            "time": "2018-09-12T20:19:47+00:00"
+            "time": "2019-01-01T15:39:52+00:00"
         },
         {
             "name": "codeception/stub",

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2018 Codegyre Developers Team, Consolidation Team
+Copyright (c) 2014-2019 Codegyre Developers Team, Consolidation Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -24,7 +24,7 @@ DEPENDENCY LICENSES:
 Name                                 Version  License
 consolidation/annotated-command      2.11.0   MIT
 consolidation/config                 1.1.1    MIT
-consolidation/log                    1.1.0    MIT
+consolidation/log                    1.1.1    MIT
 consolidation/output-formatters      3.4.0    MIT
 consolidation/self-update            1.1.5    MIT
 container-interop/container-interop  1.2.0    MIT

--- a/LICENSE
+++ b/LICENSE
@@ -21,24 +21,24 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 DEPENDENCY LICENSES:
 
-Name                                 Version  License
-consolidation/annotated-command      2.10.2   MIT
-consolidation/config                 1.1.1    MIT
-consolidation/log                    1.0.6    MIT
-consolidation/output-formatters      3.4.0    MIT
-consolidation/self-update            1.1.5    MIT
-container-interop/container-interop  1.2.0    MIT
-dflydev/dot-access-data              v1.1.0   MIT
-grasmash/expander                    1.0.0    MIT
-grasmash/yaml-expander               1.4.0    MIT
-league/container                     2.4.1    MIT
-psr/container                        1.0.0    MIT
-psr/log                              1.1.0    MIT
-symfony/console                      v4.2.1   MIT
-symfony/event-dispatcher             v4.2.1   MIT
-symfony/filesystem                   v4.2.1   MIT
-symfony/finder                       v3.4.20  MIT
-symfony/polyfill-ctype               v1.10.0  MIT
-symfony/polyfill-mbstring            v1.10.0  MIT
-symfony/process                      v4.2.1   MIT
-symfony/yaml                         v4.2.1   MIT
+Name                                 Version                               License
+consolidation/annotated-command      dev-improved-param-injection ac3ec8c  MIT
+consolidation/config                 1.1.1                                 MIT
+consolidation/log                    1.0.6                                 MIT
+consolidation/output-formatters      3.4.0                                 MIT
+consolidation/self-update            1.1.5                                 MIT
+container-interop/container-interop  1.2.0                                 MIT
+dflydev/dot-access-data              v1.1.0                                MIT
+grasmash/expander                    1.0.0                                 MIT
+grasmash/yaml-expander               1.4.0                                 MIT
+league/container                     2.4.1                                 MIT
+psr/container                        1.0.0                                 MIT
+psr/log                              1.1.0                                 MIT
+symfony/console                      v4.2.1                                MIT
+symfony/event-dispatcher             v4.2.1                                MIT
+symfony/filesystem                   v4.2.1                                MIT
+symfony/finder                       v3.4.20                               MIT
+symfony/polyfill-ctype               v1.10.0                               MIT
+symfony/polyfill-mbstring            v1.10.0                               MIT
+symfony/process                      v4.2.1                                MIT
+symfony/yaml                         v4.2.1                                MIT

--- a/LICENSE
+++ b/LICENSE
@@ -21,24 +21,24 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 DEPENDENCY LICENSES:
 
-Name                                 Version                               License
-consolidation/annotated-command      dev-improved-param-injection ac3ec8c  MIT
-consolidation/config                 1.1.1                                 MIT
-consolidation/log                    1.0.6                                 MIT
-consolidation/output-formatters      3.4.0                                 MIT
-consolidation/self-update            1.1.5                                 MIT
-container-interop/container-interop  1.2.0                                 MIT
-dflydev/dot-access-data              v1.1.0                                MIT
-grasmash/expander                    1.0.0                                 MIT
-grasmash/yaml-expander               1.4.0                                 MIT
-league/container                     2.4.1                                 MIT
-psr/container                        1.0.0                                 MIT
-psr/log                              1.1.0                                 MIT
-symfony/console                      v4.2.1                                MIT
-symfony/event-dispatcher             v4.2.1                                MIT
-symfony/filesystem                   v4.2.1                                MIT
-symfony/finder                       v3.4.20                               MIT
-symfony/polyfill-ctype               v1.10.0                               MIT
-symfony/polyfill-mbstring            v1.10.0                               MIT
-symfony/process                      v4.2.1                                MIT
-symfony/yaml                         v4.2.1                                MIT
+Name                                 Version  License
+consolidation/annotated-command      2.11.0   MIT
+consolidation/config                 1.1.1    MIT
+consolidation/log                    1.1.0    MIT
+consolidation/output-formatters      3.4.0    MIT
+consolidation/self-update            1.1.5    MIT
+container-interop/container-interop  1.2.0    MIT
+dflydev/dot-access-data              v1.1.0   MIT
+grasmash/expander                    1.0.0    MIT
+grasmash/yaml-expander               1.4.0    MIT
+league/container                     2.4.1    MIT
+psr/container                        1.0.0    MIT
+psr/log                              1.1.0    MIT
+symfony/console                      v4.2.1   MIT
+symfony/event-dispatcher             v4.2.1   MIT
+symfony/filesystem                   v4.2.1   MIT
+symfony/finder                       v3.4.20  MIT
+symfony/polyfill-ctype               v1.10.0  MIT
+symfony/polyfill-mbstring            v1.10.0  MIT
+symfony/process                      v4.2.1   MIT
+symfony/yaml                         v4.2.1   MIT

--- a/composer.json
+++ b/composer.json
@@ -22,18 +22,18 @@
     "bin":["robo"],
     "require": {
         "php": ">=5.5.0",
-        "league/container": "^2.2",
-        "consolidation/log": "~1",
+        "consolidation/annotated-command": "^2.11.0",
         "consolidation/config": "^1.0.10",
-        "consolidation/annotated-command": "^2.10.2",
+        "consolidation/log": "~1",
         "consolidation/output-formatters": "^3.1.13",
         "consolidation/self-update": "^1",
         "grasmash/yaml-expander": "^1.3",
-        "symfony/finder": "^2.5|^3|^4",
+        "league/container": "^2.2",
         "symfony/console": "^2.8|^3|^4",
-        "symfony/process": "^2.5|^3|^4",
+        "symfony/event-dispatcher": "^2.5|^3|^4",
         "symfony/filesystem": "^2.5|^3|^4",
-        "symfony/event-dispatcher": "^2.5|^3|^4"
+        "symfony/finder": "^2.5|^3|^4",
+        "symfony/process": "^2.5|^3|^4"
     },
     "require-dev": {
         "g1a/composer-test-scenarios": "^3",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=5.5.0",
         "consolidation/annotated-command": "^2.11.0",
         "consolidation/config": "^1.0.10",
-        "consolidation/log": "~1",
+        "consolidation/log": "^1.1.1",
         "consolidation/output-formatters": "^3.1.13",
         "consolidation/self-update": "^1",
         "grasmash/yaml-expander": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65157d13954d1720bb911a3b270cb4de",
+    "content-hash": "e2ad9fe01d90589af86e711d6f051335",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "dev-improved-param-injection",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "ac3ec8c1c97f2c007afba364d693cab480c4718c"
+                "reference": "edea407f57104ed518cc3c3b47d5b84403ee267a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/ac3ec8c1c97f2c007afba364d693cab480c4718c",
-                "reference": "ac3ec8c1c97f2c007afba364d693cab480c4718c",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/edea407f57104ed518cc3c3b47d5b84403ee267a",
+                "reference": "edea407f57104ed518cc3c3b47d5b84403ee267a",
                 "shasum": ""
             },
             "require": {
@@ -100,7 +100,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2018-12-28T02:29:34+00:00"
+            "time": "2018-12-29T04:43:17+00:00"
         },
         {
             "name": "consolidation/config",
@@ -158,31 +158,72 @@
         },
         {
             "name": "consolidation/log",
-            "version": "1.0.6",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/log.git",
-                "reference": "dfd8189a771fe047bf3cd669111b2de5f1c79395"
+                "reference": "44c65cb5861d8bbb01c185e49cd2807ed4405a75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/log/zipball/dfd8189a771fe047bf3cd669111b2de5f1c79395",
-                "reference": "dfd8189a771fe047bf3cd669111b2de5f1c79395",
+                "url": "https://api.github.com/repos/consolidation/log/zipball/44c65cb5861d8bbb01c185e49cd2807ed4405a75",
+                "reference": "44c65cb5861d8bbb01c185e49cd2807ed4405a75",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.0",
-                "psr/log": "~1.0",
+                "php": ">=5.4.5",
+                "psr/log": "^1.0",
                 "symfony/console": "^2.8|^3|^4"
             },
             "require-dev": {
-                "g1a/composer-test-scenarios": "^1",
-                "phpunit/phpunit": "4.*",
-                "satooshi/php-coveralls": "^2",
-                "squizlabs/php_codesniffer": "2.*"
+                "g1a/composer-test-scenarios": "^3",
+                "php-coveralls/php-coveralls": "^1",
+                "phpunit/phpunit": "^6",
+                "squizlabs/php_codesniffer": "^2"
             },
             "type": "library",
             "extra": {
+                "scenarios": {
+                    "symfony4": {
+                        "require": {
+                            "symfony/console": "^4.0"
+                        },
+                        "config": {
+                            "platform": {
+                                "php": "7.1.3"
+                            }
+                        }
+                    },
+                    "symfony2": {
+                        "require": {
+                            "symfony/console": "^2.8"
+                        },
+                        "require-dev": {
+                            "phpunit/phpunit": "^4.8.36"
+                        },
+                        "remove": [
+                            "php-coveralls/php-coveralls"
+                        ],
+                        "config": {
+                            "platform": {
+                                "php": "5.4.8"
+                            }
+                        }
+                    },
+                    "phpunit4": {
+                        "require-dev": {
+                            "phpunit/phpunit": "^4.8.36"
+                        },
+                        "remove": [
+                            "php-coveralls/php-coveralls"
+                        ],
+                        "config": {
+                            "platform": {
+                                "php": "5.4.8"
+                            }
+                        }
+                    }
+                },
                 "branch-alias": {
                     "dev-master": "1.x-dev"
                 }
@@ -203,7 +244,7 @@
                 }
             ],
             "description": "Improved Psr-3 / Psr\\Log logger based on Symfony Console components.",
-            "time": "2018-05-25T18:14:39+00:00"
+            "time": "2018-12-29T18:54:58+00:00"
         },
         {
             "name": "consolidation/output-formatters",
@@ -4057,20 +4098,21 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -4103,14 +4145,12 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "consolidation/annotated-command": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c87f64d18ac46a6166aa8e2bd6c1a841",
+    "content-hash": "65157d13954d1720bb911a3b270cb4de",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "2.10.2",
+            "version": "dev-improved-param-injection",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "5cbb8c320e0d3d2e6905374d56dc3610b7443f7b"
+                "reference": "ac3ec8c1c97f2c007afba364d693cab480c4718c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/5cbb8c320e0d3d2e6905374d56dc3610b7443f7b",
-                "reference": "5cbb8c320e0d3d2e6905374d56dc3610b7443f7b",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/ac3ec8c1c97f2c007afba364d693cab480c4718c",
+                "reference": "ac3ec8c1c97f2c007afba364d693cab480c4718c",
                 "shasum": ""
             },
             "require": {
@@ -100,7 +100,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2018-12-21T03:50:15+00:00"
+            "time": "2018-12-28T02:29:34+00:00"
         },
         {
             "name": "consolidation/config",
@@ -4108,7 +4108,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "consolidation/annotated-command": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e2ad9fe01d90589af86e711d6f051335",
+    "content-hash": "7585c852d8f6e6f1fef3b9c3ed4768c9",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -158,16 +158,16 @@
         },
         {
             "name": "consolidation/log",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/log.git",
-                "reference": "44c65cb5861d8bbb01c185e49cd2807ed4405a75"
+                "reference": "b2e887325ee90abc96b0a8b7b474cd9e7c896e3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/log/zipball/44c65cb5861d8bbb01c185e49cd2807ed4405a75",
-                "reference": "44c65cb5861d8bbb01c185e49cd2807ed4405a75",
+                "url": "https://api.github.com/repos/consolidation/log/zipball/b2e887325ee90abc96b0a8b7b474cd9e7c896e3a",
+                "reference": "b2e887325ee90abc96b0a8b7b474cd9e7c896e3a",
                 "shasum": ""
             },
             "require": {
@@ -244,7 +244,7 @@
                 }
             ],
             "description": "Improved Psr-3 / Psr\\Log logger based on Symfony Console components.",
-            "time": "2018-12-29T18:54:58+00:00"
+            "time": "2019-01-01T17:30:51+00:00"
         },
         {
             "name": "consolidation/output-formatters",
@@ -1406,21 +1406,21 @@
         },
         {
             "name": "codeception/phpunit-wrapper",
-            "version": "6.0.12",
+            "version": "6.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/phpunit-wrapper.git",
-                "reference": "de922c760dfddf8a33c4a066efcd0cd93576d957"
+                "reference": "d25db254173582bc27aa8c37cb04ce2481675bcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/de922c760dfddf8a33c4a066efcd0cd93576d957",
-                "reference": "de922c760dfddf8a33c4a066efcd0cd93576d957",
+                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/d25db254173582bc27aa8c37cb04ce2481675bcd",
+                "reference": "d25db254173582bc27aa8c37cb04ce2481675bcd",
                 "shasum": ""
             },
             "require": {
                 "phpunit/php-code-coverage": ">=4.0.4 <6.0",
-                "phpunit/phpunit": ">=5.7.27 <7.0",
+                "phpunit/phpunit": ">=5.7.27 <6.5.13",
                 "sebastian/comparator": ">=1.2.4 <3.0",
                 "sebastian/diff": ">=1.4 <4.0"
             },
@@ -1448,7 +1448,7 @@
                 }
             ],
             "description": "PHPUnit classes used by Codeception",
-            "time": "2018-09-12T20:19:47+00:00"
+            "time": "2019-01-01T15:39:52+00:00"
         },
         {
             "name": "codeception/stub",

--- a/examples/src/Robo/Plugin/Commands/ExampleCommands.php
+++ b/examples/src/Robo/Plugin/Commands/ExampleCommands.php
@@ -9,6 +9,7 @@ use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Example Robo Plugin Commands.
@@ -170,18 +171,19 @@ class ExampleCommands extends \Robo\Tasks
     }
 
     /**
-     * Demonstrate use of Symfony $input object in Robo in place of
-     * the usual "parameter arguments".
+     * Demonstrate use of SymfonyStyle $io object and Symfony $input object in
+     * Robo in place of the usual "parameter arguments".
      *
      * @arg array $a A list of commandline parameters.
      * @option foo
      * @default a []
      * @default foo []
      */
-    public function trySymfony(InputInterface $input)
+    public function trySymfony(SymfonyStyle $io, InputInterface $input)
     {
+        $io->title('Symfony Style demo');
         $a = $input->getArgument('a');
-        $this->say("The parameters passed are:\n" . var_export($a, true));
+        $io->writeln("The parameters passed are:\n" . var_export($a, true));
         $foo = $input->getOption('foo');
         if (!empty($foo)) {
             $this->say("The options passed via --foo are:\n" . var_export($foo, true));

--- a/examples/src/Robo/Plugin/Commands/ExampleCommands.php
+++ b/examples/src/Robo/Plugin/Commands/ExampleCommands.php
@@ -190,6 +190,13 @@ class ExampleCommands extends \Robo\Tasks
         }
     }
 
+    public function tryText()
+    {
+        $this->io()->text('This is some text');
+        $this->io()->text('This is some more text');
+        $this->io()->text('This is the last text');
+    }
+
     /**
      * Demonstrate Robo boolean options.
      *

--- a/src/Application.php
+++ b/src/Application.php
@@ -9,10 +9,13 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 
-class Application extends SymfonyApplication implements IOAwareInterface
+class Application extends SymfonyApplication implements IOAwareInterface, LoggerAwareInterface
 {
     use IO;
+    use LoggerAwareTrait;
 
     /**
      * @param string $name
@@ -82,5 +85,13 @@ class Application extends SymfonyApplication implements IOAwareInterface
     {
         parent::configureIO($input, $output);
         $this->resetIO($input, $output);
+        if ($this->logger instanceof \Consolidation\Log\LoggerManager) {
+            $this->logger->add('default', $this->createLogger($output));
+        }
+    }
+
+    protected function createLogger($output)
+    {
+        return new \Robo\Log\RoboLogger($output);
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,13 +1,19 @@
 <?php
 namespace Robo;
 
+use Robo\Contract\IOAwareInterface;
+use Robo\Common\IO;
 use SelfUpdate\SelfUpdateCommand;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
-class Application extends SymfonyApplication
+class Application extends SymfonyApplication implements IOAwareInterface
 {
+    use IO;
+
     /**
      * @param string $name
      * @param string $version
@@ -70,5 +76,11 @@ class Application extends SymfonyApplication
         }
         $selfUpdateCommand = new SelfUpdateCommand($this->getName(), $this->getVersion(), $repository);
         $this->add($selfUpdateCommand);
+    }
+
+    protected function configureIO(InputInterface $input, OutputInterface $output)
+    {
+        parent::configureIO($input, $output);
+        $this->resetIO($input, $output);
     }
 }

--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -1,20 +1,58 @@
 <?php
 namespace Robo\Common;
 
+use Robo\Symfony\IOStorage;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 trait IO
 {
-    use InputAwareTrait;
-    use OutputAwareTrait;
+    use InputAwareTrait {
+        input as parentInput;
+    }
+    use OutputAwareTrait {
+        output as parentOutput;
+    }
 
     /**
      * @var \Symfony\Component\Console\Style\SymfonyStyle
      */
-    protected $io;
+    protected $ioStorage;
+
+    public function setIOStorage(IOStorage $ioStorage)
+    {
+        $this->ioStorage = $ioStorage;
+    }
+
+    public function resetIO(InputInterface $input, OutputInterface $output)
+    {
+        if (!$this->ioStorage) {
+            $this->ioStorage = new IOStorage();
+        }
+        $this->ioStorage->create($input, $output);
+    }
+
+    protected function output()
+    {
+        $result = null;
+        if ($this->ioStorage) {
+            $result = $this->ioStorage->output();
+        }
+        return $result ?: $this->parentOutput();
+    }
+
+    protected function input()
+    {
+        $result = null;
+        if ($this->ioStorage) {
+            $result = $this->ioStorage->input();
+        }
+        return $result ?: $this->parentInput();
+    }
 
     /**
      * Provide access to SymfonyStyle object.
@@ -25,10 +63,10 @@ trait IO
      */
     protected function io()
     {
-        if (!$this->io) {
-            $this->io = new SymfonyStyle($this->input(), $this->output());
+        if (!$this->ioStorage) {
+            $this->ioStorage = new IOStorage();
         }
-        return $this->io;
+        return $this->ioStorage->get($this->input, $this->output);
     }
 
     /**

--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -19,7 +19,7 @@ trait IO
     }
 
     /**
-     * @var \Symfony\Component\Console\Style\SymfonyStyle
+     * @var Robo\Symfony\IOStorage
      */
     protected $ioStorage;
 

--- a/src/Contract/IOAwareInterface.php
+++ b/src/Contract/IOAwareInterface.php
@@ -6,8 +6,13 @@
 
 namespace Robo\Contract;
 
-use \Symfony\Component\Console\Input\InputAwareInterface;
+use Robo\Symfony\IOStorage;
+use Symfony\Component\Console\Input\InputAwareInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 interface IOAwareInterface extends OutputAwareInterface, InputAwareInterface
 {
+    public function setIOStorage(IOStorage $ioStorage);
+    public function resetIO(InputInterface $input, OutputInterface $output);
 }

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -237,10 +237,14 @@ class Robo
             ->withMethodCall('addDefaultSimplifiers', []);
         $container->share('prepareTerminalWidthOption', \Consolidation\AnnotatedCommand\Options\PrepareTerminalWidthOption::class)
             ->withMethodCall('setApplication', ['application']);
+        $container->share('symfonyStyleInjector', \Robo\Symfony\SymfonyStyleInjector::class);
+        $container->share('parameterInjection', \Consolidation\AnnotatedCommand\ParameterInjection::class)
+            ->withMethodCall('register', ['Symfony\Component\Console\Style\SymfonyStyle', 'symfonyStyleInjector']);
         $container->share('commandProcessor', \Consolidation\AnnotatedCommand\CommandProcessor::class)
             ->withArgument('hookManager')
             ->withMethodCall('setFormatterManager', ['formatterManager'])
             ->withMethodCall('addPrepareFormatter', ['prepareTerminalWidthOption'])
+            ->withMethodCall('setParameterInjection', ['parameterInjection'])
             ->withMethodCall(
                 'setDisplayErrorFunction',
                 [

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -163,6 +163,9 @@ class Robo
         if ($app instanceof \Robo\Contract\IOAwareInterface) {
             $app->setIOStorage($container->get('ioStorage'));
         }
+        if ($app instanceof \Psr\Log\LoggerAwareInterface) {
+            $app->setLogger($container->get('logger'));
+        }
     }
 
     /**
@@ -214,9 +217,12 @@ class Robo
 
         // Register logging and related services.
         $container->share('logStyler', \Robo\Log\RoboLogStyle::class);
-        $container->share('logger', \Robo\Log\RoboLogger::class)
-            ->withArgument('output')
-            ->withMethodCall('setLogOutputStyler', ['logStyler']);
+        $container->share('roboLogger', \Robo\Log\RoboLogger::class)
+            ->withMethodCall('setLogOutputStyler', ['logStyler'])
+            ->withArgument('output');
+        $container->share('logger', \Consolidation\Log\LoggerManager::class)
+            ->withMethodCall('setLogOutputStyler', ['logStyler'])
+            ->withMethodCall('fallbackLogger', ['roboLogger']);
         $container->add('progressBar', \Symfony\Component\Console\Helper\ProgressBar::class)
             ->withArgument('output');
         $container->share('progressIndicator', \Robo\Common\ProgressIndicator::class)

--- a/src/Symfony/IOStorage.php
+++ b/src/Symfony/IOStorage.php
@@ -1,0 +1,127 @@
+<?php
+namespace Robo\Symfony;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * IOStorage insures that a single common style object is
+ * used by all IOAware classes.
+ */
+class IOStorage
+{
+    /**
+     * @var \Symfony\Component\Console\Style\SymfonyStyle
+     */
+    protected $io;
+
+    /**
+     * @var \Symfony\Component\Console\Input\InputInterface
+     */
+    protected $input;
+
+    /**
+     * @var \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected $output;
+
+    /**
+     * @var string
+     */
+    protected $styleClass = '\Symfony\Component\Console\Style\SymfonyStyle';
+
+    public function clear()
+    {
+        $this->input = null;
+        $this->output = null;
+        $this->io = null;
+    }
+
+    /**
+     * setStyleClass sets a new style class to use.
+     *
+     * @param string $styleClass Name of class to instantiate when style object
+     *   is requested. Must be a subclass of SymfonyStyle.
+     */
+    public function setStyleClass($styleClass)
+    {
+        $this->styleClass = $styleClass;
+        $this->recreate();
+    }
+
+    /**
+     * hasStyle indicates whether there is a cached style available
+     *
+     * @return bool
+     */
+    public function hasStyle()
+    {
+        return !empty($this->io);
+    }
+
+    /**
+     * create will instantiate a new style instance, replacing what was
+     * there before.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return SymfonyStyle
+     */
+    public function create(InputInterface $input, OutputInterface $output)
+    {
+        $this->input = $input;
+        $this->output = $output;
+        return $this->instantiate();
+    }
+
+    /**
+     * recreate will make a new style object iff we have cached $input
+     * and $output objects. Otherwise it clears the cached style object.
+     */
+    protected function recreate()
+    {
+        if (!empty($this->input) && !empty($this->output)) {
+            return $this->instantiate();
+        }
+        $this->io = null;
+        return null;
+    }
+
+    /**
+     * instantiate will make a new style object from the cached input and
+     * output objects.
+     */
+    protected function instantiate()
+    {
+        $this->io = new $this->styleClass($this->input, $this->output);
+        return $this->cached();
+    }
+
+    /**
+     * get will return the cached style object, if it exists; otherwise,
+     * it will create and cache a new style object using the provided
+     * input and output objects.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return SymfonyStyle
+     */
+    public function get(InputInterface $input, OutputInterface $output)
+    {
+        if (!$this->hasStyle()) {
+            $this->create($input, $output);
+        }
+        return $this->cached();
+    }
+
+    /**
+     * cached returns the cached style object, or null if none is available.
+     *
+     * @return SymfonyStyle|null
+     */
+    public function cached()
+    {
+        return $this->io;
+    }
+}

--- a/src/Symfony/SymfonyStyleInjector.php
+++ b/src/Symfony/SymfonyStyleInjector.php
@@ -1,0 +1,15 @@
+<?php
+namespace Robo\Symfony;
+
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\CommandProcessor;
+use Consolidation\AnnotatedCommand\ParameterInjector;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class SymfonyStyleInjector implements ParameterInjector
+{
+    public function get(CommandData $commandData, $interfaceName)
+    {
+        return new SymfonyStyle($commandData->input(), $commandData->output());
+    }
+}


### PR DESCRIPTION
### Overview
This pull request:

- [x] Improves the dependency injection architecture
- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
The existing Robo DI container adds a reference to the $input and $output objects. Application::run() also takes $input and $output as parameters. What happens, then, if you want to call Application::run() multiple times with different $input and $output objects?

The answer is that some of the code will use the correct $input and $output objects, but other code will use whatever $input and $output were injected into the DI container, which would produce incorrect results. It would be better to simply not have any reference to $input and $output in the DI container at all; however, a lot of objects inject the logger, which needs $output, and a lot of commands implement IOAwareInterface, which has references to both.

This PR allows commands to take a SymfonyStyle object as a parameter, so that they do not need to use $this->io() any longer. Efforts are also made to keep the IO object updated when Application::run() is called for use by legacy applications. Some updates may be needed to "Robo as a Framework" applications in order for the legacy support to work right; however, legacy applications will not behave any worse than they currently do (references to $input and $output for IOAwareInterface objects will come from the DI container if the updates are not made).

Maybe in Robo 2.x we might be able to not inject $input and $output into the DI container at all, and require classes to either use SymfonyStyle parameter injection, or use IOAwareInterface. Direct access to OutputAwareInterface / InputAwareInterface is deprecated.

We also use the logger manager to remove references to $output from the logger. We create a logger at Application::run() time, when $output is available, and add that to the logger manager.