### PR TITLE
Docker builds with Buildkit

### DIFF
--- a/docs/tasks/Docker.md
+++ b/docs/tasks/Docker.md
@@ -28,6 +28,7 @@ Class Build
 * `option($option, $value = null, $separator = null)`  Pass option to executable. Options are prefixed with `--` , value can be provided in second parameter.
 * `options(array $options, $separator = null)`  Pass multiple options to executable. The associative array contains
 * `optionList($option, $value = null, $separator = null)`  Pass an option with multiple values to executable. Value can be a string or array.
+* `enableBuildKit()`  Build with [Docker Buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/)
 
 ## Commit
 

--- a/src/Task/Docker/Build.php
+++ b/src/Task/Docker/Build.php
@@ -27,6 +27,9 @@ class Build extends Base
      */
     protected $path;
     
+    /**
+     * @var bool
+     */
     protected $buildKit = false;
 
     /**

--- a/src/Task/Docker/Build.php
+++ b/src/Task/Docker/Build.php
@@ -64,13 +64,11 @@ class Build extends Base
     }
     
     /**
-     * @param bool $buildKit
-     *
      * @return $this
      */
-    public function enableBuildKit($buildKit = true)
+    public function enableBuildKit()
     {
-        $this->buildKit = $buildKit;
+        $this->buildKit = true;
         return $this;
     }
 }

--- a/src/Task/Docker/Build.php
+++ b/src/Task/Docker/Build.php
@@ -26,6 +26,8 @@ class Build extends Base
      * @var string
      */
     protected $path;
+    
+    protected $buildKit = false;
 
     /**
      * @param string $path
@@ -41,7 +43,11 @@ class Build extends Base
      */
     public function getCommand()
     {
-        return $this->command . ' ' . $this->arguments . ' ' . $this->path;
+        $command = $this->command;
+        if ($this->buildKit) {
+            $command = 'DOCKER_BUILDKIT=1 ' . $command;
+        }
+        return $command . ' ' . $this->arguments . ' ' . $this->path;
     }
 
     /**
@@ -52,5 +58,16 @@ class Build extends Base
     public function tag($tag)
     {
         return $this->option('-t', $tag);
+    }
+    
+    /**
+     * @param bool $buildKit
+     *
+     * @return $this
+     */
+    public function enableBuildKit($buildKit = true)
+    {
+        $this->buildKit = $buildKit;
+        return $this;
     }
 }

--- a/tests/unit/Task/DockerTest.php
+++ b/tests/unit/Task/DockerTest.php
@@ -27,6 +27,9 @@ class DockerTest extends \Codeception\TestCase\Test
 
         (new \Robo\Task\Docker\Build())->tag('something')->run();
         $docker->verifyInvoked('executeCommand', ['docker build  -t something .']);
+
+        (new \Robo\Task\Docker\Build())->enableBuildKit()->tag('something')->run();
+        $docker->verifyInvoked('executeCommand', ['DOCKER_BUILDKIT=1 docker build  -t something .']);
     }
 
     public function testDockerCommit()


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [x] Adds or fixes documentation

### Summary

Adds a new toggle for enabling Docker Buildkit.
If enabled, the required environment variable will be prepended to the command.

### Description

Commits should be squashed. :)
