### PR TITLE
Fix PHPDoc @param and @return type hints

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -59,8 +59,9 @@ class RoboFile extends \Robo\Tasks
     /**
      * Generate a new Robo task that wraps an existing utility class.
      *
-     * @param $className The name of the existing utility class to wrap.
-     * @param $wrapperClassName The name of the wrapper class to create. Optional.
+     * @param string $className The name of the existing utility class to wrap.
+     * @param string $wrapperClassName The name of the wrapper class to create. Optional.
+     *
      * @usage generate:task 'Symfony\Component\Filesystem\Filesystem' FilesystemStack
      */
     public function generateTask($className, $wrapperClassName = "")

--- a/examples/src/Robo/Plugin/Commands/ExampleCommands.php
+++ b/examples/src/Robo/Plugin/Commands/ExampleCommands.php
@@ -191,7 +191,7 @@ class ExampleCommands extends \Robo\Tasks
     /**
      * Demonstrate Robo boolean options.
      *
-     * @param $opts The options.
+     * @param array $opts The options.
      * @option boolean $silent Supress output.
      */
     public function tryOptbool($opts = ['silent|s' => false])

--- a/src/Application.php
+++ b/src/Application.php
@@ -61,7 +61,8 @@ class Application extends SymfonyApplication
     /**
      * Add self update command, do nothing if null is provided
      *
-     * @param string $repository GitHub Repository for self update
+     * @param string $repository
+     *   GitHub Repository for self update.
      */
     public function addSelfUpdateCommand($repository = null)
     {

--- a/src/ClassDiscovery/ClassDiscoveryInterface.php
+++ b/src/ClassDiscovery/ClassDiscoveryInterface.php
@@ -10,7 +10,7 @@ namespace Robo\ClassDiscovery;
 interface ClassDiscoveryInterface
 {
     /**
-     * @param $searchPattern
+     * @param string $searchPattern
      *
      * @return $this
      */
@@ -22,7 +22,7 @@ interface ClassDiscoveryInterface
     public function getClasses();
 
     /**
-     * @param $class
+     * @param string $class
      *
      * @return string|null
      */

--- a/src/ClassDiscovery/RelativeNamespaceDiscovery.php
+++ b/src/ClassDiscovery/RelativeNamespaceDiscovery.php
@@ -35,7 +35,7 @@ class RelativeNamespaceDiscovery extends AbstractClassDiscovery
     /**
      * @param string $relativeNamespace
      *
-     * @return RelativeNamespaceDiscovery
+     * @return $this
      */
     public function setRelativeNamespace($relativeNamespace)
     {
@@ -45,7 +45,7 @@ class RelativeNamespaceDiscovery extends AbstractClassDiscovery
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function getClasses()
     {
@@ -77,8 +77,8 @@ class RelativeNamespaceDiscovery extends AbstractClassDiscovery
     }
 
     /**
-     * @param $directories
-     * @param $pattern
+     * @param string|array $directories
+     * @param string $pattern
      *
      * @return \Symfony\Component\Finder\Finder
      */
@@ -93,9 +93,9 @@ class RelativeNamespaceDiscovery extends AbstractClassDiscovery
     }
 
     /**
-     * @param $path
+     * @param string $path
      *
-     * @return mixed
+     * @return string
      */
     protected function convertPathToNamespace($path)
     {
@@ -103,6 +103,8 @@ class RelativeNamespaceDiscovery extends AbstractClassDiscovery
     }
 
     /**
+     * @param string $namespace
+     *
      * @return string
      */
     public function convertNamespaceToPath($namespace)

--- a/src/Collection/CallableTask.php
+++ b/src/Collection/CallableTask.php
@@ -32,7 +32,7 @@ class CallableTask implements TaskInterface
     }
 
     /**
-     * @return \Robo\Result
+     * {@inheritdoc}
      */
     public function run()
     {
@@ -52,6 +52,9 @@ class CallableTask implements TaskInterface
         return $result;
     }
 
+    /**
+     * @return \Robo\State\Data
+     */
     public function getState()
     {
         if ($this->reference instanceof StateAwareInterface) {

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -42,17 +42,17 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
     protected $taskList = [];
 
     /**
-     * @var TaskInterface[]
+     * @var \Robo\Contract\TaskInterface[]
      */
     protected $rollbackStack = [];
 
     /**
-     * @var TaskInterface[]
+     * @var \Robo\Contract\TaskInterface[]
      */
     protected $completionStack = [];
 
     /**
-     * @var CollectionInterface
+     * @var \Robo\Collection\CollectionInterface
      */
     protected $parentCollection;
 
@@ -74,6 +74,9 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
         $this->resetState();
     }
 
+    /**
+     * @param int $interval
+     */
     public function setProgressBarAutoDisplayInterval($interval)
     {
         if (!$this->progressIndicator) {
@@ -209,7 +212,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
      *
      * @param string $method
      * @param string $name
-     * @param callable|TaskInterface $task
+     * @param callable|\Robo\Contract\TaskInterface $task
      * @param string $nameOfTaskToAdd
      *
      * @return $this
@@ -280,7 +283,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
     /**
      * Return the list of task names added to this collection.
      *
-     * @return array
+     * @return string[]
      */
     public function taskNames()
     {
@@ -308,7 +311,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
      * @param string $name
      *   The name of the task to insert before.  The named task MUST exist.
      *
-     * @return Element
+     * @return \Robo\Collection\Element
      *   The task group for the named task. Generally this is only
      *   used to call 'before()' and 'after()'.
      */
@@ -323,7 +326,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
     /**
      * Add a list of tasks to our task collection.
      *
-     * @param TaskInterface[] $tasks
+     * @param \Robo\Contract\TaskInterface[] $tasks
      *   An array of tasks to run with rollback protection
      *
      * @return $this
@@ -342,7 +345,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
      * @param string $name
      * @param \Robo\Contract\TaskInterface $task
      *
-     * @return \Robo\Collection\Collection
+     * @return $this
      */
     protected function addToTaskList($name, TaskInterface $task)
     {
@@ -392,7 +395,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
     /**
      * Get the appropriate parent collection to use
      *
-     * @return CollectionInterface
+     * @return \Robo\Collection\CollectionInterface|$this
      */
     public function getParentCollection()
     {
@@ -413,8 +416,10 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
      * function directly is to add a task that sends notification
      * when a task fails.
      *
-     * @param TaskInterface $rollbackTask
+     * @param \Robo\Contract\TaskInterface $rollbackTask
      *   The rollback task to run on failure.
+     *
+     * @return null
      */
     public function registerRollback(TaskInterface $rollbackTask)
     {
@@ -441,8 +446,10 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
      * the nested task completes; they are not deferred to the end of
      * the containing collection's execution.
      *
-     * @param TaskInterface $completionTask
+     * @param \Robo\Contract\TaskInterface $completionTask
      *   The completion task to run at the end of all other operations.
+     *
+     * @return null
      */
     public function registerCompletion(TaskInterface $completionTask)
     {
@@ -547,7 +554,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
      * Return the failing result, or success if all tasks run.
      *
      * @param string $name
-     * @param TaskInterface[] $taskList
+     * @param \Robo\Contract\TaskInterface[] $taskList
      * @param \Robo\Result $result
      *
      * @return \Robo\Result
@@ -641,7 +648,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
     }
 
     /**
-     * @param TaskInterface|NestedCollectionInterface|WrappedTaskInterface $task
+     * @param \Robo\Contract\TaskInterface|\Robo\Collection\NestedCollectionInterface|\Robo\Contract\WrappedTaskInterface $task
      *
      * @return \Robo\Result
      */
@@ -662,6 +669,10 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
         return $taskResult;
     }
 
+    /**
+     * @param \Robo\Contract\TaskInterface $task
+     * @param \Robo\State\Data $taskResult
+     */
     protected function doStateUpdates($task, Data $taskResult)
     {
         $this->updateState($taskResult);
@@ -674,6 +685,13 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
         }
     }
 
+    /**
+     * @param \Robo\Contract\TaskInterface $task
+     * @param string $key
+     * @param string $source
+     *
+     * @return $this
+     */
     public function storeState($task, $key, $source = '')
     {
         $this->messageStoreKeys[spl_object_hash($task)] = [$key, $source];
@@ -681,6 +699,13 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
         return $this;
     }
 
+    /**
+     * @param \Robo\Contract\TaskInterface $task
+     * @param string $functionName
+     * @param string $stateKey
+     *
+     * @return $this
+     */
     public function deferTaskConfiguration($task, $functionName, $stateKey)
     {
         return $this->defer(
@@ -698,6 +723,11 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
      * runs. Use this time to provide more settings for the task, e.g. from
      * the collection's shared state, which is populated with the results
      * of previous test runs.
+     *
+     * @param \Robo\Contract\TaskInterface $task
+     * @param callable $callback
+     *
+     * @return $this
      */
     public function defer($task, $callback)
     {
@@ -706,6 +736,9 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
         return $this;
     }
 
+    /**
+     * @param \Robo\Contract\TaskInterface $task
+     */
     protected function doDeferredInitialization($task)
     {
         // If the task is a state consumer, then call its receiveState method
@@ -727,7 +760,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
 
     /**
      * @param TaskInterface|NestedCollectionInterface|WrappedTaskInterface $task
-     * @param $parentCollection
+     * @param \Robo\Collection\CollectionInterface $parentCollection
      */
     protected function setParentCollectionForTask($task, $parentCollection)
     {
@@ -744,7 +777,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
      *
      * This is used to roll back or complete.
      *
-     * @param TaskInterface[] $taskList
+     * @param \Robo\Contract\TaskInterface[] $taskList
      */
     protected function runTaskListIgnoringFailures(array $taskList)
     {
@@ -766,7 +799,7 @@ class Collection extends BaseTask implements CollectionInterface, CommandInterfa
     /**
      * Give all of our tasks to the provided collection builder.
      *
-     * @param CollectionBuilder $builder
+     * @param \Robo\Collection\CollectionBuilder $builder
      */
     public function transferTasks($builder)
     {

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -55,12 +55,12 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     protected $commandFile;
 
     /**
-     * @var CollectionInterface
+     * @var \Robo\Collection\CollectionInterface
      */
     protected $collection;
 
     /**
-     * @var TaskInterface
+     * @var \Robo\Contract\TaskInterface
      */
     protected $currentTask;
 
@@ -78,6 +78,12 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         $this->resetState();
     }
 
+    /**
+     * @param \League\Container\ContainerInterface $container
+     * @param \Robo\Tasks $commandFile
+     *
+     * @return static
+     */
     public static function create($container, $commandFile)
     {
         $builder = new self($commandFile);
@@ -141,8 +147,9 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
      * any results already in place will be moved out of the way and
      * then deleted.
      *
-     * @param string $finalDestination The path where the working directory
-     *   will be moved once the task collection completes.
+     * @param string $finalDestination
+     *   The path where the working directory will be moved once the task
+     *   collection completes.
      *
      * @return string
      */
@@ -152,6 +159,9 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         return $this->taskWorkDir($finalDestination)->getPath();
     }
 
+    /**
+     * @return $this
+     */
     public function addTask(TaskInterface $task)
     {
         $this->getCollection()->add($task);
@@ -165,6 +175,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
    *
    * @param callable $code
    * @param int|string $name
+   *
    * @return $this
    */
     public function addCode(callable $code, $name = \Robo\Collection\CollectionInterface::UNNAMEDTASK)
@@ -176,7 +187,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     /**
      * Add a list of tasks to our task collection.
      *
-     * @param TaskInterface[] $tasks
+     * @param \Robo\Contract\TaskInterface[] $tasks
      *   An array of tasks to run with rollback protection
      *
      * @return $this
@@ -187,6 +198,9 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function rollback(TaskInterface $task)
     {
         // Ensure that we have a collection if we are going to add
@@ -195,18 +209,27 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function rollbackCode(callable $rollbackCode)
     {
         $this->getCollection()->rollbackCode($rollbackCode);
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function completion(TaskInterface $task)
     {
         $this->getCollection()->completion($task);
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function completionCode(callable $completionCode)
     {
         $this->getCollection()->completionCode($completionCode);
@@ -227,8 +250,6 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     }
 
     /**
-     * @param \Robo\Collection\NestedCollectionInterface $parentCollection
-     *
      * @return $this
      */
     public function setParentCollection(NestedCollectionInterface $parentCollection)
@@ -243,7 +264,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
      *
      * TODO: protected
      *
-     * @param TaskInterface $task
+     * @param \Robo\Contract\TaskInterface $task
      *
      * @return $this
      */
@@ -265,28 +286,54 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         return $this;
     }
 
+    /**
+     * @return \Robo\State\Data
+     */
     public function getState()
     {
         $collection = $this->getCollection();
         return $collection->getState();
     }
 
+    /**
+     * @param int|string $key
+     * @param mixed $source
+     *
+     * @return $this
+     */
     public function storeState($key, $source = '')
     {
-        return $this->callCollectionStateFuntion(__FUNCTION__, func_get_args());
+        return $this->callCollectionStateFunction(__FUNCTION__, func_get_args());
     }
 
+    /**
+     * @param string $functionName
+     * @param int|string $stateKey
+     *
+     * @return $this
+     */
     public function deferTaskConfiguration($functionName, $stateKey)
     {
-        return $this->callCollectionStateFuntion(__FUNCTION__, func_get_args());
+        return $this->callCollectionStateFunction(__FUNCTION__, func_get_args());
     }
 
+    /**
+     * @param callable$callback
+     *
+     * @return $this
+     */
     public function defer($callback)
     {
-        return $this->callCollectionStateFuntion(__FUNCTION__, func_get_args());
+        return $this->callCollectionStateFunction(__FUNCTION__, func_get_args());
     }
 
-    protected function callCollectionStateFuntion($functionName, $args)
+    /**
+     * @param string $functionName
+     * @param array $args
+     *
+     * @return $this
+     */
+    protected function callCollectionStateFunction($functionName, $args)
     {
         $currentTask = ($this->currentTask instanceof WrappedTaskInterface) ? $this->currentTask->original() : $this->currentTask;
 
@@ -298,6 +345,24 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
         return $this;
     }
 
+    /**
+     * @param string $functionName
+     * @param array $args
+     *
+     * @return $this
+     *
+     * @deprecated Use ::callCollectionStateFunction() instead.
+     */
+    protected function callCollectionStateFuntion($functionName, $args)
+    {
+        return $this->callCollectionStateFunction($functionName, $args);
+    }
+
+    /**
+     * @param int $verbosityThreshold
+     *
+     * @return $this
+     */
     public function setVerbosityThreshold($verbosityThreshold)
     {
         $currentTask = ($this->currentTask instanceof WrappedTaskInterface) ? $this->currentTask->original() : $this->currentTask;
@@ -324,7 +389,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     /**
      * Create a new builder with its own task collection
      *
-     * @return CollectionBuilder
+     * @return \Robo\Collection\CollectionBuilder
      */
     public function newBuilder()
     {
@@ -413,7 +478,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
      * @param string|object $name
      * @param array $args
      *
-     * @return \Robo\Collection\CollectionBuilder
+     * @return $this
      */
     public function build($name, $args)
     {
@@ -428,7 +493,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     }
 
     /**
-     * @param InflectionInterface $task
+     * @param \Robo\Contract\TaskInterface $task
      * @param array $args
      *
      * @return \Robo\Collection\CompletionWrapper|\Robo\Task\Simulator
@@ -479,6 +544,9 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     /**
      * Check to see if there are any setter methods defined in configuration
      * for this task.
+     *
+     * @param string $taskClass
+     * @param \Robo\Contract\TaskInterface $task
      */
     protected function configureTask($taskClass, $task)
     {
@@ -526,7 +594,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getCommand()
     {
@@ -542,7 +610,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     }
 
     /**
-     * @return \Robo\Collection\Collection
+     * @return \Robo\Collection\CollectionInterface
      */
     public function original()
     {
@@ -552,7 +620,7 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
     /**
      * Return the collection of tasks associated with this builder.
      *
-     * @return CollectionInterface
+     * @return \Robo\Collection\CollectionInterface
      */
     public function getCollection()
     {

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -23,20 +23,21 @@ interface CollectionInterface extends NestedCollectionInterface
      * method ONLY if its 'run()' method completes successfully, and some
      * task added after it fails.
      *
-     * @param TaskInterface $task
+     * @param \Robo\Contract\TaskInterface $task
      *   The task to add to our collection.
      * @param int|string $name
      *   An optional name for the task -- missing or UNNAMEDTASK for unnamed tasks.
      *   Names are used for positioning before and after tasks.
      *
-     * @return CollectionInterface
+     * @return $this
      */
     public function add(TaskInterface $task, $name = self::UNNAMEDTASK);
 
     /**
      * Add arbitrary code to execute as a task.
      *
-     * @param callable $code Code to execute as a task
+     * @param callable $code
+     *   Code to execute as a task
      * @param int|string $name
      *   An optional name for the task -- missing or UNNAMEDTASK for unnamed tasks.
      *   Names are used for positioning before and after tasks.
@@ -51,8 +52,10 @@ interface CollectionInterface extends NestedCollectionInterface
      * provided callback is a TaskInterface or Collection, then it will be
      * executed.
      *
-     * @param CollectionInterface|array $iterable A collection of things to iterate
-     * @param $code $code A callback function to call for each item in the collection.
+     * @param static|array $iterable
+     *   A collection of things to iterate.
+     * @param callable $code
+     *   A callback function to call for each item in the collection.
      *
      * @return $this
      */
@@ -63,7 +66,7 @@ interface CollectionInterface extends NestedCollectionInterface
      * will execute ONLY if all of the tasks added before it complete
      * successfully, AND some task added after it fails.
      *
-     * @param TaskInterface $rollbackTask
+     * @param \Robo\Contract\TaskInterface $rollbackTask
      *   The rollback task to add.  Note that the 'run()' method of the
      *   task executes, not its 'rollback()' method.  To use the 'rollback()'
      *   method, add the task via 'Collection::add()' instead.
@@ -75,7 +78,8 @@ interface CollectionInterface extends NestedCollectionInterface
     /**
      * Add arbitrary code to execute as a rollback.
      *
-     * @param callable $rollbackTask Code to execute during rollback processing
+     * @param callable $rollbackTask
+     *   Code to execute during rollback processing.
      *
      * @return $this
      */
@@ -87,7 +91,7 @@ interface CollectionInterface extends NestedCollectionInterface
      * any task fails.  Completion tasks never cause errors to be returned
      * from Collection::run(), even if they fail.
      *
-     * @param TaskInterface $completionTask
+     * @param \Robo\Contract\TaskInterface $completionTask
      *   The completion task to add.  Note that the 'run()' method of the
      *   task executes, just as if the task was added normally.
      *
@@ -98,7 +102,8 @@ interface CollectionInterface extends NestedCollectionInterface
     /**
      * Add arbitrary code to execute as a completion.
      *
-     * @param callable $completionTask Code to execute after collection completes
+     * @param callable $completionTask
+     *   Code to execute after collection completes
      *
      * @return $this
      */
@@ -109,7 +114,7 @@ interface CollectionInterface extends NestedCollectionInterface
      *
      * @param string $name
      *   The name of the task to insert before.  The named task MUST exist.
-     * @param callable|TaskInterface $task
+     * @param callable|\Robo\Contract\TaskInterface $task
      *   The task to add.
      * @param int|string $nameOfTaskToAdd
      *   The name of the task to add. If not provided, will be associated
@@ -124,7 +129,7 @@ interface CollectionInterface extends NestedCollectionInterface
      *
      * @param string $name
      *   The name of the task to insert before.  The named task MUST exist.
-     * @param callable|TaskInterface $task
+     * @param callable|\Robo\Contract\TaskInterface $task
      *   The task to add.
      * @param int|string $nameOfTaskToAdd
      *   The name of the task to add. If not provided, will be associated
@@ -140,10 +145,13 @@ interface CollectionInterface extends NestedCollectionInterface
      * method was called. If one of the previous tasks fail, then this
      * message will not be printed.
      *
-     * @param string $text Message to print.
-     * @param array $context Extra context data for use by the logger. Note
+     * @param string $text
+     *   Message to print.
+     * @param array $context
+     *   Extra context data for use by the logger. Note
      *   that the data from the collection state is merged with the provided context.
-     * @param \Psr\Log\LogLevel|string $level The log level to print the information at. Default is NOTICE.
+     * @param \Psr\Log\LogLevel|string $level
+     *   The log level to print the information at. Default is NOTICE.
      *
      * @return $this
      */

--- a/src/Collection/CollectionProcessHook.php
+++ b/src/Collection/CollectionProcessHook.php
@@ -17,7 +17,7 @@ use Robo\Result;
 class CollectionProcessHook implements ProcessResultInterface
 {
     /**
-     * @param \Robo\Result|\Robo\Contract\TaskInterface $result
+     * @param \Robo\Contract\TaskInterface|mixed $result
      * @param \Consolidation\AnnotatedCommand\CommandData $commandData
      *
      * @return null|\Robo\Result

--- a/src/Collection/CompletionWrapper.php
+++ b/src/Collection/CompletionWrapper.php
@@ -52,7 +52,7 @@ class CompletionWrapper extends BaseTask implements WrappedTaskInterface
      *
      * @param \Robo\Collection\Collection $collection
      * @param \Robo\Contract\TaskInterface $task
-     * @param \Robo\Contract\TaskInterface|NULL $rollbackTask
+     * @param \Robo\Contract\TaskInterface|null $rollbackTask
      */
     public function __construct(Collection $collection, TaskInterface $task, TaskInterface $rollbackTask = null)
     {

--- a/src/Collection/Element.php
+++ b/src/Collection/Element.php
@@ -20,12 +20,12 @@ class Element
     protected $task;
 
     /**
-     * @var array
+     * @var \Robo\Contract\TaskInterface[]|callable[]
      */
     protected $before = [];
 
     /**
-     * @var array
+     * @var \Robo\Contract\TaskInterface[]|callable[]
      */
     protected $after = [];
 
@@ -35,7 +35,7 @@ class Element
     }
 
     /**
-     * @param mixed $before
+     * @param \Robo\Contract\TaskInterface|callable $before
      * @param string $name
      */
     public function before($before, $name)
@@ -48,7 +48,7 @@ class Element
     }
 
     /**
-     * @param mixed $after
+     * @param \Robo\Contract\TaskInterface|callable $after
      * @param string $name
      */
     public function after($after, $name)
@@ -61,7 +61,7 @@ class Element
     }
 
     /**
-     * @return array
+     * @return \Robo\Contract\TaskInterface[]|callable[]
      */
     public function getBefore()
     {
@@ -69,7 +69,7 @@ class Element
     }
 
     /**
-     * @return array
+     * @return \Robo\Contract\TaskInterface[]|callable[]
      */
     public function getAfter()
     {
@@ -85,7 +85,7 @@ class Element
     }
 
     /**
-     * @return array
+     * @return \Robo\Contract\TaskInterface[]|callable[]
      */
     public function getTaskList()
     {

--- a/src/Collection/TaskForEach.php
+++ b/src/Collection/TaskForEach.php
@@ -110,7 +110,7 @@ class TaskForEach extends BaseTask implements NestedCollectionInterface, Builder
     /**
      * @param callable $fn
      *
-     * @return \Robo\Collection\TaskForEach
+     * @return $this
      */
     public function call(callable $fn)
     {
@@ -124,7 +124,7 @@ class TaskForEach extends BaseTask implements NestedCollectionInterface, Builder
     /**
      * @param callable $fn
      *
-     * @return \Robo\Collection\TaskForEach
+     * @return $this
      */
     public function withBuilder(callable $fn)
     {

--- a/src/Collection/Temporary.php
+++ b/src/Collection/Temporary.php
@@ -25,10 +25,16 @@ namespace Robo\Collection;
  */
 class Temporary
 {
+
+    /**
+     * @var \Robo\Collection\Collection
+     */
     private static $collection;
 
     /**
      * Provides direct access to the collection of temporaries, if necessary.
+     *
+     * @return \Robo\Collection\Collection
      */
     public static function getCollection()
     {

--- a/src/Common/CommandArguments.php
+++ b/src/Common/CommandArguments.php
@@ -96,6 +96,11 @@ trait CommandArguments
      * Pass multiple options to executable. The associative array contains
      * the key:value pairs that become `--key value`, for each item in the array.
      * Values are automatically escaped.
+     *
+     * @param array $options
+     * @param string $separator
+     *
+     * @return $this
      */
     public function options(array $options, $separator = ' ')
     {

--- a/src/Common/ConfigAwareTrait.php
+++ b/src/Common/ConfigAwareTrait.php
@@ -8,14 +8,14 @@ use Consolidation\Config\ConfigInterface;
 trait ConfigAwareTrait
 {
     /**
-     * @var ConfigInterface
+     * @var \Consolidation\Config\ConfigInterface
      */
     protected $config;
 
     /**
      * Set the config management object.
      *
-     * @param ConfigInterface $config
+     * @param \Consolidation\Config\ConfigInterface $config
      *
      * @return $this
      */
@@ -29,7 +29,7 @@ trait ConfigAwareTrait
     /**
      * Get the config management object.
      *
-     * @return \Robo\Config\Config
+     * @return \Consolidation\Config\ConfigInterface
      */
     public function getConfig()
     {
@@ -79,7 +79,7 @@ trait ConfigAwareTrait
     /**
      * @param string $key
      * @param mixed $value
-     * @param Config|null $config
+     * @param \Consolidation\Config\ConfigInterface|null $config
      */
     public static function configure($key, $value, $config = null)
     {

--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -124,6 +124,9 @@ trait ExecCommand
         return $cmd;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function getCommandDescription()
     {
         return $this->process->getCommandLine();

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -66,22 +66,60 @@ trait ExecTrait
      */
     abstract public function getCommandDescription();
 
-    /** Typically provided by Timer trait via ProgressIndicatorAwareTrait. */
+    /**
+     * @see \Robo\Common\ProgressIndicatorAwareTrait
+     * @see \Robo\Common\Timer
+     */
     abstract public function startTimer();
+
+    /**
+     * @see \Robo\Common\ProgressIndicatorAwareTrait
+     * @see \Robo\Common\Timer
+     */
     abstract public function stopTimer();
+
+    /**
+     * @return null|float
+     *
+     * @see \Robo\Common\ProgressIndicatorAwareTrait
+     * @see \Robo\Common\Timer
+     */
     abstract public function getExecutionTime();
 
     /**
-     * Typically provided by TaskIO Trait.
+     * @return bool
+     *
+     * @see \Robo\Common\TaskIO
      */
     abstract public function hideTaskProgress();
+
+    /**
+     * @param bool $inProgress
+     *
+     * @see \Robo\Common\TaskIO
+     */
     abstract public function showTaskProgress($inProgress);
+
+    /**
+     * @param string $text
+     * @param null|array $context
+     *
+     * @see \Robo\Common\TaskIO
+     */
     abstract public function printTaskInfo($text, $context = null);
 
     /**
-     * Typically provided by VerbosityThresholdTrait.
+     * @return bool
+     *
+     * @see \Robo\Common\VerbosityThresholdTrait
      */
     abstract public function verbosityMeetsThreshold();
+
+    /**
+     * @param string $message
+     *
+     * @see \Robo\Common\VerbosityThresholdTrait
+     */
     abstract public function writeMessage($message);
 
     /**
@@ -104,6 +142,8 @@ trait ExecTrait
 
     /**
      * Executes command in background mode (asynchronously)
+     *
+     * @param bool $arg
      *
      * @return $this
      */
@@ -141,6 +181,11 @@ trait ExecTrait
 
     /**
      * Set a single environment variable, or multiple.
+     *
+     * @param string|array $env
+     * @param bool|string $value
+     *
+     * @return $this
      */
     public function env($env, $value = null)
     {
@@ -179,7 +224,7 @@ trait ExecTrait
     /**
      * Attach tty to process for interactive input
      *
-     * @param $interactive bool
+     * @param bool $interactive
      *
      * @return $this
      */
@@ -275,7 +320,7 @@ trait ExecTrait
     }
 
     /**
-     * @param Process $process
+     * @param \Symfony\Component\Process\Process $process
      * @param callable $output_callback
      *
      * @return \Robo\ResultData
@@ -354,9 +399,6 @@ trait ExecTrait
         return new ResultData($this->process->getExitCode());
     }
 
-    /**
-     *
-     */
     protected function stop()
     {
         if ($this->background && isset($this->process) && $this->process->isRunning()) {
@@ -384,9 +426,9 @@ trait ExecTrait
     }
 
     /**
-     * @param $command
+     * @param string $command
      *
-     * @return mixed
+     * @return string
      */
     protected function formatCommandDisplay($command)
     {

--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -19,7 +19,7 @@ trait IO
     /**
      * Provide access to SymfonyStyle object.
      *
-     * @return SymfonyStyle
+     * @return \Symfony\Component\Console\Style\SymfonyStyle
      *
      * @see http://symfony.com/blog/new-in-symfony-2-8-console-style-guide
      */

--- a/src/Common/OutputAdapter.php
+++ b/src/Common/OutputAdapter.php
@@ -13,6 +13,9 @@ class OutputAdapter implements OutputAdapterInterface, OutputAwareInterface
 {
     use OutputAwareTrait;
 
+    /**
+     * @var int[]
+     */
     protected $verbosityMap = [
         VerbosityThresholdInterface::VERBOSITY_NORMAL => OutputInterface::VERBOSITY_NORMAL,
         VerbosityThresholdInterface::VERBOSITY_VERBOSE => OutputInterface::VERBOSITY_VERBOSE,
@@ -20,6 +23,9 @@ class OutputAdapter implements OutputAdapterInterface, OutputAwareInterface
         VerbosityThresholdInterface::VERBOSITY_DEBUG => OutputInterface::VERBOSITY_DEBUG,
     ];
 
+    /**
+     * {@inheritdoc}
+     */
     public function verbosityMeetsThreshold($verbosityThreshold)
     {
         if (!isset($this->verbosityMap[$verbosityThreshold])) {
@@ -31,6 +37,9 @@ class OutputAdapter implements OutputAdapterInterface, OutputAwareInterface
         return $verbosity >= $verbosityThreshold;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function writeMessage($message)
     {
         $this->output()->write($message);

--- a/src/Common/ProcessExecutor.php
+++ b/src/Common/ProcessExecutor.php
@@ -16,14 +16,19 @@ class ProcessExecutor implements ConfigAwareInterface, LoggerAwareInterface, Out
     use OutputAwareTrait;
 
     /**
-     * @param Process $process
-     * @return type
+     * @param \Symfony\Component\Process\Process $process
      */
     public function __construct(Process $process)
     {
         $this->process = $process;
     }
 
+    /**
+     * @param \League\Container\ContainerInterface $container
+     * @param \Symfony\Component\Process\Process $process
+     *
+     * @return static
+     */
     public static function create($container, $process)
     {
         $processExecutor = new self($process);
@@ -37,7 +42,7 @@ class ProcessExecutor implements ConfigAwareInterface, LoggerAwareInterface, Out
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     protected function getCommandDescription()
     {

--- a/src/Common/ProcessUtils.php
+++ b/src/Common/ProcessUtils.php
@@ -26,9 +26,11 @@ class ProcessUtils
     /**
      * Escapes a string to be used as a shell argument.
      *
-     * @param string $argument The argument that will be escaped
+     * @param string $argument
+     *   The argument that will be escaped.
      *
-     * @return string The escaped argument
+     * @return string
+     *   The escaped argument.
      *
      * @deprecated since version 3.3, to be removed in 4.0. Use a command line array or give env vars to the `Process::start/run()` method instead.
      */

--- a/src/Common/ProgressIndicatorAwareTrait.php
+++ b/src/Common/ProgressIndicatorAwareTrait.php
@@ -24,7 +24,7 @@ trait ProgressIndicatorAwareTrait
     /**
      * @param null|\Robo\Common\ProgressIndicator $progressIndicator
      *
-     * @return ProgressIndicatorAwareInterface
+     * @return $this
      */
     public function setProgressIndicator($progressIndicator)
     {

--- a/src/Common/ResourceExistenceChecker.php
+++ b/src/Common/ResourceExistenceChecker.php
@@ -7,9 +7,11 @@ trait ResourceExistenceChecker
      * Checks if the given input is a file or folder.
      *
      * @param string|string[] $resources
-     * @param string $type "file", "dir", "fileAndDir"
+     * @param string $type
+     *   Allowed values: "file", "dir", "fileAndDir"
      *
-     * @return bool True if no errors were encountered otherwise false.
+     * @return bool
+     *   True if no errors were encountered otherwise false.
      */
     protected function checkResources($resources, $type = 'fileAndDir')
     {
@@ -41,8 +43,10 @@ trait ResourceExistenceChecker
      *
      * It will print an error as well on the console.
      *
-     * @param string $resource File or folder.
-     * @param string $type "file", "dir", "fileAndDir"
+     * @param string $resource
+     *   File or folder.
+     * @param string $type
+     *   Allowed values: "file", "dir", "fileAndDir".
      *
      * @return bool
      */

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -22,7 +22,7 @@ trait TaskIO
     use VerbosityThresholdTrait;
 
     /**
-     * @return mixed|null|\Psr\Log\LoggerInterface
+     * @return null|\Psr\Log\LoggerInterface
      */
     public function logger()
     {
@@ -169,7 +169,7 @@ trait TaskIO
     }
 
     /**
-     * @param $inProgress
+     * @param bool $inProgress
      */
     protected function showTaskProgress($inProgress)
     {
@@ -218,7 +218,8 @@ trait TaskIO
     /**
      * @param null|array $context
      *
-     * @return array with context information
+     * @return array
+     *   Context information.
      */
     protected function getTaskContext($context = null)
     {

--- a/src/Common/TimeKeeper.php
+++ b/src/Common/TimeKeeper.php
@@ -44,9 +44,10 @@ class TimeKeeper
     }
 
     /**
-     * Format a duration into a human-readable time
+     * Format a duration into a human-readable time.
      *
-     * @param float $duration Duration in seconds, with fractional component
+     * @param float $duration
+     *   Duration in seconds, with fractional component.
      *
      * @return string
      */

--- a/src/Common/VerbosityThresholdTrait.php
+++ b/src/Common/VerbosityThresholdTrait.php
@@ -20,13 +20,23 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 trait VerbosityThresholdTrait
 {
-    /** var OutputAdapterInterface */
+    /**
+     * @var \Robo\Contract\OutputAdapterInterface
+     */
     protected $outputAdapter;
+
+    /**
+     * @var int
+     */
     protected $verbosityThreshold = 0;
 
     /**
-     * Required verbocity level before any TaskIO output will be produced.
+     * Required verbosity level before any TaskIO output will be produced.
      * e.g. OutputInterface::VERBOSITY_VERBOSE
+     *
+     * @param int $verbosityThreshold
+     *
+     * @return $this
      */
     public function setVerbosityThreshold($verbosityThreshold)
     {
@@ -34,6 +44,9 @@ trait VerbosityThresholdTrait
         return $this;
     }
 
+    /**
+     * @return int
+     */
     public function verbosityThreshold()
     {
         return $this->verbosityThreshold;
@@ -45,18 +58,24 @@ trait VerbosityThresholdTrait
     }
 
     /**
-     * @return OutputAdapterInterface
+     * @return \Robo\Contract\OutputAdapterInterface
      */
     public function outputAdapter()
     {
         return $this->outputAdapter;
     }
 
+    /**
+     * @return bool
+     */
     public function hasOutputAdapter()
     {
         return isset($this->outputAdapter);
     }
 
+    /**
+     * @return bool
+     */
     public function verbosityMeetsThreshold()
     {
         if ($this->hasOutputAdapter()) {
@@ -67,7 +86,9 @@ trait VerbosityThresholdTrait
 
     /**
      * Print a message if the selected verbosity level is over this task's
-     * verbosity threshhold.
+     * verbosity threshold.
+     *
+     * @param string $message
      */
     public function writeMessage($message)
     {

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -70,6 +70,10 @@ class Config extends ConfigOverlay implements GlobalOptionDefaultValuesInterface
 
     /**
      * Remove the 'options.' prefix from the global options list.
+     *
+     * @param array $globalOptions
+     *
+     * @return array
      */
     protected function trimPrefixFromGlobalOptions($globalOptions)
     {

--- a/src/Contract/OutputAdapterInterface.php
+++ b/src/Contract/OutputAdapterInterface.php
@@ -6,6 +6,15 @@ namespace Robo\Contract;
  */
 interface OutputAdapterInterface
 {
+    /**
+     * @param int $verbosityThreshold
+     *
+     * @return bool
+     */
     public function verbosityMeetsThreshold($verbosityThreshold);
+
+    /**
+     * @param string $message
+     */
     public function writeMessage($message);
 }

--- a/src/Contract/VerbosityThresholdInterface.php
+++ b/src/Contract/VerbosityThresholdInterface.php
@@ -14,11 +14,40 @@ interface VerbosityThresholdInterface
     const VERBOSITY_VERY_VERBOSE = 3;
     const VERBOSITY_DEBUG = 4;
 
+    /**
+     * @param int $verbosityThreshold
+     *
+     * @return $this
+     */
     public function setVerbosityThreshold($verbosityThreshold);
+
+    /**
+     * @return int
+     */
     public function verbosityThreshold();
+
+    /**
+     * @param \Robo\Contract\OutputAdapterInterface $outputAdapter
+     */
     public function setOutputAdapter(OutputAdapterInterface $outputAdapter);
+
+    /**
+     * @return \Robo\Contract\OutputAdapterInterface
+     */
     public function outputAdapter();
+
+    /**
+     * @return bool
+     */
     public function hasOutputAdapter();
+
+    /**
+     * @return int
+     */
     public function verbosityMeetsThreshold();
+
+    /**
+     * @param string $message
+     */
     public function writeMessage($message);
 }

--- a/src/Exception/TaskException.php
+++ b/src/Exception/TaskException.php
@@ -3,6 +3,13 @@ namespace Robo\Exception;
 
 class TaskException extends \Exception
 {
+
+    /**
+     * TaskException constructor.
+     *
+     * @param string|object $class
+     * @param string $message
+     */
     public function __construct($class, $message)
     {
         if (is_object($class)) {

--- a/src/Exception/TaskExitException.php
+++ b/src/Exception/TaskExitException.php
@@ -3,6 +3,14 @@ namespace Robo\Exception;
 
 class TaskExitException extends \Exception
 {
+
+    /**
+     * TaskExitException constructor.
+     *
+     * @param string|object $class
+     * @param string $message
+     * @param int $status
+     */
     public function __construct($class, $message, $status)
     {
         if (is_object($class)) {

--- a/src/GlobalOptionsEventListener.php
+++ b/src/GlobalOptionsEventListener.php
@@ -12,10 +12,14 @@ class GlobalOptionsEventListener implements EventSubscriberInterface, ConfigAwar
 {
     use ConfigAwareTrait;
 
-    /** @var Application */
+    /**
+     * @var \Robo\Application
+     */
     protected $application;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $prefix;
 
     /**
@@ -28,6 +32,10 @@ class GlobalOptionsEventListener implements EventSubscriberInterface, ConfigAwar
 
     /**
      * Add a reference to the Symfony Console application object.
+     *
+     * @param \Robo\Application $application
+     *
+     * @return $this
      */
     public function setApplication($application)
     {
@@ -37,7 +45,10 @@ class GlobalOptionsEventListener implements EventSubscriberInterface, ConfigAwar
 
     /**
      * Stipulate the prefix to use for option injection.
+     *
      * @param string $prefix
+     *
+     * @return $this
      */
     public function setGlobalOptionsPrefix($prefix)
     {
@@ -118,6 +129,7 @@ class GlobalOptionsEventListener implements EventSubscriberInterface, ConfigAwar
      * the input string contains no '=' character, then the value will be 'true'.
      *
      * @param string $value
+     *
      * @return array
      */
     protected function splitConfigKeyValue($value)
@@ -130,6 +142,8 @@ class GlobalOptionsEventListener implements EventSubscriberInterface, ConfigAwar
     /**
      * Get default option values from the Symfony Console application, if
      * it is available.
+     *
+     * @return array
      */
     protected function applicationOptionDefaultValues()
     {

--- a/src/Log/ResultPrinter.php
+++ b/src/Log/ResultPrinter.php
@@ -27,7 +27,7 @@ class ResultPrinter implements LoggerAwareInterface, ProgressIndicatorAwareInter
      *
      * @param \Robo\Result $result
      *
-     * @return bool
+     * @return null|bool
      */
     public function printResult(Result $result)
     {

--- a/src/Result.php
+++ b/src/Result.php
@@ -19,7 +19,7 @@ class Result extends ResultData
 
     /**
      * @param \Robo\Contract\TaskInterface $task
-     * @param string $exitCode
+     * @param int $exitCode
      * @param string $message
      * @param array $data
      */
@@ -37,6 +37,11 @@ class Result extends ResultData
     /**
      * Tasks should always return a Result. However, they are also
      * allowed to return NULL or an array to indicate success.
+     *
+     * @param \Robo\Contract\TaskInterface $task
+     * @param \Robo\Result|\Robo\State\Data|\Robo\ResultData|array|null
+     *
+     * @return static
      */
     public static function ensureResult($task, $result)
     {
@@ -79,7 +84,7 @@ class Result extends ResultData
      * @param string $extension
      * @param string $service
      *
-     * @return \Robo\Result
+     * @return static
      */
     public static function errorMissingExtension(TaskInterface $task, $extension, $service)
     {
@@ -94,7 +99,7 @@ class Result extends ResultData
      * @param string $class
      * @param string $package
      *
-     * @return \Robo\Result
+     * @return static
      */
     public static function errorMissingPackage(TaskInterface $task, $class, $package)
     {
@@ -109,7 +114,7 @@ class Result extends ResultData
      * @param string $message
      * @param array $data
      *
-     * @return \Robo\Result
+     * @return static
      */
     public static function error(TaskInterface $task, $message, $data = [])
     {
@@ -121,7 +126,7 @@ class Result extends ResultData
      * @param \Exception $e
      * @param array $data
      *
-     * @return \Robo\Result
+     * @return static
      */
     public static function fromException(TaskInterface $task, \Exception $e, $data = [])
     {
@@ -137,7 +142,7 @@ class Result extends ResultData
      * @param string $message
      * @param array $data
      *
-     * @return \Robo\Result
+     * @return static
      */
     public static function success(TaskInterface $task, $message = '', $data = [])
     {

--- a/src/ResultData.php
+++ b/src/ResultData.php
@@ -40,7 +40,7 @@ class ResultData extends Data implements ExitCodeInterface, OutputDataInterface
      * @param string $message
      * @param array $data
      *
-     * @return \Robo\ResultData
+     * @return static
      */
     public static function message($message, $data = [])
     {
@@ -51,7 +51,7 @@ class ResultData extends Data implements ExitCodeInterface, OutputDataInterface
      * @param string $message
      * @param array $data
      *
-     * @return \Robo\ResultData
+     * @return static
      */
     public static function cancelled($message = '', $data = [])
     {

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -25,7 +25,7 @@ class Robo
     /**
      * The currently active container object, or NULL if not initialized yet.
      *
-     * @var ContainerInterface|null
+     * @var \League\Container\ContainerInterface|null
      */
     protected static $container;
 
@@ -37,6 +37,7 @@ class Robo
      * @param null|string $appName
      * @param null|string $appVersion
      * @param null|\Symfony\Component\Console\Output\OutputInterface $output
+     * @param null|string $repository
      *
      * @return int
      */
@@ -51,7 +52,7 @@ class Robo
     /**
      * Sets a new global container.
      *
-     * @param ContainerInterface $container
+     * @param \League\Container\ContainerInterface $container
      *   A new container instance to replace the current.
      */
     public static function setContainer(ContainerInterface $container)
@@ -94,6 +95,10 @@ class Robo
 
     /**
      * Create a config object and load it from the provided paths.
+     *
+     * @param string[] $paths
+     *
+     * @return \Consolidation\Config\ConfigInterface
      */
     public static function createConfiguration($paths)
     {
@@ -104,6 +109,9 @@ class Robo
 
     /**
      * Use a simple config loader to load configuration values from specified paths
+     *
+     * @param string[] $paths
+     * @param null|\Consolidation\Config\ConfigInterface $config
      */
     public static function loadConfiguration($paths, $config = null)
     {
@@ -127,7 +135,7 @@ class Robo
      * @param null|\Symfony\Component\Console\Input\InputInterface $input
      * @param null|\Symfony\Component\Console\Output\OutputInterface $output
      * @param null|\Robo\Application $app
-     * @param null|ConfigInterface $config
+     * @param null|\Consolidation\Config\ConfigInterface $config
      * @param null|\Composer\Autoload\ClassLoader $classLoader
      *
      * @return \League\Container\Container|\League\Container\ContainerInterface
@@ -174,7 +182,7 @@ class Robo
      *
      * @param \League\Container\ContainerInterface $container
      * @param \Symfony\Component\Console\Application $app
-     * @param ConfigInterface $config
+     * @param \Consolidation\Config\ConfigInterface $config
      * @param null|\Symfony\Component\Console\Input\InputInterface $input
      * @param null|\Symfony\Component\Console\Output\OutputInterface $output
      * @param null|\Composer\Autoload\ClassLoader $classLoader
@@ -356,7 +364,7 @@ class Robo
     }
 
     /**
-     * @return ConfigInterface
+     * @return \Consolidation\Config\ConfigInterface
      */
     public static function config()
     {
@@ -399,6 +407,9 @@ class Robo
         return static::service('input');
     }
 
+    /**
+     * @return \Robo\Common\ProcessExecutor
+     */
     public static function process(Process $process)
     {
         return ProcessExecutor::create(static::getContainer(), $process);

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -31,7 +31,9 @@ class Runner implements ContainerAwareInterface
     protected $roboFile;
 
     /**
-     * @var string working dir of Robo
+     * Working dir of Robo.
+     *
+     * @var string
      */
     protected $dir;
 
@@ -41,12 +43,16 @@ class Runner implements ContainerAwareInterface
     protected $errorConditions = [];
 
     /**
-     * @var string GitHub Repo for SelfUpdate
+     * GitHub Repo for SelfUpdate.
+     *
+     * @var string
      */
     protected $selfUpdateRepository = null;
 
     /**
-     * @var string filename to load configuration from (set to 'robo.yml' for RoboFiles)
+     * Filename to load configuration from (set to 'robo.yml' for RoboFiles).
+     *
+     * @var string
      */
     protected $configFilename = 'conf.yml';
 
@@ -56,7 +62,7 @@ class Runner implements ContainerAwareInterface
     protected $envConfigPrefix = false;
 
     /**
-     * @var \Composer\Autoload\ClassLoader
+     * @var null|\Composer\Autoload\ClassLoader
      */
     protected $classLoader = null;
 
@@ -79,6 +85,10 @@ class Runner implements ContainerAwareInterface
         $this->dir = getcwd();
     }
 
+    /**
+     * @param string $msg
+     * @param string $errorType
+     */
     protected function errorCondition($msg, $errorType)
     {
         $this->errorConditions[$msg] = $errorType;
@@ -147,6 +157,9 @@ class Runner implements ContainerAwareInterface
 
     /**
      * Get a list of locations where config files may be loaded
+     *
+     * @param string $userConfig
+     *
      * @return string[]
      */
     protected function getConfigFilePaths($userConfig)
@@ -258,9 +271,9 @@ class Runner implements ContainerAwareInterface
     }
 
     /**
-     * @param $relativeNamespace
+     * @param string $relativeNamespace
      *
-     * @return array|string[]
+     * @return string[]
      */
     protected function discoverCommandClasses($relativeNamespace)
     {
@@ -275,7 +288,7 @@ class Runner implements ContainerAwareInterface
      * @param \Robo\Application $app
      * @param string|BuilderAwareInterface|ContainerAwareInterface $commandClass
      *
-     * @return mixed|void
+     * @return null|object
      */
     public function registerCommandClass($app, $commandClass)
     {
@@ -295,7 +308,7 @@ class Runner implements ContainerAwareInterface
     }
 
     /**
-     * @param string|BuilderAwareInterface|ContainerAwareInterface  $commandClass
+     * @param string|\Robo\Contract\BuilderAwareInterface|\League\Container\ContainerAwareInterface $commandClass
      *
      * @return null|object
      */
@@ -344,7 +357,8 @@ class Runner implements ContainerAwareInterface
      *
      * @param array $args
      *
-     * @return array $args with shebang script removed
+     * @return array $args
+     *   With shebang script removed.
      */
     protected function shebang($args)
     {
@@ -371,9 +385,11 @@ class Runner implements ContainerAwareInterface
      * Determine if the specified argument is a path to a shebang script.
      * If so, load it.
      *
-     * @param string $filepath file to check
+     * @param string $filepath
+     *   File to check.
      *
-     * @return bool Returns TRUE if shebang script was processed
+     * @return bool
+     *   Returns TRUE if shebang script was processed.
      */
     protected function isShebangFile($filepath)
     {

--- a/src/State/Consumer.php
+++ b/src/State/Consumer.php
@@ -6,7 +6,7 @@ use Robo\State\Data;
 interface Consumer
 {
     /**
-     * @return Data
+     * @return \Robo\State\Data
      */
     public function receiveState(Data $state);
 }

--- a/src/State/Data.php
+++ b/src/State/Data.php
@@ -40,7 +40,7 @@ class Data extends \ArrayObject
     }
 
     /**
-     * @param string message
+     * @param string $message
      */
     public function setMessage($message)
     {
@@ -52,7 +52,7 @@ class Data extends \ArrayObject
      * existing in this result takes precedence over the
      * data in the Result being merged.
      *
-     * @param \Robo\ResultData $result
+     * @param \Robo\State\Data $result
      *
      * @return $this
      */
@@ -123,6 +123,10 @@ class Data extends \ArrayObject
 
     /**
      * Accumulate execution time
+     *
+     * @param array|float $duration
+     *
+     * @return null|float
      */
     public function accumulateExecutionTime($duration)
     {
@@ -136,6 +140,10 @@ class Data extends \ArrayObject
 
     /**
      * Accumulate the message.
+     *
+     * @param string $message
+     *
+     * @return string
      */
     public function accumulateMessage($message)
     {

--- a/src/State/StateAwareInterface.php
+++ b/src/State/StateAwareInterface.php
@@ -6,23 +6,24 @@ use Robo\State\Data;
 interface StateAwareInterface
 {
     /**
-     * @return Data
+     * @return \Robo\State\Data
      */
     public function getState();
 
     /**
-     * @param Data state
+     * @param \Robo\State\Data $state
      */
     public function setState(Data $state);
 
     /**
-     * @param $key
-     * @param value
+     * @param int|string $key
+     * @param mixed $value
      */
     public function setStateValue($key, $value);
 
     /**
-     * @param Data update state takes precedence over current state.
+     * @param \Robo\State\Data
+     *   Update state takes precedence over current state.
      */
     public function updateState(Data $update);
 

--- a/src/State/StateAwareTrait.php
+++ b/src/State/StateAwareTrait.php
@@ -3,45 +3,43 @@ namespace Robo\State;
 
 use Robo\State\Data;
 
+/**
+ * @see \Robo\State\StateAwareInterface
+ */
 trait StateAwareTrait
 {
+    /**
+     * @var \Robo\State\Data
+     */
     protected $state;
 
     /**
-     * {@inheritdoc}
+     * @return \Robo\State\Data
      */
     public function getState()
     {
         return $this->state;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setState(Data $state)
     {
         $this->state = $state;
     }
 
     /**
-     * {@inheritdoc}
+     * @param int|string $key
+     * @param mixed $value
      */
     public function setStateValue($key, $value)
     {
         $this->state[$key] = $value;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function updateState(Data $update)
     {
         $this->state->update($update);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function resetState()
     {
         $this->state = new Data();

--- a/src/Task/ApiGen/ApiGen.php
+++ b/src/Task/ApiGen/ApiGen.php
@@ -31,6 +31,10 @@ class ApiGen extends BaseTask implements CommandInterface
      * @var string
      */
     protected $command;
+
+    /**
+     * @var string
+     */
     protected $operation = 'generate';
 
     /**
@@ -84,10 +88,12 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param array|Traversable|string $arg a single object or something traversable
+     * @param array|\Traversable|string $arg
+     *   A single object or something traversable.
      *
-     * @return array|Traversable the provided argument if it was already traversable, or the given
-     *                           argument returned as a one-element array
+     * @return array|\Traversable
+     *   The provided argument if it was already traversable, or the given
+     *   argument returned as a one-element array.
      */
     protected static function forceTraversable($arg)
     {
@@ -99,10 +105,12 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param array|string $arg a single argument or an array of multiple string values
+     * @param array|string $arg
+     *   A single argument or an array of multiple string values.
      *
-     * @return string a comma-separated string of all of the provided arguments, suitable
-     *                as a command-line "list" type argument for ApiGen
+     * @return string
+     *   A comma-separated string of all of the provided arguments, suitable as
+     *   a command-line "list" type argument for ApiGen.
      */
     protected static function asList($arg)
     {
@@ -111,13 +119,15 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $val an argument to be normalized
-     * @param string $default one of self::BOOL_YES or self::BOOK_NO if the provided
-     *               value could not deterministically be converted to a
-     *               yes or no value
+     * @param bool|string $val
+     *   An argument to be normalized.
+     * @param string $default
+     *   One of self::BOOL_YES or self::BOOK_NO if the provided value could not
+     *   deterministically be converted to a yes or no value.
      *
-     * @return string the given value as a command-line "yes|no" type of argument for ApiGen,
-     *                or the default value if none could be determined
+     * @return string
+     *   The given value as a command-line "yes|no" type of argument for ApiGen,
+     *   or the default value if none could be determined.
      */
     protected static function asTextBool($val, $default)
     {
@@ -155,7 +165,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param array|string|Traversable $src one or more source values
+     * @param array|string|\Traversable $src
+     *   One or more source values.
      *
      * @return $this
      */
@@ -179,7 +190,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param array|string $exts one or more extensions
+     * @param array|string $exts
+     *   One or more extensions.
      *
      * @return $this
      */
@@ -190,7 +202,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param array|string $exclude one or more exclusions
+     * @param array|string $exclude
+     *   One or more exclusions.
      *
      * @return $this
      */
@@ -203,7 +216,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param array|string|Traversable $path one or more skip-doc-path values
+     * @param array|string|\Traversable $path
+     *   One or more skip-doc-path values.
      *
      * @return $this
      */
@@ -216,7 +230,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param array|string|Traversable $prefix one or more skip-doc-prefix values
+     * @param array|string|\Traversable $prefix
+     *   One or more skip-doc-prefix values.
      *
      * @return $this
      */
@@ -229,7 +244,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param array|string $charset one or more charsets
+     * @param array|string $charset
+     *   One or more charsets.
      *
      * @return $this
      */
@@ -306,7 +322,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param array|string $tags one or more supported html tags
+     * @param array|string $tags
+     *   One or more supported html tags.
      *
      * @return $this
      */
@@ -328,7 +345,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param array|string $types or more supported autocomplete types
+     * @param array|string $types
+     *   One or more supported autocomplete types.
      *
      * @return $this
      */
@@ -339,7 +357,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param array|string $levels one or more access levels
+     * @param array|string $levels
+     *   One or more access levels.
      *
      * @return $this
      */
@@ -350,7 +369,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param boolean|string $internal 'yes' or true if internal, 'no' or false if not
+     * @param boolean|string $internal
+     *   'yes' or true if internal, 'no' or false if not.
      *
      * @return $this
      */
@@ -361,8 +381,9 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param boolean|string $php 'yes' or true to generate documentation for internal php classes,
-     *                            'no' or false otherwise
+     * @param bool|string $php
+     *   'yes' or true to generate documentation for internal php classes, 'no'
+     *   or false otherwise.
      *
      * @return $this
      */
@@ -373,7 +394,9 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $tree 'yes' or true to generate a tree view of classes, 'no' or false otherwise
+     * @param bool|string $tree
+     *   'yes' or true to generate a tree view of classes, 'no' or false
+     *   otherwise.
      *
      * @return $this
      */
@@ -384,7 +407,9 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $dep 'yes' or true to generate documentation for deprecated classes, 'no' or false otherwise
+     * @param bool|string $dep
+     *   'yes' or true to generate documentation for deprecated classes, 'no' or
+     *   false otherwise.
      *
      * @return $this
      */
@@ -395,7 +420,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $todo 'yes' or true to document tasks, 'no' or false otherwise
+     * @param bool|string $todo
+     *   'yes' or true to document tasks, 'no' or false otherwise.
      *
      * @return $this
      */
@@ -406,7 +432,9 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $src 'yes' or true to generate highlighted source code, 'no' or false otherwise
+     * @param bool|string $src
+     *   'yes' or true to generate highlighted source code, 'no' or false
+     *   otherwise.
      *
      * @return $this
      */
@@ -417,7 +445,9 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $zipped 'yes' or true to generate downloadable documentation, 'no' or false otherwise
+     * @param bool|string $zipped
+     *   'yes' or true to generate downloadable documentation, 'no' or false
+     *   otherwise.
      *
      * @return $this
      */
@@ -427,6 +457,11 @@ class ApiGen extends BaseTask implements CommandInterface
         return $this;
     }
 
+    /**
+     * @param string $path
+     *
+     * @return $this
+     */
     public function report($path)
     {
         $this->option('report', $path);
@@ -434,7 +469,9 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $wipeout 'yes' or true to clear out the destination directory, 'no' or false otherwise
+     * @param bool|string $wipeout
+     *   'yes' or true to clear out the destination directory, 'no' or false
+     *   otherwise.
      *
      * @return $this
      */
@@ -445,7 +482,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $quiet 'yes' or true for quiet, 'no' or false otherwise
+     * @param bool|string $quiet
+     *   'yes' or true for quiet, 'no' or false otherwise.
      *
      * @return $this
      */
@@ -456,7 +494,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $bar 'yes' or true to display a progress bar, 'no' or false otherwise
+     * @param bool|string $bar
+     *   'yes' or true to display a progress bar, 'no' or false otherwise.
      *
      * @return $this
      */
@@ -467,7 +506,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $colors 'yes' or true colorize the output, 'no' or false otherwise
+     * @param bool|string $colors
+     *   'yes' or true colorize the output, 'no' or false otherwise.
      *
      * @return $this
      */
@@ -478,7 +518,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $check 'yes' or true to check for updates, 'no' or false otherwise
+     * @param bool|string $check
+     *   'yes' or true to check for updates, 'no' or false otherwise.
      *
      * @return $this
      */
@@ -489,7 +530,8 @@ class ApiGen extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param bool|string $debug 'yes' or true to enable debug mode, 'no' or false otherwise
+     * @param bool|string $debug
+     *   'yes' or true to enable debug mode, 'no' or false otherwise.
      *
      * @return $this
      */

--- a/src/Task/ApiGen/loadTasks.php
+++ b/src/Task/ApiGen/loadTasks.php
@@ -6,7 +6,7 @@ trait loadTasks
     /**
      * @param null|string $pathToApiGen
      *
-     * @return \Robo\Task\ApiGen\ApiGen
+     * @return \Robo\Task\ApiGen\ApiGen|\Robo\Collection\CollectionBuilder
      */
     protected function taskApiGen($pathToApiGen = null)
     {

--- a/src/Task/Archive/Pack.php
+++ b/src/Task/Archive/Pack.php
@@ -40,7 +40,8 @@ class Pack extends BaseTask implements PrintedInterface
     /**
      * Construct the class.
      *
-     * @param string $archiveFile The full path and name of the archive file to create.
+     * @param string $archiveFile
+     *   The full path and name of the archive file to create.
      *
      * @since   1.0
      */
@@ -52,7 +53,8 @@ class Pack extends BaseTask implements PrintedInterface
     /**
      * Satisfy the parent requirement.
      *
-     * @return bool Always returns true.
+     * @return bool
+     *   Always returns true.
      *
      * @since   1.0
      */
@@ -76,10 +78,10 @@ class Pack extends BaseTask implements PrintedInterface
      * Add an item to the archive. Like file_exists(), the parameter
      * may be a file or a directory.
      *
-     * @var string
-     *             Relative path and name of item to store in archive
-     * @var string
-     *             Absolute or relative path to file or directory's location in filesystem
+     * @param string $placementLocation
+     *   Relative path and name of item to store in archive.
+     * @param string $filesystemLocation
+     *   Absolute or relative path to file or directory's location in filesystem.
      *
      * @return $this
      */
@@ -94,10 +96,10 @@ class Pack extends BaseTask implements PrintedInterface
      * Alias for addFile, in case anyone has angst about using
      * addFile with a directory.
      *
-     * @var string
-     *             Relative path and name of directory to store in archive
-     * @var string
-     *             Absolute or relative path to directory or directory's location in filesystem
+     * @param string $placementLocation
+     *   Relative path and name of directory to store in archive.
+     * @param string $filesystemLocation
+     *   Absolute or relative path to directory or directory's location in filesystem.
      *
      * @return $this
      */
@@ -111,13 +113,14 @@ class Pack extends BaseTask implements PrintedInterface
     /**
      * Add a file or directory, or list of same to the archive.
      *
-     * @var string|array
-     *                   If given a string, should contain the relative filesystem path to the
-     *                   the item to store in archive; this will also be used as the item's
-     *                   path in the archive, so absolute paths should not be used here.
-     *                   If given an array, the key of each item should be the path to store
-     *                   in the archive, and the value should be the filesystem path to the
-     *                   item to store.
+     * @param string|array $item
+     *   If given a string, should contain the relative filesystem path to the
+     *   the item to store in archive; this will also be used as the item's
+     *   path in the archive, so absolute paths should not be used here.
+     *   If given an array, the key of each item should be the path to store
+     *   in the archive, and the value should be the filesystem path to the
+     *   item to store.
+     *
      * @return $this
      */
     public function add($item)

--- a/src/Task/Archive/loadTasks.php
+++ b/src/Task/Archive/loadTasks.php
@@ -4,9 +4,9 @@ namespace Robo\Task\Archive;
 trait loadTasks
 {
     /**
-     * @param $filename
+     * @param string $filename
      *
-     * @return Pack
+     * @return \Robo\Task\Archive\Pack|\Robo\Collection\CollectionBuilder
      */
     protected function taskPack($filename)
     {
@@ -14,9 +14,9 @@ trait loadTasks
     }
 
     /**
-     * @param $filename
+     * @param string $filename
      *
-     * @return Extract
+     * @return \Robo\Task\Archive\Extract|\Robo\Collection\CollectionBuilder
      */
     protected function taskExtract($filename)
     {

--- a/src/Task/Assets/ImageMinify.php
+++ b/src/Task/Assets/ImageMinify.php
@@ -150,7 +150,7 @@ class ImageMinify extends BaseTask
      *
      * @link https://github.com/imagemin
      *
-     * @var array
+     * @var string[]
      */
     protected $imageminRepos = [
         // PNG
@@ -171,6 +171,9 @@ class ImageMinify extends BaseTask
         'cwebp' => 'https://github.com/imagemin/cwebp-bin', // note: we do not support this minifier because it creates WebP from non-WebP files
     ];
 
+    /**
+     * @param string|string[] $dirs
+     */
     public function __construct($dirs)
     {
         is_array($dirs)
@@ -257,7 +260,7 @@ class ImageMinify extends BaseTask
     }
 
     /**
-     * @param array $dirs
+     * @param string[] $dirs
      *
      * @return array|\Robo\Result
      *
@@ -325,7 +328,7 @@ class ImageMinify extends BaseTask
     }
 
     /**
-     * @param array $files
+     * @param string[] $files
      *
      * @return \Robo\Result
      */
@@ -584,6 +587,12 @@ class ImageMinify extends BaseTask
         return $command;
     }
 
+    /**
+     * @param string $from
+     * @param string $to
+     *
+     * @return string
+     */
     protected function gifsicle($from, $to)
     {
         $command = sprintf('gifsicle -o "%s" "%s"', $to, $from);

--- a/src/Task/Assets/Minify.php
+++ b/src/Task/Assets/Minify.php
@@ -23,7 +23,7 @@ use Robo\Task\BaseTask;
 class Minify extends BaseTask
 {
     /**
-     * @var array
+     * @var string[]
      */
     protected $types = ['css', 'js'];
 
@@ -43,7 +43,7 @@ class Minify extends BaseTask
     protected $type;
 
     /**
-     * @var array
+     * @var bool[]
      */
     protected $squeezeOptions = [
         'singleLine' => true,
@@ -87,7 +87,8 @@ class Minify extends BaseTask
     /**
      * Sets type with validation.
      *
-     * @param string $type css|js
+     * @param string $type
+     *   Allowed values: "css", "js".
      *
      * @return $this
      */
@@ -217,11 +218,11 @@ class Minify extends BaseTask
     }
 
     /**
-     * specialVarRx option for the JS minimisation.
+     * Set specialVarRx option for the JS minimisation.
      *
      * @param bool $specialVarRx
      *
-     * @return $this ;
+     * @return $this
      */
     public function specialVarRx($specialVarRx)
     {

--- a/src/Task/Assets/loadTasks.php
+++ b/src/Task/Assets/loadTasks.php
@@ -4,10 +4,10 @@ namespace Robo\Task\Assets;
 trait loadTasks
 {
     /**
-    * @param string $input
-    *
-     * @return \Robo\Task\Assets\Minify
-    */
+     * @param string $input
+     *
+     * @return \Robo\Task\Assets\Minify|\Robo\Collection\CollectionBuilder
+     */
     protected function taskMinify($input)
     {
         return $this->task(Minify::class, $input);
@@ -16,7 +16,7 @@ trait loadTasks
     /**
      * @param string|string[] $input
      *
-     * @return \Robo\Task\Assets\ImageMinify
+     * @return \Robo\Task\Assets\ImageMinify|\Robo\Collection\CollectionBuilder
      */
     protected function taskImageMinify($input)
     {
@@ -26,7 +26,7 @@ trait loadTasks
    /**
     * @param array $input
     *
-    * @return \Robo\Task\Assets\Less
+    * @return \Robo\Task\Assets\Less|\Robo\Collection\CollectionBuilder
     */
     protected function taskLess($input)
     {
@@ -36,7 +36,7 @@ trait loadTasks
     /**
      * @param array $input
      *
-     * @return \Robo\Task\Assets\Scss
+     * @return \Robo\Task\Assets\Scss|\Robo\Collection\CollectionBuilder
      */
     protected function taskScss($input)
     {

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -50,9 +50,6 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
         $this->command = $this->receiveCommand($command);
     }
 
-    /**
-     *
-     */
     public function __destruct()
     {
         $this->stop();
@@ -60,6 +57,8 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
 
     /**
      * Executes command in background mode (asynchronously)
+     *
+     * @param bool $arg
      *
      * @return $this
      */

--- a/src/Task/Base/loadTasks.php
+++ b/src/Task/Base/loadTasks.php
@@ -6,7 +6,7 @@ trait loadTasks
     /**
      * @param string|\Robo\Contract\CommandInterface $command
      *
-     * @return Exec
+     * @return \Robo\Task\Base\Exec|\Robo\Collection\CollectionBuilder
      */
     protected function taskExec($command)
     {
@@ -14,7 +14,7 @@ trait loadTasks
     }
 
     /**
-     * @return ExecStack
+     * @return \Robo\Task\Base\ExecStack|\Robo\Collection\CollectionBuilder
      */
     protected function taskExecStack()
     {
@@ -22,7 +22,7 @@ trait loadTasks
     }
 
     /**
-     * @return ParallelExec
+     * @return \Robo\Task\Base\ParallelExec|\Robo\Collection\CollectionBuilder
      */
     protected function taskParallelExec()
     {
@@ -30,8 +30,9 @@ trait loadTasks
     }
 
     /**
-     * @param $command
-     * @return SymfonyCommand
+     * @param \Symfony\Component\Console\Command\Command $command
+     *
+     * @return \Robo\Task\Base\SymfonyCommand|\Robo\Collection\CollectionBuilder
      */
     protected function taskSymfonyCommand($command)
     {
@@ -39,7 +40,7 @@ trait loadTasks
     }
 
     /**
-     * @return Watch
+     * @return \Robo\Task\Base\Watch|\Robo\Collection\CollectionBuilder
      */
     protected function taskWatch()
     {

--- a/src/Task/BaseTask.php
+++ b/src/Task/BaseTask.php
@@ -23,6 +23,8 @@ abstract class BaseTask implements TaskInterface, LoggerAwareInterface, Verbosit
      * ConfigAwareInterface uses this to decide where configuration
      * items come from. Default is this prefix + class name + key,
      * e.g. `task.Remote.Ssh.remoteDir`.
+     *
+     * @return string
      */
     protected static function configPrefix()
     {
@@ -33,6 +35,8 @@ abstract class BaseTask implements TaskInterface, LoggerAwareInterface, Verbosit
      * ConfigAwareInterface uses this to decide where configuration
      * items come from. Default is this prefix + class name + key,
      * e.g. `task.Ssh.remoteDir`.
+     *
+     * @return string
      */
     protected static function configPostfix()
     {

--- a/src/Task/Bower/Base.php
+++ b/src/Task/Bower/Base.php
@@ -8,7 +8,14 @@ abstract class Base extends BaseTask
 {
     use \Robo\Common\ExecOneCommand;
 
+    /**
+     * @var array
+     */
     protected $opts = [];
+
+    /**
+     * @var string
+     */
     protected $action = '';
 
     /**

--- a/src/Task/Bower/loadTasks.php
+++ b/src/Task/Bower/loadTasks.php
@@ -6,7 +6,7 @@ trait loadTasks
     /**
      * @param null|string $pathToBower
      *
-     * @return Install
+     * @return \Robo\Task\Bower\Install|\Robo\Collection\CollectionBuilder
      */
     protected function taskBowerInstall($pathToBower = null)
     {
@@ -16,7 +16,7 @@ trait loadTasks
     /**
      * @param null|string $pathToBower
      *
-     * @return Update
+     * @return \Robo\Task\Bower\Update|\Robo\Collection\CollectionBuilder
      */
     protected function taskBowerUpdate($pathToBower = null)
     {

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -18,6 +18,9 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
      */
     protected $executable;
 
+    /**
+     * @var \Robo\Result
+     */
     protected $result;
 
     /**
@@ -69,9 +72,9 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
             $command = $this->executable . ' ' . $this->stripExecutableFromCommand($command);
             $command = trim($command);
         }
-        
+
         $this->exec[] = $command;
-        
+
         return $this;
     }
 

--- a/src/Task/Composer/Base.php
+++ b/src/Task/Composer/Base.php
@@ -15,7 +15,7 @@ abstract class Base extends BaseTask implements CommandInterface
     protected $command = '';
 
     /**
-     * @var boolena
+     * @var bool
      */
     protected $built = false;
 
@@ -65,6 +65,8 @@ abstract class Base extends BaseTask implements CommandInterface
     /**
      * adds `prefer-dist` option to composer
      *
+     * @param bool $preferDist
+     *
      * @return $this
      */
     public function preferDist($preferDist = true)
@@ -89,6 +91,8 @@ abstract class Base extends BaseTask implements CommandInterface
 
     /**
      * adds `dev` option to composer
+     *
+     * @param bool $dev
      *
      * @return $this
      */
@@ -115,6 +119,8 @@ abstract class Base extends BaseTask implements CommandInterface
     /**
      * adds `ansi` option to composer
      *
+     * @param bool $ansi
+     *
      * @return $this
      */
     public function ansi($ansi = true)
@@ -137,6 +143,11 @@ abstract class Base extends BaseTask implements CommandInterface
         return $this;
     }
 
+    /**
+     * @param bool $interaction
+     *
+     * @return $this
+     */
     public function interaction($interaction = true)
     {
         if (!$interaction) {
@@ -159,6 +170,8 @@ abstract class Base extends BaseTask implements CommandInterface
     /**
      * adds `optimize-autoloader` option to composer
      *
+     * @param bool $optimize
+     *
      * @return $this
      */
     public function optimizeAutoloader($optimize = true)
@@ -172,6 +185,8 @@ abstract class Base extends BaseTask implements CommandInterface
     /**
      * adds `ignore-platform-reqs` option to composer
      *
+     * @param bool $ignore
+     *
      * @return $this
      */
     public function ignorePlatformRequirements($ignore = true)
@@ -182,6 +197,8 @@ abstract class Base extends BaseTask implements CommandInterface
 
     /**
      * disable plugins
+     *
+     * @param bool $disable
      *
      * @return $this
      */
@@ -196,6 +213,8 @@ abstract class Base extends BaseTask implements CommandInterface
     /**
      * skip scripts
      *
+     * @param bool $disable
+     *
      * @return $this
      */
     public function noScripts($disable = true)
@@ -208,6 +227,8 @@ abstract class Base extends BaseTask implements CommandInterface
 
     /**
      * adds `--working-dir $dir` option to composer
+     *
+     * @param string $dir
      *
      * @return $this
      */

--- a/src/Task/Composer/Config.php
+++ b/src/Task/Composer/Config.php
@@ -19,7 +19,11 @@ class Config extends Base
     protected $action = 'config';
 
     /**
-     * Set a configuration value
+     * Set a configuration value.
+     *
+     * @param string $key
+     * @param string $value
+     *
      * @return $this
      */
     public function set($key, $value)
@@ -31,6 +35,9 @@ class Config extends Base
 
     /**
      * Operate on the global repository
+     *
+     * @param bool $useGlobal
+     *
      * @return $this
      */
     public function useGlobal($useGlobal = true)
@@ -42,6 +49,10 @@ class Config extends Base
     }
 
     /**
+     * @param string $id
+     * @param string $uri
+     * @param string $repoType
+     *
      * @return $this
      */
     public function repository($id, $uri, $repoType = 'vcs')
@@ -53,6 +64,8 @@ class Config extends Base
     }
 
     /**
+     * @param string $id
+     *
      * @return $this
      */
     public function removeRepository($id)
@@ -62,6 +75,8 @@ class Config extends Base
     }
 
     /**
+     * @param string $id
+     *
      * @return $this
      */
     public function disableRepository($id)
@@ -72,6 +87,8 @@ class Config extends Base
     }
 
     /**
+     * @param string $id
+     *
      * @return $this
      */
     public function enableRepository($id)

--- a/src/Task/Composer/CreateProject.php
+++ b/src/Task/Composer/CreateProject.php
@@ -18,11 +18,24 @@ class CreateProject extends Base
      */
     protected $action = 'create-project';
 
+    /**
+     * @var
+     */
     protected $source;
+
+    /**
+     * @var string
+     */
     protected $target = '';
+
+    /**
+     * @var string
+     */
     protected $version = '';
 
     /**
+     * @param string $source
+     *
      * @return $this
      */
     public function source($source)
@@ -32,6 +45,8 @@ class CreateProject extends Base
     }
 
     /**
+     * @param string $target
+     *
      * @return $this
      */
     public function target($target)
@@ -41,6 +56,8 @@ class CreateProject extends Base
     }
 
     /**
+     * @param string $version
+     *
      * @return $this
      */
     public function version($version)
@@ -49,6 +66,11 @@ class CreateProject extends Base
         return $this;
     }
 
+    /**
+     * @param bool $keep
+     *
+     * @return $this
+     */
     public function keepVcs($keep = true)
     {
         if ($keep) {
@@ -57,6 +79,11 @@ class CreateProject extends Base
         return $this;
     }
 
+    /**
+     * @param bool $noInstall
+     *
+     * @return $this
+     */
     public function noInstall($noInstall = true)
     {
         if ($noInstall) {
@@ -66,6 +93,8 @@ class CreateProject extends Base
     }
 
     /**
+     * @param string $repository
+     *
      * @return $this
      */
     public function repository($repository)
@@ -77,6 +106,8 @@ class CreateProject extends Base
     }
 
     /**
+     * @param string $stability
+     *
      * @return $this
      */
     public function stability($stability)
@@ -87,6 +118,9 @@ class CreateProject extends Base
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function buildCommand()
     {
         $this->arg($this->source);

--- a/src/Task/Composer/DumpAutoload.php
+++ b/src/Task/Composer/DumpAutoload.php
@@ -40,6 +40,8 @@ class DumpAutoload extends Base
     protected $optimize;
 
     /**
+     * @param bool $optimize
+     *
      * @return $this
      */
     public function optimize($optimize = true)

--- a/src/Task/Composer/Init.php
+++ b/src/Task/Composer/Init.php
@@ -19,6 +19,8 @@ class Init extends Base
     protected $action = 'init';
 
     /**
+     * @param string $projectName
+     *
      * @return $this
      */
     public function projectName($projectName)
@@ -28,6 +30,8 @@ class Init extends Base
     }
 
     /**
+     * @param string $description
+     *
      * @return $this
      */
     public function description($description)
@@ -37,6 +41,8 @@ class Init extends Base
     }
 
     /**
+     * @param string $author
+     *
      * @return $this
      */
     public function author($author)
@@ -46,6 +52,8 @@ class Init extends Base
     }
 
     /**
+     * @param string $type
+     *
      * @return $this
      */
     public function projectType($type)
@@ -55,6 +63,8 @@ class Init extends Base
     }
 
     /**
+     * @param string $homepage
+     *
      * @return $this
      */
     public function homepage($homepage)
@@ -65,6 +75,10 @@ class Init extends Base
 
     /**
      * 'require' is a keyword, so it cannot be a method name.
+     *
+     * @param string $project
+     * @param null|string $version
+     *
      * @return $this
      */
     public function dependency($project, $version = null)
@@ -77,6 +91,8 @@ class Init extends Base
     }
 
     /**
+     * @param string $stability
+     *
      * @return $this
      */
     public function stability($stability)
@@ -86,6 +102,8 @@ class Init extends Base
     }
 
     /**
+     * @param string $license
+     *
      * @return $this
      */
     public function license($license)
@@ -95,6 +113,8 @@ class Init extends Base
     }
 
     /**
+     * @param string $repository
+     *
      * @return $this
      */
     public function repository($repository)

--- a/src/Task/Composer/Remove.php
+++ b/src/Task/Composer/Remove.php
@@ -19,6 +19,8 @@ class Remove extends Base
     protected $action = 'remove';
 
     /**
+     * @param bool $dev
+     *
      * @return $this
      */
     public function dev($dev = true)
@@ -30,6 +32,8 @@ class Remove extends Base
     }
 
     /**
+     * @param bool $noProgress
+     *
      * @return $this
      */
     public function noProgress($noProgress = true)
@@ -41,6 +45,8 @@ class Remove extends Base
     }
 
     /**
+     * @param bool $noUpdate
+     *
      * @return $this
      */
     public function noUpdate($noUpdate = true)
@@ -52,6 +58,8 @@ class Remove extends Base
     }
 
     /**
+     * @param bool $updateNoDev
+     *
      * @return $this
      */
     public function updateNoDev($updateNoDev = true)
@@ -63,6 +71,8 @@ class Remove extends Base
     }
 
     /**
+     * @param bool $updateWithDependencies
+     *
      * @return $this
      */
     public function noUpdateWithDependencies($updateWithDependencies = true)

--- a/src/Task/Composer/RequireDependency.php
+++ b/src/Task/Composer/RequireDependency.php
@@ -20,6 +20,10 @@ class RequireDependency extends Base
 
     /**
      * 'require' is a keyword, so it cannot be a method name.
+     *
+     * @param string $project
+     * @param null|string $version
+     *
      * @return $this
      */
     public function dependency($project, $version = null)

--- a/src/Task/Composer/Validate.php
+++ b/src/Task/Composer/Validate.php
@@ -19,6 +19,8 @@ class Validate extends Base
     protected $action = 'validate';
 
     /**
+     * @param bool $noCheckAll
+     *
      * @return $this
      */
     public function noCheckAll($noCheckAll = true)
@@ -30,6 +32,8 @@ class Validate extends Base
     }
 
     /**
+     * @param bool $noCheckLock
+     *
      * @return $this
      */
     public function noCheckLock($noCheckLock = true)
@@ -41,6 +45,8 @@ class Validate extends Base
     }
 
     /**
+     * @param bool $noCheckPublish
+     *
      * @return $this
      */
     public function noCheckPublish($noCheckPublish = true)
@@ -52,6 +58,8 @@ class Validate extends Base
     }
 
     /**
+     * @param bool $withDependencies
+     *
      * @return $this
      */
     public function withDependencies($withDependencies = true)
@@ -63,6 +71,8 @@ class Validate extends Base
     }
 
     /**
+     * @param bool $strict
+     *
      * @return $this
      */
     public function strict($strict = true)

--- a/src/Task/Composer/loadTasks.php
+++ b/src/Task/Composer/loadTasks.php
@@ -6,7 +6,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return Install
+     * @return \Robo\Task\Composer\Install|\Robo\Collection\CollectionBuilder
      */
     protected function taskComposerInstall($pathToComposer = null)
     {
@@ -16,7 +16,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return Update
+     * @return \Robo\Task\Composer\Update|\Robo\Collection\CollectionBuilder
      */
     protected function taskComposerUpdate($pathToComposer = null)
     {
@@ -26,7 +26,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return DumpAutoload
+     * @return \Robo\Task\Composer\DumpAutoload|\Robo\Collection\CollectionBuilder
      */
     protected function taskComposerDumpAutoload($pathToComposer = null)
     {
@@ -36,7 +36,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return Init
+     * @return \Robo\Task\Composer\Init|\Robo\Collection\CollectionBuilder
      */
     protected function taskComposerInit($pathToComposer = null)
     {
@@ -46,7 +46,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return Config
+     * @return \Robo\Task\Composer\Config|\Robo\Collection\CollectionBuilder
      */
     protected function taskComposerConfig($pathToComposer = null)
     {
@@ -56,7 +56,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return Validate
+     * @return \Robo\Task\Composer\Validate|\Robo\Collection\CollectionBuilder
      */
     protected function taskComposerValidate($pathToComposer = null)
     {
@@ -66,7 +66,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return Remove
+     * @return \Robo\Task\Composer\Remove|\Robo\Collection\CollectionBuilder
      */
     protected function taskComposerRemove($pathToComposer = null)
     {
@@ -76,7 +76,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return RequireDependency
+     * @return \Robo\Task\Composer\RequireDependency|\Robo\Collection\CollectionBuilder
      */
     protected function taskComposerRequire($pathToComposer = null)
     {
@@ -86,7 +86,7 @@ trait loadTasks
     /**
      * @param null|string $pathToComposer
      *
-     * @return CreateProject
+     * @return \Robo\Task\Composer\CreateProject|\Robo\Collection\CollectionBuilder
      */
     protected function taskComposerCreateProject($pathToComposer = null)
     {

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -216,7 +216,7 @@ class Changelog extends BaseTask implements BuilderAwareInterface
     }
 
     /**
-     * @return \Robo\Result|string
+     * @return string
      */
     protected function generateBody()
     {
@@ -235,7 +235,7 @@ class Changelog extends BaseTask implements BuilderAwareInterface
     }
 
     /**
-     * @param $i
+     * @param string $i
      *
      * @return string
      */

--- a/src/Task/Development/GitHub.php
+++ b/src/Task/Development/GitHub.php
@@ -86,7 +86,7 @@ abstract class GitHub extends BaseTask
     }
 
     /**
-     * @param $password
+     * @param string $password
      *
      * @return $this
      */
@@ -97,7 +97,7 @@ abstract class GitHub extends BaseTask
     }
 
     /**
-     * @param $accessToken
+     * @param string $token
      *
      * @return $this
      */

--- a/src/Task/Development/OpenBrowser.php
+++ b/src/Task/Development/OpenBrowser.php
@@ -31,7 +31,7 @@ class OpenBrowser extends BaseTask
     protected $urls = [];
 
     /**
-     * @param string|array $url
+     * @param string|string[] $url
      */
     public function __construct($url)
     {

--- a/src/Task/Development/SemVer.php
+++ b/src/Task/Development/SemVer.php
@@ -88,6 +88,11 @@ class SemVer implements TaskInterface
         return str_replace($search, $replace, $this->format);
     }
 
+    /**
+     * @param string $version
+     *
+     * @return $this
+     */
     public function version($version)
     {
         $this->parseString($version);
@@ -228,6 +233,11 @@ class SemVer implements TaskInterface
         return true;
     }
 
+    /**
+     * @param string $semverString
+     *
+     * @throws \Robo\Exception\TaskException
+     */
     protected function parseString($semverString)
     {
         if (!preg_match_all(self::REGEX_STRING, $semverString, $matches)) {
@@ -241,6 +251,8 @@ class SemVer implements TaskInterface
     }
 
     /**
+     * @param string $semverFileContents
+     *
      * @throws \Robo\Exception\TaskException
      */
     protected function parseFile($semverFileContents)

--- a/src/Task/Development/loadTasks.php
+++ b/src/Task/Development/loadTasks.php
@@ -6,7 +6,7 @@ trait loadTasks
     /**
      * @param string $filename
      *
-     * @return Changelog
+     * @return \Robo\Task\Development\Changelog|\Robo\Collection\CollectionBuilder
      */
     protected function taskChangelog($filename = 'CHANGELOG.md')
     {
@@ -16,7 +16,7 @@ trait loadTasks
     /**
      * @param string $filename
      *
-     * @return GenerateMarkdownDoc
+     * @return \Robo\Task\Development\GenerateMarkdownDoc|\Robo\Collection\CollectionBuilder
      */
     protected function taskGenDoc($filename)
     {
@@ -27,7 +27,7 @@ trait loadTasks
      * @param string $className
      * @param string $wrapperClassName
      *
-     * @return \Robo\Task\Development\GenerateTask
+     * @return \Robo\Task\Development\GenerateTask|\Robo\Collection\CollectionBuilder
      */
     protected function taskGenTask($className, $wrapperClassName = '')
     {
@@ -37,7 +37,7 @@ trait loadTasks
     /**
      * @param string $pathToSemVer
      *
-     * @return SemVer
+     * @return \Robo\Task\Development\SemVer|\Robo\Collection\CollectionBuilder
      */
     protected function taskSemVer($pathToSemVer = '.semver')
     {
@@ -47,7 +47,7 @@ trait loadTasks
     /**
      * @param int $port
      *
-     * @return PhpServer
+     * @return \Robo\Task\Development\PhpServer|\Robo\Collection\CollectionBuilder
      */
     protected function taskServer($port = 8000)
     {
@@ -57,7 +57,7 @@ trait loadTasks
     /**
      * @param string $filename
      *
-     * @return PackPhar
+     * @return \Robo\Task\Development\PackPhar|\Robo\Collection\CollectionBuilder
      */
     protected function taskPackPhar($filename)
     {
@@ -67,7 +67,7 @@ trait loadTasks
     /**
      * @param string $tag
      *
-     * @return GitHubRelease
+     * @return \Robo\Task\Development\GitHubRelease|\Robo\Collection\CollectionBuilder
      */
     protected function taskGitHubRelease($tag)
     {
@@ -77,7 +77,7 @@ trait loadTasks
     /**
      * @param string|array $url
      *
-     * @return OpenBrowser
+     * @return \Robo\Task\Development\OpenBrowser|\Robo\Collection\CollectionBuilder
      */
     protected function taskOpenBrowser($url)
     {

--- a/src/Task/Docker/Commit.php
+++ b/src/Task/Docker/Commit.php
@@ -54,7 +54,7 @@ class Commit extends Base
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return $this
      */

--- a/src/Task/Docker/Exec.php
+++ b/src/Task/Docker/Exec.php
@@ -64,7 +64,7 @@ class Exec extends Base
     }
 
     /**
-     * {@inheritdoc)}
+     * {@inheritdoc}
      */
     public function interactive($interactive = true)
     {

--- a/src/Task/Docker/Run.php
+++ b/src/Task/Docker/Run.php
@@ -115,7 +115,7 @@ class Run extends Base
     }
 
     /**
-     * {@inheritdoc)}
+     * {@inheritdoc}
      */
     public function interactive($interactive = true)
     {
@@ -155,7 +155,8 @@ class Run extends Base
      * inherited from ExecTrait.
      *
      * @param array $env
-     * @return type
+     *
+     * @return $this
      */
     public function envVars(array $env)
     {

--- a/src/Task/Docker/loadTasks.php
+++ b/src/Task/Docker/loadTasks.php
@@ -6,7 +6,7 @@ trait loadTasks
     /**
      * @param string $image
      *
-     * @return \Robo\Task\Docker\Run
+     * @return \Robo\Task\Docker\Run|\Robo\Collection\CollectionBuilder
      */
     protected function taskDockerRun($image)
     {
@@ -16,7 +16,7 @@ trait loadTasks
     /**
      * @param string $image
      *
-     * @return \Robo\Task\Docker\Pull
+     * @return \Robo\Task\Docker\Pull|\Robo\Collection\CollectionBuilder
      */
     protected function taskDockerPull($image)
     {
@@ -26,7 +26,7 @@ trait loadTasks
     /**
      * @param string $path
      *
-     * @return \Robo\Task\Docker\Build
+     * @return \Robo\Task\Docker\Build|\Robo\Collection\CollectionBuilder
      */
     protected function taskDockerBuild($path = '.')
     {
@@ -36,7 +36,7 @@ trait loadTasks
     /**
      * @param string|\Robo\Task\Docker\Result $cidOrResult
      *
-     * @return \Robo\Task\Docker\Stop
+     * @return \Robo\Task\Docker\Stop|\Robo\Collection\CollectionBuilder
      */
     protected function taskDockerStop($cidOrResult)
     {
@@ -46,7 +46,7 @@ trait loadTasks
     /**
      * @param string|\Robo\Task\Docker\Result $cidOrResult
      *
-     * @return \Robo\Task\Docker\Commit
+     * @return \Robo\Task\Docker\Commit|\Robo\Collection\CollectionBuilder
      */
     protected function taskDockerCommit($cidOrResult)
     {
@@ -56,7 +56,7 @@ trait loadTasks
     /**
      * @param string|\Robo\Task\Docker\Result $cidOrResult
      *
-     * @return \Robo\Task\Docker\Start
+     * @return \Robo\Task\Docker\Start|\Robo\Collection\CollectionBuilder
      */
     protected function taskDockerStart($cidOrResult)
     {
@@ -66,7 +66,7 @@ trait loadTasks
     /**
      * @param string|\Robo\Task\Docker\Result $cidOrResult
      *
-     * @return \Robo\Task\Docker\Remove
+     * @return \Robo\Task\Docker\Remove|\Robo\Collection\CollectionBuilder
      */
     protected function taskDockerRemove($cidOrResult)
     {
@@ -76,7 +76,7 @@ trait loadTasks
     /**
      * @param string|\Robo\Task\Docker\Result $cidOrResult
      *
-     * @return \Robo\Task\Docker\Exec
+     * @return \Robo\Task\Docker\Exec|\Robo\Collection\CollectionBuilder
      */
     protected function taskDockerExec($cidOrResult)
     {

--- a/src/Task/File/Concat.php
+++ b/src/Task/File/Concat.php
@@ -26,7 +26,7 @@ class Concat extends BaseTask
     use ResourceExistenceChecker;
 
     /**
-     * @var array|Iterator
+     * @var array|\Iterator
      */
     protected $files;
 
@@ -38,7 +38,7 @@ class Concat extends BaseTask
     /**
      * Constructor.
      *
-     * @param array|Iterator $files
+     * @param array|\Iterator $files
      */
     public function __construct($files)
     {

--- a/src/Task/File/Write.php
+++ b/src/Task/File/Write.php
@@ -75,7 +75,8 @@ class Write extends BaseTask
      *
      * @param string $line
      *
-     * @return $this The current instance
+     * @return $this
+     *   The current instance.
      */
     public function line($line)
     {
@@ -88,7 +89,8 @@ class Write extends BaseTask
      *
      * @param array $lines
      *
-     * @return $this The current instance
+     * @return $this
+     *   The current instance.
      */
     public function lines(array $lines)
     {
@@ -101,7 +103,8 @@ class Write extends BaseTask
      *
      * @param string $text
      *
-     * @return $this The current instance
+     * @return $this
+     *   The current instance.
      */
     public function text($text)
     {
@@ -120,7 +123,8 @@ class Write extends BaseTask
      *
      * @param string $filename
      *
-     * @return $this The current instance
+     * @return $this
+     *   The current instance.
      */
     public function textFromFile($filename)
     {
@@ -134,7 +138,8 @@ class Write extends BaseTask
      * @param string $name
      * @param string $val
      *
-     * @return $this The current instance
+     * @return $this
+     *   The current instance.
      */
     public function place($name, $val)
     {
@@ -149,7 +154,8 @@ class Write extends BaseTask
      * @param string $string
      * @param string $replacement
      *
-     * @return $this The current instance
+     * @return $this
+     *   The current instance.
      */
     public function replace($string, $replacement)
     {
@@ -163,7 +169,8 @@ class Write extends BaseTask
      * @param string $pattern
      * @param string $replacement
      *
-     * @return $this The current instance
+     * @return $this
+     *   The current instance.
      */
     public function regexReplace($pattern, $replacement)
     {
@@ -202,8 +209,8 @@ class Write extends BaseTask
     }
 
     /**
-     * @param $contents string
-     * @param $filename string
+     * @param string $contents
+     * @param string $filename
      *
      * @return string
      */

--- a/src/Task/File/loadTasks.php
+++ b/src/Task/File/loadTasks.php
@@ -6,7 +6,7 @@ trait loadTasks
     /**
      * @param array|\Iterator $files
      *
-     * @return \Robo\Task\File\Concat
+     * @return \Robo\Task\File\Concat|\Robo\Collection\CollectionBuilder
      */
     protected function taskConcat($files)
     {
@@ -16,7 +16,7 @@ trait loadTasks
     /**
      * @param string $file
      *
-     * @return \Robo\Task\File\Replace
+     * @return \Robo\Task\File\Replace|\Robo\Collection\CollectionBuilder
      */
     protected function taskReplaceInFile($file)
     {
@@ -26,7 +26,7 @@ trait loadTasks
     /**
      * @param string $file
      *
-     * @return \Robo\Task\File\Write
+     * @return \Robo\Task\File\Write|\Robo\Collection\CollectionBuilder
      */
     protected function taskWriteToFile($file)
     {
@@ -39,7 +39,7 @@ trait loadTasks
      * @param string $baseDir
      * @param bool $includeRandomPart
      *
-     * @return \Robo\Task\File\TmpFile
+     * @return \Robo\Task\File\TmpFile|\Robo\Collection\CollectionBuilder
      */
     protected function taskTmpFile($filename = 'tmp', $extension = '', $baseDir = '', $includeRandomPart = true)
     {

--- a/src/Task/Filesystem/CopyDir.php
+++ b/src/Task/Filesystem/CopyDir.php
@@ -23,6 +23,8 @@ class CopyDir extends BaseDir
     /**
      * Explicitly declare our consturctor, so that
      * our copyDir() method does not look like a php4 constructor.
+     *
+     * @param string|string[] $dirs
      */
     public function __construct($dirs)
     {
@@ -140,6 +142,12 @@ class CopyDir extends BaseDir
 
     /**
      * Check to see if the current item is excluded.
+     *
+     * @param string $file
+     * @param string $src
+     * @param string $parent
+     *
+     * @return bool
      */
     protected function excluded($file, $src, $parent)
     {
@@ -154,6 +162,10 @@ class CopyDir extends BaseDir
     /**
      * Avoid problems comparing paths on Windows that may have a
      * combination of DIRECTORY_SEPARATOR and /.
+     *
+     * @param string$item
+     *
+     * @return string
      */
     protected function simplifyForCompare($item)
     {

--- a/src/Task/Filesystem/loadTasks.php
+++ b/src/Task/Filesystem/loadTasks.php
@@ -6,7 +6,7 @@ trait loadTasks
     /**
      * @param string|string[] $dirs
      *
-     * @return \Robo\Task\Filesystem\CleanDir
+     * @return \Robo\Task\Filesystem\CleanDir|\Robo\Collection\CollectionBuilder
      */
     protected function taskCleanDir($dirs)
     {
@@ -16,7 +16,7 @@ trait loadTasks
     /**
      * @param string|string[] $dirs
      *
-     * @return \Robo\Task\Filesystem\DeleteDir
+     * @return \Robo\Task\Filesystem\DeleteDir|\Robo\Collection\CollectionBuilder
      */
     protected function taskDeleteDir($dirs)
     {
@@ -28,7 +28,7 @@ trait loadTasks
      * @param string $base
      * @param bool $includeRandomPart
      *
-     * @return \Robo\Task\Filesystem\WorkDir
+     * @return \Robo\Task\Filesystem\WorkDir|\Robo\Collection\CollectionBuilder
      */
     protected function taskTmpDir($prefix = 'tmp', $base = '', $includeRandomPart = true)
     {
@@ -38,7 +38,7 @@ trait loadTasks
     /**
      * @param string $finalDestination
      *
-     * @return \Robo\Task\Filesystem\TmpDir
+     * @return \Robo\Task\Filesystem\TmpDir|\Robo\Collection\CollectionBuilder
      */
     protected function taskWorkDir($finalDestination)
     {
@@ -48,7 +48,7 @@ trait loadTasks
     /**
      * @param string|string[] $dirs
      *
-     * @return \Robo\Task\Filesystem\CopyDir
+     * @return \Robo\Task\Filesystem\CopyDir|\Robo\Collection\CollectionBuilder
      */
     protected function taskCopyDir($dirs)
     {
@@ -58,7 +58,7 @@ trait loadTasks
     /**
      * @param string|string[] $dirs
      *
-     * @return \Robo\Task\Filesystem\MirrorDir
+     * @return \Robo\Task\Filesystem\MirrorDir|\Robo\Collection\CollectionBuilder
      */
     protected function taskMirrorDir($dirs)
     {
@@ -68,7 +68,7 @@ trait loadTasks
     /**
      * @param string|string[] $dirs
      *
-     * @return \Robo\Task\Filesystem\FlattenDir
+     * @return \Robo\Task\Filesystem\FlattenDir|\Robo\Collection\CollectionBuilder
      */
     protected function taskFlattenDir($dirs)
     {
@@ -76,7 +76,7 @@ trait loadTasks
     }
 
     /**
-     * @return \Robo\Task\Filesystem\FilesystemStack
+     * @return \Robo\Task\Filesystem\FilesystemStack|\Robo\Collection\CollectionBuilder
      */
     protected function taskFilesystemStack()
     {

--- a/src/Task/Gulp/loadTasks.php
+++ b/src/Task/Gulp/loadTasks.php
@@ -7,7 +7,7 @@ trait loadTasks
      * @param string $task
      * @param null|string $pathToGulp
      *
-     * @return \Robo\Task\Gulp\Run
+     * @return \Robo\Task\Gulp\Run|\Robo\Collection\CollectionBuilder
      */
     protected function taskGulpRun($task = 'default', $pathToGulp = null)
     {

--- a/src/Task/Npm/Install.php
+++ b/src/Task/Npm/Install.php
@@ -21,7 +21,7 @@ use Robo\Contract\CommandInterface;
 class Install extends Base implements CommandInterface
 {
     /**
-     * @var string
+     * {@inheritdoc}
      */
     protected $action = 'install';
 

--- a/src/Task/Npm/Update.php
+++ b/src/Task/Npm/Update.php
@@ -19,7 +19,7 @@ namespace Robo\Task\Npm;
 class Update extends Base
 {
     /**
-     * @var string
+     * {@inheritdoc}
      */
     protected $action = 'update';
 

--- a/src/Task/Npm/loadTasks.php
+++ b/src/Task/Npm/loadTasks.php
@@ -6,7 +6,7 @@ trait loadTasks
     /**
      * @param null|string $pathToNpm
      *
-     * @return \Robo\Task\Npm\Install
+     * @return \Robo\Task\Npm\Install|\Robo\Collection\CollectionBuilder
      */
     protected function taskNpmInstall($pathToNpm = null)
     {
@@ -16,7 +16,7 @@ trait loadTasks
     /**
      * @param null|string $pathToNpm
      *
-     * @return \Robo\Task\Npm\Update
+     * @return \Robo\Task\Npm\Update|\Robo\Collection\CollectionBuilder
      */
     protected function taskNpmUpdate($pathToNpm = null)
     {

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -447,6 +447,8 @@ class Rsync extends BaseTask implements CommandInterface
     }
 
     /**
+     * @param string $from
+     *
      * @return string
      */
     protected function getFromPathSpec($from)

--- a/src/Task/Remote/loadTasks.php
+++ b/src/Task/Remote/loadTasks.php
@@ -4,7 +4,7 @@ namespace Robo\Task\Remote;
 trait loadTasks
 {
     /**
-     * @return \Robo\Task\Remote\Rsync
+     * @return \Robo\Task\Remote\Rsync|\Robo\Collection\CollectionBuilder
      */
     protected function taskRsync()
     {
@@ -15,7 +15,7 @@ trait loadTasks
      * @param null|string $hostname
      * @param null|string $user
      *
-     * @return \Robo\Task\Remote\Ssh
+     * @return \Robo\Task\Remote\Ssh|\Robo\Collection\CollectionBuilder
      */
     protected function taskSshExec($hostname = null, $user = null)
     {

--- a/src/Task/Simulator.php
+++ b/src/Task/Simulator.php
@@ -43,7 +43,7 @@ class Simulator extends BaseTask implements CommandInterface
      * @param string $function
      * @param array $args
      *
-     * @return \Robo\Result|\Robo\Task\Simulator
+     * @return \Robo\Result|$this
      */
     public function __call($function, $args)
     {
@@ -109,7 +109,7 @@ class Simulator extends BaseTask implements CommandInterface
     }
 
     /**
-     * @param string $action
+     * @param array $action
      *
      * @return string
      */

--- a/src/Task/StackBasedTask.php
+++ b/src/Task/StackBasedTask.php
@@ -85,7 +85,7 @@ abstract class StackBasedTask extends BaseTask
      * this class.  Calling one of the delegate's methods will defer
      * execution until the run() method is called.
      *
-     * @return null
+     * @return null|object
      */
     protected function getDelegate()
     {
@@ -219,7 +219,7 @@ abstract class StackBasedTask extends BaseTask
      * Execute one task method
      *
      * @param string $command
-     * @param string $action
+     * @param array $action
      *
      * @return \Robo\Result
      */

--- a/src/Task/Testing/Atoum.php
+++ b/src/Task/Testing/Atoum.php
@@ -48,7 +48,7 @@ class Atoum extends BaseTask implements CommandInterface, PrintedInterface
     /**
      * Tag or Tags to filter.
      *
-     * @param string|array $tags
+     * @param string|string[] $tags
      *
      * @return $this
      */
@@ -124,7 +124,7 @@ class Atoum extends BaseTask implements CommandInterface, PrintedInterface
     /**
      * Test file or test files to run.
      *
-     * @param string|array
+     * @param string|string[]
      *
      * @return $this
      */
@@ -136,7 +136,8 @@ class Atoum extends BaseTask implements CommandInterface, PrintedInterface
     /**
      * Test directory or directories to run.
      *
-     * @param string|array A single directory or a list of directories.
+     * @param string|string[]
+     *   A single directory or a list of directories.
      *
      * @return $this
      */
@@ -147,7 +148,7 @@ class Atoum extends BaseTask implements CommandInterface, PrintedInterface
 
     /**
      * @param string $option
-     * @param string|array $values
+     * @param string|string[] $values
      *
      * @return $this
      */

--- a/src/Task/Testing/Behat.php
+++ b/src/Task/Testing/Behat.php
@@ -74,7 +74,7 @@ class Behat extends BaseTask implements CommandInterface, PrintedInterface
     }
 
     /**
-     * @param $config_file
+     * @param string $config_file
      *
      * @return $this
      */
@@ -142,10 +142,7 @@ class Behat extends BaseTask implements CommandInterface, PrintedInterface
     }
 
     /**
-     * Returns command that can be executed.
-     * This method is used to pass generated command from one task to another.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getCommand()
     {

--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -28,7 +28,7 @@ use Symfony\Component\Process\Process;
 class Codecept extends BaseTask implements CommandInterface, PrintedInterface
 {
     use \Robo\Common\ExecOneCommand;
-    
+
     /**
      * @var string
      */

--- a/src/Task/Testing/PHPUnit.php
+++ b/src/Task/Testing/PHPUnit.php
@@ -35,6 +35,13 @@ class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
      */
     protected $files = '';
 
+    /**
+     * PHPUnit constructor.
+     *
+     * @param null|string $pathToPhpUnit
+     *
+     * @throws \Robo\Exception\TaskException
+     */
     public function __construct($pathToPhpUnit = null)
     {
         $this->command = $pathToPhpUnit;
@@ -150,7 +157,8 @@ class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
     /**
      * Directory of test files or single test file to run.
      *
-     * @param string $files A single test file or a directory containing test files.
+     * @param string $files
+     *   A single test file or a directory containing test files.
      *
      * @return $this
      *
@@ -171,7 +179,8 @@ class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
     /**
      * Test the provided file.
      *
-     * @param string $file path to file to test
+     * @param string $file
+     *   Path to file to test.
      *
      * @return $this
      */

--- a/src/Task/Testing/Phpspec.php
+++ b/src/Task/Testing/Phpspec.php
@@ -28,15 +28,24 @@ class Phpspec extends BaseTask implements CommandInterface, PrintedInterface
     protected $command;
 
     /**
-     * @var string[] $formaters available formaters for format option
+     * @var string[] $formaters
+     *   Available formaters for format option.
      */
     protected $formaters = ['progress', 'html', 'pretty', 'junit', 'dot', 'tap'];
 
     /**
-     * @var array $verbose_levels available verbose levels
+     * @var array $verbose_levels
+     *   Available verbose levels.
      */
     protected $verbose_levels = ['v', 'vv', 'vvv'];
 
+    /**
+     * Phpspec constructor.
+     *
+     * @param null|string $pathToPhpspec
+     *
+     * @throws \Robo\Exception\TaskException
+     */
     public function __construct($pathToPhpspec = null)
     {
         $this->command = $pathToPhpspec;
@@ -67,6 +76,11 @@ class Phpspec extends BaseTask implements CommandInterface, PrintedInterface
         return $this;
     }
 
+    /**
+     * @param string $level
+     *
+     * @return $this
+     */
     public function verbose($level = 'v')
     {
         if (!in_array($level, $this->verbose_levels)) {
@@ -76,24 +90,40 @@ class Phpspec extends BaseTask implements CommandInterface, PrintedInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function noAnsi()
     {
         $this->option('no-ansi');
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function noInteraction()
     {
         $this->option('no-interaction');
         return $this;
     }
 
+    /**
+     * @param string $config_file
+     *
+     * @return $this
+     */
     public function config($config_file)
     {
         $this->option('config', $config_file);
         return $this;
     }
 
+    /**
+     * @param string $formater
+     *
+     * @return $this
+     */
     public function format($formater)
     {
         if (!in_array($formater, $this->formaters)) {
@@ -103,11 +133,17 @@ class Phpspec extends BaseTask implements CommandInterface, PrintedInterface
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getCommand()
     {
         return $this->command . $this->arguments;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function run()
     {
         $this->printTaskInfo('Running phpspec {arguments}', ['arguments' => $this->arguments]);

--- a/src/Task/Testing/loadTasks.php
+++ b/src/Task/Testing/loadTasks.php
@@ -6,7 +6,7 @@ trait loadTasks
     /**
      * @param null|string $pathToCodeception
      *
-     * @return \Robo\Task\Testing\Codecept
+     * @return \Robo\Task\Testing\Codecept|\Robo\Collection\CollectionBuilder
      */
     protected function taskCodecept($pathToCodeception = null)
     {
@@ -16,7 +16,7 @@ trait loadTasks
     /**
      * @param null|string $pathToPhpUnit
      *
-     * @return \Robo\Task\Testing\PHPUnit
+     * @return \Robo\Task\Testing\PHPUnit|\Robo\Collection\CollectionBuilder
      */
     protected function taskPhpUnit($pathToPhpUnit = null)
     {
@@ -24,9 +24,9 @@ trait loadTasks
     }
 
     /**
-     * @param null $pathToPhpspec
+     * @param null|string $pathToPhpspec
      *
-     * @return \Robo\Task\Testing\Phpspec
+     * @return \Robo\Task\Testing\Phpspec|\Robo\Collection\CollectionBuilder
      */
     protected function taskPhpspec($pathToPhpspec = null)
     {
@@ -34,9 +34,9 @@ trait loadTasks
     }
 
     /**
-     * @param null $pathToAtoum
+     * @param null|string $pathToAtoum
      *
-     * @return \Robo\Task\Testing\Atoum
+     * @return \Robo\Task\Testing\Atoum|\Robo\Collection\CollectionBuilder
      */
     protected function taskAtoum($pathToAtoum = null)
     {
@@ -44,9 +44,9 @@ trait loadTasks
     }
 
     /**
-     * @param null $pathToBehat
+     * @param null|string $pathToBehat
      *
-     * @return \Robo\Task\Testing\Behat
+     * @return \Robo\Task\Testing\Behat|\Robo\Collection\CollectionBuilder
      */
     protected function taskBehat($pathToBehat = null)
     {

--- a/src/Task/Vcs/GitStack.php
+++ b/src/Task/Vcs/GitStack.php
@@ -42,6 +42,7 @@ class GitStack extends CommandStack
      *
      * @param string $repo
      * @param string $to
+     * @param string $branch
      *
      * @return $this
      */

--- a/src/Task/Vcs/SvnStack.php
+++ b/src/Task/Vcs/SvnStack.php
@@ -34,7 +34,7 @@ class SvnStack extends CommandStack implements CommandInterface
     protected $stopOnFail = false;
 
     /**
-     * @var \Robo\Result
+     * {@inheritdoc}
      */
     protected $result;
 
@@ -60,7 +60,7 @@ class SvnStack extends CommandStack implements CommandInterface
      *
      * @param string $path
      *
-     * @return $this;
+     * @return $this
      */
     public function update($path = '')
     {

--- a/src/Task/Vcs/loadTasks.php
+++ b/src/Task/Vcs/loadTasks.php
@@ -8,7 +8,7 @@ trait loadTasks
      * @param string $password
      * @param string $pathToSvn
      *
-     * @return \Robo\Task\Vcs\SvnStack
+     * @return \Robo\Task\Vcs\SvnStack|\Robo\Collection\CollectionBuilder
      */
     protected function taskSvnStack($username = '', $password = '', $pathToSvn = 'svn')
     {
@@ -18,7 +18,7 @@ trait loadTasks
     /**
      * @param string $pathToGit
      *
-     * @return \Robo\Task\Vcs\GitStack
+     * @return \Robo\Task\Vcs\GitStack|\Robo\Collection\CollectionBuilder
      */
     protected function taskGitStack($pathToGit = 'git')
     {
@@ -28,7 +28,7 @@ trait loadTasks
     /**
      * @param string $pathToHg
      *
-     * @return \Robo\Task\Vcs\HgStack
+     * @return \Robo\Task\Vcs\HgStack|\Robo\Collection\CollectionBuilder
      */
     protected function taskHgStack($pathToHg = 'hg')
     {

--- a/tests/src/RoboFileFixture.php
+++ b/tests/src/RoboFileFixture.php
@@ -23,7 +23,8 @@ class RoboFileFixture extends \Robo\Tasks implements LoggerAwareInterface, Custo
     /**
      * Demonstrate Robo variable argument passing.
      *
-     * @param $a A list of commandline parameters.
+     * @param array $a
+     *   A list of commandline parameters.
      */
     public function testArrayArgs(array $a)
     {


### PR DESCRIPTION
This pull request contains only PHPDoc modifications.
For example `@param $foo` vs `@param string $foo`