### PR TITLE
Changed leafo to scssphp as leafo is archived

### DIFF
--- a/src/Task/Assets/Scss.php
+++ b/src/Task/Assets/Scss.php
@@ -19,7 +19,7 @@ use Robo\Result;
  * Use the following scss compiler in your project:
  *
  * ```
- * "leafo/scssphp": "~0.1",
+ * "scssphp/scssphp ": "~1.0.0",
  * ```
  *
  * You can implement additional compilers by extending this task and adding a
@@ -34,12 +34,12 @@ class Scss extends CssPreprocessor
      * @var string[]
      */
     protected $compilers = [
-        'scssphp', // https://github.com/leafo/scssphp
+        'scssphp', // https://github.com/scssphp/scssphp
     ];
 
     /**
      * scssphp compiler
-     * @link https://github.com/leafo/scssphp
+     * @link https://github.com/scssphp/scssphp
      *
      * @param string $file
      *
@@ -47,12 +47,12 @@ class Scss extends CssPreprocessor
      */
     protected function scssphp($file)
     {
-        if (!class_exists('\Leafo\ScssPhp\Compiler')) {
-            return Result::errorMissingPackage($this, 'scssphp', 'leafo/scssphp');
+        if (!class_exists('\ScssPhp\ScssPhp\Compiler')) {
+            return Result::errorMissingPackage($this, 'scssphp', 'scssphp/scssphp');
         }
 
         $scssCode = file_get_contents($file);
-        $scss = new \Leafo\ScssPhp\Compiler();
+        $scss = new \ScssPhp\ScssPhp\Compiler();
 
         // set options for the scssphp compiler
         if (isset($this->compilerOptions['importDirs'])) {
@@ -71,16 +71,16 @@ class Scss extends CssPreprocessor
      *
      * The method setFormatter($formatterName) sets the current formatter to $formatterName,
      * the name of a class as a string that implements the formatting interface. See the source
-     * for Leafo\ScssPhp\Formatter\Expanded for an example.
+     * for ScssPhp\ScssPhp\Formatter\Expanded for an example.
      *
-     * Five formatters are included with leafo/scssphp:
-     * - Leafo\ScssPhp\Formatter\Expanded
-     * - Leafo\ScssPhp\Formatter\Nested (default)
-     * - Leafo\ScssPhp\Formatter\Compressed
-     * - Leafo\ScssPhp\Formatter\Compact
-     * - Leafo\ScssPhp\Formatter\Crunched
+     * Five formatters are included with scssphp/scssphp:
+     * - ScssPhp\ScssPhp\Formatter\Expanded
+     * - ScssPhp\ScssPhp\Formatter\Nested (default)
+     * - ScssPhp\ScssPhp\Formatter\Compressed
+     * - ScssPhp\ScssPhp\Formatter\Compact
+     * - ScssPhp\ScssPhp\Formatter\Crunched
      *
-     * @link http://leafo.github.io/scssphp/docs/#output-formatting
+     * @link https://scssphp.github.io/scssphp/docs/#output-formatting
      *
      * @param string $formatterName
      *


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Changed out leafo/scssphp to scssphp/scssphp as leafo/scssphp is archived, and development is continuting at scssphp/scssphp.

### Description
Development is continuting at scssphp/scssphp, see https://github.com/leafo/scssphp and new repo https://github.com/scssphp/scssphp.

Will need to update documentation on robo.li: https://robo.li/tasks/Assets/#scss
