### PR TITLE
Incorrect namespace for IOAwareInterface

### DIFF
--- a/src/Robo.php
+++ b/src/Robo.php
@@ -324,7 +324,7 @@ class Robo
             ->invokeMethod('setLogger', ['logger']);
         $container->inflector(\League\Container\ContainerAwareInterface::class)
             ->invokeMethod('setContainer', ['container']);
-        $container->inflector(\Robo\Symfony\IOAwareInterface::class)
+        $container->inflector(\Robo\Contract\IOAwareInterface::class)
             ->invokeMethod('setIOStorage', ['ioStorage']);
         $container->inflector(\Symfony\Component\Console\Input\InputAwareInterface::class)
             ->invokeMethod('setInput', ['input']);


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
`Robo\Contract\IOAwareInterface`

### Description

not done by a human, props. @phpstan