### PR TITLE
Hide error output when printing has been disabled

### DIFF
--- a/src/Log/ResultPrinter.php
+++ b/src/Log/ResultPrinter.php
@@ -73,8 +73,8 @@ class ResultPrinter implements LoggerAwareInterface, ProgressIndicatorAwareInter
         }
         if ($printOutput) {
             $this->printMessage(LogLevel::ERROR, "{message}", $context);
+            $this->printMessage(LogLevel::ERROR, 'Exit code {code}', $context);
         }
-        $this->printMessage(LogLevel::ERROR, 'Exit code {code}', $context);
         return true;
     }
 


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Hide error output when printing has been disabled

### Description
Nothing should be printed if printing is disabled.
Before, successful messages were being hidden, but error exit codes were being printed out, even if `$task->silent(true);`