### PR TITLE
ImageMinify: Prevent undefined variable error

### DIFF
--- a/src/Task/Assets/ImageMinify.php
+++ b/src/Task/Assets/ImageMinify.php
@@ -339,6 +339,8 @@ class ImageMinify extends BaseTask
 
         // loop through the files
         foreach ($files as $from => $to) {
+            $minifier = '';
+
             if (!isset($this->minifier)) {
                 // check filetype based on the extension
                 $extension = strtolower(pathinfo($from, PATHINFO_EXTENSION));


### PR DESCRIPTION
If the given imagefile is not one of the defaults (png/jpg/gif/svg) and no minifier was passed to the ImageMinify task a warning for an undefined variable is show.

Prevent this by setting an empty string to the beginning of the file check.

Refs #852

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Adds an empty variable string to the beginning of the loop to check for matching minifiers. This will prevent trying to access a non existing variable later on.

### Note

This bugfix is for the master (Development version 2.x).

It may also be cherry-picked to the `1.x` branch as well (I could send a second PR as well).