### PR TITLE
Use $argv directly in framework documentation

### DIFF
--- a/docs/framework.md
+++ b/docs/framework.md
@@ -60,7 +60,6 @@ $runner
   ->setClassLoader($classLoader);
 
 // Execute the command and return the result.
-$argv = $_SERVER['argv'];
 $output = new \Symfony\Component\Console\Output\ConsoleOutput();
 $statusCode = $runner->execute($argv, $appName, $appVersion, $output);
 exit($statusCode);


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [x] Fixes documentation

### Summary
In command line PHP scripts the variable $argv is prefilled with command line parameters to the script. The deleted line is doubling this and in addition, most coding style tools make it an issue to use unfiltered globals.

Filtering that global (like in `$argv = filter_input_array($_SERVER['argv'])`) results in plenty of errors. 

Lastly it probably results in validation errors because $argv is a reserved variable. 

### Description
see http://php.net/manual/en/reserved.variables.argv.php
see consolidation/Robo#839