### PR TITLE
Tiny formatting fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ All protected methods in traits that start with `task` prefix are tasks and can 
 ## Examples
 
 The best way to learn Robo by example is to take a look into [its own RoboFile](https://github.com/consolidation/Robo/blob/master/RoboFile.php)
- or [RoboFile of Codeception project](https://github.com/Codeception/Codeception/blob/2.4/RoboFile.php). There are also some basic example commands in examples/RoboFile.php.
+ or [RoboFile of Codeception project](https://github.com/Codeception/Codeception/blob/2.4/RoboFile.php). There are also some basic example commands in `examples/RoboFile.php`.
 
 Here are some snippets from them:
 


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
A tiny markdown formatting fix/improvement to the README

