### PR TITLE
Create a semver file if using the SemVer task for the first time

### DIFF
--- a/src/Task/Development/SemVer.php
+++ b/src/Task/Development/SemVer.php
@@ -226,6 +226,7 @@ class SemVer implements TaskInterface
         if (empty($this->path)) {
             return true;
         }
+
         $semver = sprintf(
             self::SEMVER,
             $this->version['major'],
@@ -234,7 +235,8 @@ class SemVer implements TaskInterface
             $this->version['special'],
             $this->version['metadata']
         );
-        if (is_writeable($this->path) === false || file_put_contents($this->path, $semver) === false) {
+
+        if (file_put_contents($this->path, $semver) === false) {
             throw new TaskException($this, 'Failed to write semver file.');
         }
         return true;

--- a/tests/integration/SemVerTest.php
+++ b/tests/integration/SemVerTest.php
@@ -1,0 +1,43 @@
+<?php
+namespace Robo;
+
+use PHPUnit\Framework\TestCase;
+use Robo\Traits\TestTasksTrait;
+
+class SemVerTest extends TestCase
+{
+    use TestTasksTrait;
+    use Task\Development\loadTasks;
+
+    protected $fixtures;
+
+    public function setUp()
+    {
+        $this->fixtures = new Fixtures();
+        $this->initTestTasksTrait();
+    }
+
+    public function tearDown()
+    {
+        $this->fixtures->cleanup();
+    }
+
+    public function testSemVerFileWrite()
+    {
+        $this->fixtures->createAndCdToSandbox();
+
+        $sampleCss = $this->fixtures->dataFile('sample.css');
+
+        $outputFile = '.semver';
+
+        $result = $this->taskSemVer($outputFile)
+            ->increment()
+            ->run();
+
+        $this->assertTrue($result->wasSuccessful(), $result->getMessage());
+
+        $this->assertFileExists($outputFile);
+        $outputFileContents = file_get_contents($outputFile);
+        $this->assertContains('major', $outputFileContents, 'Semver file has expected structure');
+    }
+}


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [x] Has tests that cover changes

### Summary
Issue description: 959

Remove the check that a given filename is writeable, since this requires the file to exist beforehand.
    
We dont expect the file to exist however. Therefore this check should not be made, or create a file if failing.

Since this check is included in file_put_contents anyway we may remove the check safely.

I added a test for this issue as well.