### PR TITLE
Fixes #936: Github access_token via query parameter is deprecated.

### DIFF
--- a/src/Task/Development/GitHub.php
+++ b/src/Task/Development/GitHub.php
@@ -133,7 +133,7 @@ abstract class GitHub extends BaseTask
         }
 
         if (!empty($this->accessToken)) {
-            $url .= "?access_token=" . $this->accessToken;
+            curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: ' . sprintf('token %s', $this->accessToken)]);
         }
 
         curl_setopt_array(


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
See #936: Github has deprecated the usage of access_token via a query parameter as Robo currently uses for Github requests. You should use an authorization header with the access token instead.

This is untested but I'm pretty sure should work.
