### PR TITLE
Allow command classes to end in Commands or Command.

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -2,7 +2,7 @@
 
 Robo tasks can be added to your Robo application by using Composer to suppliment the set of built-in tasks that Robo provides by default. To find existing Robo task extensions, search in Packagist for projects of type [robo-tasks](https://packagist.org/search/?type=robo-tasks).
 
-The convention used to add new tasks for use in your RoboFiles is to create a wrapper trait named `Tasks` in your namespace that instantiates the implementation class for each task. Each task method in the trait should start with the prefix `task`, and should use **chained method calls** for configuration. Task execution should be triggered by the method `run`. 
+The convention used to add new tasks for use in your RoboFiles is to create a wrapper trait named `Tasks` in your namespace that instantiates the implementation class for each task. Each task method in the trait should start with the prefix `task`, and should use **chained method calls** for configuration. Task execution should be triggered by the method `run`.
 
 To include additional tasks in your RoboFile, you must `use` the appropriate `Tasks` in your RoboFile. See the section [Including Additional Tasks](#including-additional-tasks) below. To create your own Robo extension that provides tasks for use in RoboFiles, then you must write your own class that implements TaskInterface, and create a `Tasks` trait for it as described in the section [Creating a Robo Extension](#creating-a-robo-extension).
 
@@ -22,7 +22,7 @@ Once the extension you wish to use has been added to your vendor directory, you 
 class RoboFile extends \Robo\Tasks
 {
   use \Boedah\Robo\Task\Drush\Tasks;
-  
+
   public function test()
   {
     // ...
@@ -72,13 +72,13 @@ class MyCustomCommands extends \Robo\Tasks
 ```
 
 Please note: command files classes must be placed under `Robo/Plugin/Commands` relative namespace and their name
-must end in `Commands.php`.
+must end in `Command.php` or `Commands.php`.
 
 You can now access your new commands via Robo:
 
 ```
-$ ./vendor/bin/robo 
-$ ./robo 
+$ ./vendor/bin/robo
+$ ./robo
 Robo 1.2.2-dev
 
 Usage:
@@ -89,8 +89,8 @@ Available commands:
   help                  Displays help for a command
   list                  Lists commands
  my-project
-  my-project:command-one       
-  my-project:command-two        
+  my-project:command-one
+  my-project:command-two
 ```
 
 ## Creating a Robo Extension

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -267,7 +267,7 @@ class Runner implements ContainerAwareInterface
         /** @var \Robo\ClassDiscovery\RelativeNamespaceDiscovery $discovery */
         $discovery = Robo::service('relativeNamespaceDiscovery');
         $discovery->setRelativeNamespace($relativeNamespace.'\Commands')
-            ->setSearchPattern('*Commands.php');
+            ->setSearchPattern('/.*Commands?\.php$/');
         return $discovery->getClasses();
     }
 

--- a/tests/plugins/Robo/Plugin/Commands/ThirdCustomCommand.php
+++ b/tests/plugins/Robo/Plugin/Commands/ThirdCustomCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Robo\PluginTest\Robo\Plugin\Commands;
+
+/**
+ * Class ThirdCustomCommand
+ *
+ * @package Robo\Commands
+ */
+class ThirdCustomCommand
+{
+    /**
+     * @command custom:command-five
+     */
+    public function commandFive()
+    {
+    }
+
+    /**
+     * @command custom:command-six
+     */
+    public function commandSix()
+    {
+    }
+}

--- a/tests/unit/ClassDiscovery/RelativeNamespaceDiscoveryTest.php
+++ b/tests/unit/ClassDiscovery/RelativeNamespaceDiscoveryTest.php
@@ -14,11 +14,12 @@ class RelativeNamespaceDiscoveryTest extends \Codeception\Test\Unit
         $classLoader->addPsr4('\\Robo\\PluginTest\\', [realpath(__DIR__.'/../../plugins')]);
         $service = new RelativeNamespaceDiscovery($classLoader);
         $service->setRelativeNamespace('Robo\Plugin');
-        $service->setSearchPattern('*Commands.php');
+        $service->setSearchPattern('/.*Commands?\.php$/');
         $classes = $service->getClasses();
 
         $this->assertContains('\Robo\PluginTest\Robo\Plugin\Commands\FirstCustomCommands', $classes);
         $this->assertContains('\Robo\PluginTest\Robo\Plugin\Commands\SecondCustomCommands', $classes);
+        $this->assertContains('\Robo\PluginTest\Robo\Plugin\Commands\ThirdCustomCommand', $classes);
         $this->assertNotContains('\Robo\PluginTest\Robo\Plugin\Commands\NotValidClassName', $classes);
     }
 
@@ -34,6 +35,10 @@ class RelativeNamespaceDiscoveryTest extends \Codeception\Test\Unit
 
         $actual = $service->getFile('\Robo\PluginTest\Robo\Plugin\Commands\SecondCustomCommands');
         $this->assertStringEndsWith('SecondCustomCommands.php', $actual);
+
+
+        $actual = $service->getFile('\Robo\PluginTest\Robo\Plugin\Commands\ThirdCustomCommand');
+        $this->assertStringEndsWith('ThirdCustomCommand.php', $actual);
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [x] Adds a feature
- [x] Has tests that cover changes

### Summary
This PR allows command classes to end in both Commands or Command, and (because of PSR-4) the files in Commands.php or Command.php

### Description
In my head it makes more sense to have a command file/class per command, in stead of one with multiple. You could perfectly do this right now, but the filename wouldn't make sense. It's a bit of a nitpick, but it just seems cleaner in my mind.
