### PR TITLE
Updating phpdoc to reflect correct typecast

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -21,7 +21,7 @@ class Runner implements ContainerAwareInterface
     use ContainerAwareTrait;
 
     /**
-     * @var string
+     * @var string|array
      */
     protected $roboClass;
 
@@ -68,8 +68,8 @@ class Runner implements ContainerAwareInterface
     /**
      * Class Constructor
      *
-     * @param null|string $roboClass
-     * @param null|string $roboFile
+     * @param null|string|array $roboClass
+     * @param null|string       $roboFile
      */
     public function __construct($roboClass = null, $roboFile = null)
     {


### PR DESCRIPTION
### Overview
The parameter roboClass of the constructor accepts string and array (as per https://robo.li/framework/), but is commented so that only string is expected.

- [x ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

