### PR TITLE
Fixes #849: Allow default argument for confirm() questions.

### DIFF
--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -125,12 +125,13 @@ trait IO
 
     /**
      * @param string $question
+     * @param bool $default
      *
      * @return string
      */
-    protected function confirm($question)
+    protected function confirm($question, $default = false)
     {
-        return $this->doAsk(new ConfirmationQuestion($this->formatQuestion($question . ' (y/n)'), false));
+        return $this->doAsk(new ConfirmationQuestion($this->formatQuestion($question . ' (y/n)'), $default));
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:
- [x] Adds a feature
- [ ] Has tests that cover changes

### Summary
Allow a default argument for confirm() prompts so they can be run non-interactively (BLT currently has to override this method to allow a default argument). This also aligns more closely with the super method in Symfony, which takes a default argument.

It's a somewhat trivial change, not sure if it needs dedicated tests.