### PR TITLE
Added the exists() method to FilesystemStack

### DIFF
--- a/src/Task/Filesystem/FilesystemStack.php
+++ b/src/Task/Filesystem/FilesystemStack.php
@@ -36,6 +36,7 @@ use Robo\Common\BuilderAwareTrait;
  * @method $this remove(string|array|\Traversable $file)
  * @method $this rename(string $from, string $to, bool $force = false)
  * @method $this symlink(string $from, string $to, bool $copyOnWindows = false)
+ * @method $this exists(string|iterable $files)
  * @method $this mirror(string $from, string $to, \Traversable $iterator = null, array $options = [])
  */
 class FilesystemStack extends StackBasedTask implements BuilderAwareInterface
@@ -122,6 +123,17 @@ class FilesystemStack extends StackBasedTask implements BuilderAwareInterface
         }
         return true;
     }
+
+    /**
+     * @param string|iterable $files
+     *
+     * @return bool
+     */
+    protected function _exists($files)
+    {
+        $this->fs->exists($files);
+    }
+
 
     /**
      * @param string $origin


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Adds a missing `exists()` method to the taskFilesystemStack.

### Description
For a project I needed to check if a given directory and/or file exists. As this method exists on the [Filesystem component of Symfony](https://github.com/symfony/symfony/blob/4.2/src/Symfony/Component/Filesystem/Filesystem.php), I thought it would be nice to add this method to Robo's FilesystemStack as well.
