### PR TITLE
added the --no-suggest option to composer tasks

### DIFF
--- a/docs/tasks/Composer.md
+++ b/docs/tasks/Composer.md
@@ -209,6 +209,7 @@ $this->taskComposerInstall('path/to/my/composer.phar')
 * `ignorePlatformRequirements($ignore = null)`  adds `ignore-platform-reqs` option to composer
 * `disablePlugins($disable = null)`  disable plugins
 * `noScripts($disable = null)`  skip scripts
+* `noSuggest($noSuggest = true)` skip suggestions
 * `workingDir($dir)`  adds `--working-dir $dir` option to composer
 * `buildCommand()`  Copy class fields into command options as directed.
 * `dir($dir)`  Changes working directory of command
@@ -282,6 +283,7 @@ $this->taskComposerRequire()->dependency('foo/bar', '^.2.4.8')->run();
 * `ignorePlatformRequirements($ignore = null)`  adds `ignore-platform-reqs` option to composer
 * `disablePlugins($disable = null)`  disable plugins
 * `noScripts($disable = null)`  skip scripts
+* `noSuggest($noSuggest = true)` skip suggestions
 * `workingDir($dir)`  adds `--working-dir $dir` option to composer
 * `buildCommand()`  Copy class fields into command options as directed.
 * `dir($dir)`  Changes working directory of command
@@ -326,6 +328,7 @@ $this->taskComposerUpdate('path/to/my/composer.phar')
 * `ignorePlatformRequirements($ignore = null)`  adds `ignore-platform-reqs` option to composer
 * `disablePlugins($disable = null)`  disable plugins
 * `noScripts($disable = null)`  skip scripts
+* `noSuggest($noSuggest = true)` skip suggestions
 * `workingDir($dir)`  adds `--working-dir $dir` option to composer
 * `buildCommand()`  Copy class fields into command options as directed.
 * `dir($dir)`  Changes working directory of command

--- a/src/Task/Composer/Install.php
+++ b/src/Task/Composer/Install.php
@@ -31,7 +31,7 @@ class Install extends Base
 
     /**
      * adds `no-suggest` option to composer
-     * 
+     *
      * @param bool $noSuggest
      *
      * @return $this

--- a/src/Task/Composer/Install.php
+++ b/src/Task/Composer/Install.php
@@ -30,6 +30,19 @@ class Install extends Base
     protected $action = 'install';
 
     /**
+     * adds `no-suggest` option to composer
+     * 
+     * @param bool $noSuggest
+     *
+     * @return $this
+     */
+    public function noSuggest($noSuggest = true)
+    {
+        $this->option('--no-suggest');
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function run()

--- a/src/Task/Composer/RequireDependency.php
+++ b/src/Task/Composer/RequireDependency.php
@@ -44,6 +44,19 @@ class RequireDependency extends Base
     }
 
     /**
+     * adds `no-suggest` option to composer
+     *
+     * @param bool $noSuggest
+     *
+     * @return $this
+     */
+    public function noSuggest($noSuggest = true)
+    {
+        $this->option('--no-suggest');
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function run()

--- a/src/Task/Composer/Update.php
+++ b/src/Task/Composer/Update.php
@@ -30,6 +30,19 @@ class Update extends Base
     protected $action = 'update';
 
     /**
+     * adds `no-suggest` option to composer
+     *
+     * @param bool $noSuggest
+     *
+     * @return $this
+     */
+    public function noSuggest($noSuggest = true)
+    {
+        $this->option('--no-suggest');
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function run()


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [x] Adds or fixes documentation

### Summary
Added the ability to use composer install, update and require tasks with the `--no-suggest` option

### Description
```php
$this->taskComposerInstall()->noSuggest()->run(); // composer install --no-suggest
```

Regarding tests, i found some related to composer tasks in https://github.com/consolidation/Robo/blob/master/tests/unit/Task/ComposerTest.php but i haven't been able to run them. I can add some if required but i would need some guidance on how to do it.

Thanks