### PR TITLE
Add a limit to replace via regexp

### DIFF
--- a/src/Task/File/Replace.php
+++ b/src/Task/File/Replace.php
@@ -45,6 +45,11 @@ class Replace extends BaseTask
     protected $from;
 
     /**
+     * @var integer
+     */
+    protected $limit = -1;
+
+    /**
      * @var string|string[]
      */
     protected $to;
@@ -113,6 +118,19 @@ class Replace extends BaseTask
     }
 
     /**
+     * If used with $this->regexp() how many counts will be replaced
+     *
+     * @param int $limit
+     *
+     * @return $this
+     */
+    public function limit($limit)
+    {
+        $this->limit = $limit;
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function run()
@@ -124,7 +142,7 @@ class Replace extends BaseTask
 
         $text = file_get_contents($this->filename);
         if ($this->regex) {
-            $text = preg_replace($this->regex, $this->to, $text, -1, $count);
+            $text = preg_replace($this->regex, $this->to, $text, $this->limit, $count);
         } else {
             $text = str_replace($this->from, $this->to, $text, $count);
         }


### PR DESCRIPTION
# Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary

When using [Replace with Regexp](https://robo.li/tasks/File/#replace) there is no possibility to add a limit to the replaced items. This would be useful for instance when I replace version numbers in the DocBlock of fields and we want to replace only a single occurence.

for consolidation/Robo#945