### PR TITLE
ImageMinify: Prevent undefined variable error (#852) (backport for 1.x)

### DIFF
--- a/src/Task/Assets/ImageMinify.php
+++ b/src/Task/Assets/ImageMinify.php
@@ -339,6 +339,8 @@ class ImageMinify extends BaseTask
 
         // loop through the files
         foreach ($files as $from => $to) {
+            $minifier = '';
+
             if (!isset($this->minifier)) {
                 // check filetype based on the extension
                 $extension = strtolower(pathinfo($from, PATHINFO_EXTENSION));


### PR DESCRIPTION
Followup for PR #853 

Backports the fix for issue #852 into 1.x branch.

Refs #852

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
See #853 