### PR TITLE
Add sourcemap support for src/Task/Assets/Scss.php

### DIFF
--- a/src/Task/Assets/Scss.php
+++ b/src/Task/Assets/Scss.php
@@ -63,6 +63,10 @@ class Scss extends CssPreprocessor
             $scss->setFormatter($this->compilerOptions['formatter']);
         }
 
+        if (isset($this->compilerOptions['sourceMap'])) {
+            $scss->setSourceMap($this->compilerOptions['sourceMap']);
+        }
+
         return $scss->compile($scssCode);
     }
 


### PR DESCRIPTION
### Related issue

https://github.com/consolidation/Robo/issues/884

### Overview
This pull request:

- [X] Adds a feature

### Summary
By doing:
```php
$compiler_options['sourceMap'] = Compiler::SOURCE_MAP_INLINE;
$result = $this->taskScss()
   ->setFormatter($formatter)
   ->compiler('scssphp', $compiler_options)
   ->run();
```

### Description
It might need extra work for support sourcemap in a file.


(https://github.com/consolidation/Robo/pull/885 against `master`)