### PR TITLE
taskPack modified to correctly set file permissions in ZIP files (ins…

### DIFF
--- a/src/Task/Archive/Pack.php
+++ b/src/Task/Archive/Pack.php
@@ -245,10 +245,20 @@ class Pack extends BaseTask implements PrintedInterface
                     if (!$zip->addFile($file->getRealpath(), "{$placementLocation}/{$relativePathname}")) {
                         return Result::error($this, "Could not add directory $filesystemLocation to the archive; error adding {$file->getRealpath()}.");
                     }
+                    if (stripos(PHP_OS, 'WIN') !== 0)
+                    {
+                        $zip->setExternalAttributesName("{$placementLocation}/{$relativePathname}", \ZipArchive::OPSYS_UNIX,
+                            $file->getPerms() << 16);
+                    }
                 }
             } elseif (is_file($filesystemLocation)) {
                 if (!$zip->addFile($filesystemLocation, $placementLocation)) {
                     return Result::error($this, "Could not add file $filesystemLocation to the archive.");
+                }
+                if (stripos(PHP_OS, 'WIN') !== 0)
+                {
+                    $zip->setExternalAttributesName($placementLocation, \ZipArchive::OPSYS_UNIX,
+                        fileperms($filesystemLocation) << 16);
                 }
             } else {
                 return Result::error($this, "Could not find $filesystemLocation for the archive.");


### PR DESCRIPTION
…tead of default 0666)

### Overview
This pull request:
- [x] Adds a feature

### Summary
taskPack modified to correctly set file permissions in ZIP files

### Description
Without these changes, on any Unix/Linux system, created ZIP files extracts with all files having permissions 0666 and there is no way to change it. This fix adds code to automatically set permissions in archive same to permissions of original files.