### PR TITLE
Adding documentation as option to pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@ This pull request:
 - [ ] Adds a feature
 - [ ] Breaks backwards compatibility
 - [ ] Has tests that cover changes
+- [ ] Adds or fixes documentation
 
 ### Summary
 Short overview of what changed.


### PR DESCRIPTION
I often run into pull requests that add or fix the documentation. This should be an option in the pull request template.