### PR TITLE
Fix BuilderAwareTrait.php to prevent Fatal Error

### DIFF
--- a/src/Common/BuilderAwareTrait.php
+++ b/src/Common/BuilderAwareTrait.php
@@ -40,6 +40,11 @@ trait BuilderAwareTrait
      */
     protected function collectionBuilder()
     {
+        // Check builder is not null, or FATAL ERROR will be raised
+        if (is_null($this->getBuilder()) {
+            throw new \RuntimeException('Builder CANNOT be null');
+        }
+            
         return $this->getBuilder()->newBuilder();
     }
 }


### PR DESCRIPTION
### Overview
This pull request:
Fixes the BuilderAwareTrait.php to prevent fatal error

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Added a null check and throwing an exception which can be caught in user code unlike fatal errors.

### Description
Fixes the BuilderAwareTrait.php to prevent Fatal Error:
PHP Fatal error:  Uncaught Error: Call to a member function newBuilder() on null in /vendor/consolidation/robo/src/Common/BuilderAwareTrait.php:43
