### PR TITLE
Rename callCollectionStateFuntion to callCollectionStateFunction

### DIFF
--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -273,20 +273,20 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
 
     public function storeState($key, $source = '')
     {
-        return $this->callCollectionStateFuntion(__FUNCTION__, func_get_args());
+        return $this->callCollectionStateFunction(__FUNCTION__, func_get_args());
     }
 
     public function deferTaskConfiguration($functionName, $stateKey)
     {
-        return $this->callCollectionStateFuntion(__FUNCTION__, func_get_args());
+        return $this->callCollectionStateFunction(__FUNCTION__, func_get_args());
     }
 
     public function defer($callback)
     {
-        return $this->callCollectionStateFuntion(__FUNCTION__, func_get_args());
+        return $this->callCollectionStateFunction(__FUNCTION__, func_get_args());
     }
 
-    protected function callCollectionStateFuntion($functionName, $args)
+    protected function callCollectionStateFunction($functionName, $args)
     {
         $currentTask = ($this->currentTask instanceof WrappedTaskInterface) ? $this->currentTask->original() : $this->currentTask;
 


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [x] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
There was a typo in a method name in the CollectionBuilder class. Thankfully it is a protected method so it should be somewhat safe from API breaks.