### PR TITLE
Add stderr() convenience method to Robo\Common\IO.

### DIFF
--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -3,11 +3,12 @@ namespace Robo\Common;
 
 use Robo\Symfony\IOStorage;
 use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 trait IO
 {
@@ -43,6 +44,15 @@ trait IO
             $result = $this->ioStorage->output();
         }
         return $result ?: $this->parentOutput();
+    }
+
+    protected function stderr()
+    {
+        $output = $this->output();
+        if ($output instanceof ConsoleOutputInterface) {
+            $output = $output->getErrorOutput();
+        }
+        return $output;
     }
 
     protected function input()


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
We need a trivial helper function to give us access to stderr (when available)