### PR TITLE
Add sample with changed file handling to Base/Watch documentation

### DIFF
--- a/src/Task/Base/Watch.php
+++ b/src/Task/Base/Watch.php
@@ -37,9 +37,9 @@ use Robo\Task\BaseTask;
  *      )->run();
  * ?>
  * ```
- * 
+ *
  * Pass through the changed file to the callable function
- * 
+ *
  * ```
  * $this
  *  ->taskWatch()
@@ -53,7 +53,7 @@ use Robo\Task\BaseTask;
  *  )
  *  ->run();
  * ```
- * 
+ *
  * The $event parameter is a [standard Symfony file resource object](https://api.symfony.com/3.1/Symfony/Component/Config/Resource/FileResource.html)
  */
 class Watch extends BaseTask

--- a/src/Task/Base/Watch.php
+++ b/src/Task/Base/Watch.php
@@ -37,6 +37,24 @@ use Robo\Task\BaseTask;
  *      )->run();
  * ?>
  * ```
+ * 
+ * Pass through the changed file to the callable function
+ * 
+ * ```
+ * $this
+ *  ->taskWatch()
+ *  ->monitor(
+ *      'filename',
+ *      function ($event) {
+ *          $resource = $event->getResource();
+ *          ... do something with (string)$resource ...
+ *      },
+ *      FilesystemEvent::ALL
+ *  )
+ *  ->run();
+ * ```
+ * 
+ * The $event parameter is a [standard Symfony file resource object](https://api.symfony.com/3.1/Symfony/Component/Config/Resource/FileResource.html)
  */
 class Watch extends BaseTask
 {


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [x] Adds documentation

### Summary
See consolidation/Robo#845 for this. Requested was a way to know which file(s) are changed when calling the `$callable` parameter. This is available via Lurker, but not documented yet. 
