### PR TITLE
Class ZipArchive does not have a constructor

### DIFF
--- a/src/Task/Archive/Pack.php
+++ b/src/Task/Archive/Pack.php
@@ -215,7 +215,7 @@ class Pack extends BaseTask implements PrintedInterface
             return Result::errorMissingExtension($this, 'zlib', 'zip packing');
         }
 
-        $zip = new \ZipArchive($archiveFile, \ZipArchive::CREATE);
+        $zip = new \ZipArchive();
         if (!$zip->open($archiveFile, \ZipArchive::CREATE)) {
             return Result::error($this, "Could not create zip archive {$archiveFile}");
         }


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Class ZipArchive does not have a constructor and must be instantiated without any parameters.

### Description
https://www.php.net/manual/en/class.ziparchive.php

props. @phpstan
