### PR TITLE
Use Process::fromShellCommandline when constructing a Process object from a command string.

### DIFF
--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -141,7 +141,7 @@ trait ExecCommand
     protected function executeCommand($command)
     {
         // TODO: Symfony 4 requires that we supply the working directory.
-        $result_data = $this->execute(new Process($command, getcwd()));
+        $result_data = $this->execute(Process::fromShellCommandline($command, getcwd()));
         return new Result(
             $this,
             $result_data->getExitCode(),

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -78,7 +78,7 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
     public function process($command)
     {
         // TODO: Symfony 4 requires that we supply the working directory.
-        $this->processes[] = new Process($this->receiveCommand($command), getcwd());
+        $this->processes[] = Process::fromShellCommandline($this->receiveCommand($command), getcwd());
         return $this;
     }
 


### PR DESCRIPTION
c.f. #917 