### PR TITLE
Escape SSH commands correctly

### DIFF
--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -2,6 +2,7 @@
 
 namespace Robo\Task\Remote;
 
+use Robo\Common\ProcessUtils;
 use Robo\Contract\CommandInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
@@ -261,13 +262,13 @@ class Ssh extends BaseTask implements CommandInterface, SimulatedInterface
      */
     protected function sshCommand($command)
     {
-        $command = $this->receiveCommand($command);
+        $command = ProcessUtils::escapeArgument($this->receiveCommand($command));
         $sshOptions = $this->arguments;
         $hostSpec = $this->hostname;
         if ($this->user) {
             $hostSpec = $this->user . '@' . $hostSpec;
         }
 
-        return "ssh{$sshOptions} {$hostSpec} '{$command}'";
+        return "ssh{$sshOptions} {$hostSpec} {$command}";
     }
 }

--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -2,7 +2,6 @@
 
 namespace Robo\Task\Remote;
 
-use Robo\Common\ProcessUtils;
 use Robo\Contract\CommandInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
@@ -262,7 +261,7 @@ class Ssh extends BaseTask implements CommandInterface, SimulatedInterface
      */
     protected function sshCommand($command)
     {
-        $command = ProcessUtils::escapeArgument($this->receiveCommand($command));
+        $command = static::escape($this->receiveCommand($command));
         $sshOptions = $this->arguments;
         $hostSpec = $this->hostname;
         if ($this->user) {


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
This changes the way SSH commands are escaped in order to work with commands containing `'`.

### Description
Consider the following code:
```php
    $gitTask = $this->taskGitStack()
      ->commit('foo bar');

    $this->taskSshExec()
      ->exec($gitTask)
      ->run();
```

Without this patch, it will produce (which will fail):
```bash
ssh server 'cd "/path/" && git commit -m 'foo bar''
```

And with the patch:
```bash
ssh server 'cd "/path/" && git commit -m '\''foo bar'\'''
```
(Now the Git message is escaped correctly.)

Sorry, we are still stuck on Robo 1.4.12 but I would understand if you didn't want to merge a fix on this old branch.