### PR TITLE
Add ignorelist to pack command.

### DIFF
--- a/docs/tasks/Archive.md
+++ b/docs/tasks/Archive.md
@@ -39,6 +39,7 @@ $this->taskPack(
 ->add('README')                         // Puts file 'README' in archive at the root
 ->add('project')                        // Puts entire contents of directory 'project' in archinve inside 'project'
 ->addFile('dir/file.txt', 'file.txt')   // Takes 'file.txt' from cwd and puts it in archive inside 'dir'.
+->exclude(['dir\/.*.zip', '.*.md'])      // Add regex (or array of regex) to the excluded patterns list.
 ->run();
 ?>
 ```
@@ -47,4 +48,5 @@ $this->taskPack(
 * `addFile($placementLocation, $filesystemLocation)`  Add an item to the archive. Like file_exists(), the parameter
 * `addDir($placementLocation, $filesystemLocation)`  Alias for addFile, in case anyone has angst about using
 * `add($item)`  Add a file or directory, or list of same to the archive.
+* `exclude($ignoreList)`  Allow files or folder to be excluded from the archive. Use regex, without enclosing slashes.
 

--- a/src/Task/Archive/Pack.php
+++ b/src/Task/Archive/Pack.php
@@ -17,6 +17,7 @@ use Symfony\Component\Finder\Finder;
  * ->add('README')                         // Puts file 'README' in archive at the root
  * ->add('project')                        // Puts entire contents of directory 'project' in archinve inside 'project'
  * ->addFile('dir/file.txt', 'file.txt')   // Takes 'file.txt' from cwd and puts it in archive inside 'dir'.
+ * ->exclude(['dir\/.*.zip', '.*.md'])      // Add regex (or array of regex) to the excluded patterns list.
  * ->run();
  * ?>
  * ```
@@ -142,13 +143,13 @@ class Pack extends BaseTask implements PrintedInterface
     }
 
     /**
-     * Set the files or folder to be excluded from the archive.
+     * Allow files or folder to be excluded from the archive. Use regex, without enclosing slashes.
      *
      * @param string|string[]
      *   A pattern to be excluded or an array of patterns.
-     *   Zip allows regexp, glob or  string.
+     *   Zip allows regexp, glob or string.
      *   @see \Symfony\Component\Finder\Finder::notName
-     *   Tar only allows regexp.
+     *   Tar, gz and bz2 allow only regexp.
      *   @see \Archive_Tar::setIgnoreList
      *
      * @return $this

--- a/tests/integration/PackExtractTest.php
+++ b/tests/integration/PackExtractTest.php
@@ -30,7 +30,7 @@ class PackExtractTest extends TestCase
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
             return [['zip']];
         }
-        return [['tar'], ['tar'], ['tar.gz'], ['tar.bz2'], ['tgz']];
+        return [['zip'], ['tar'], ['tar.gz'], ['tar.bz2'], ['tgz']];
     }
 
     /**
@@ -57,6 +57,7 @@ class PackExtractTest extends TestCase
         $result = $this->taskPack("deeply.$archiveType")
             ->add(['deep' => 'some/deeply'])
             ->exclude(['structu3.*.re'])
+            ->exclude('nested4')
             ->run();
         $this->assertTrue($result->wasSuccessful(), $result->getMessage());
         $this->assertFileExists("deeply.$archiveType");
@@ -75,6 +76,7 @@ class PackExtractTest extends TestCase
         $this->assertFileExists("extracted-$archiveType/nested/structu.re");
         $this->assertFileNotExists("extracted-$archiveType/nested3/structu31.re");
         $this->assertFileNotExists("extracted-$archiveType/nested3/structu32.re");
+        $this->assertDirectoryNotExists("extracted-$archiveType/nested4");
         // Next, we'll extract the same archive again, this time preserving
         // the top-level folder.
         $this->taskExtract("deeply.$archiveType")
@@ -86,6 +88,7 @@ class PackExtractTest extends TestCase
         $this->assertFileExists("preserved-$archiveType/deep/nested/structu.re");
         $this->assertFileNotExists("preserved-$archiveType/deep/nested3/structu31.re");
         $this->assertFileNotExists("preserved-$archiveType/deep/nested3/structu32.re");
+        $this->assertDirectoryNotExists("preserved-$archiveType/deep/nested4");
         // Make another archive, this time composed of fanciful locations
         $result = $this->taskPack("composed.$archiveType")
             ->add(['a/b/existing_file' => 'some/deeply/existing_file'])

--- a/tests/integration/PackExtractTest.php
+++ b/tests/integration/PackExtractTest.php
@@ -30,7 +30,7 @@ class PackExtractTest extends TestCase
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
             return [['zip']];
         }
-        return [['zip'], ['tar'], ['tar.gz'], ['tar.bz2'], ['tgz']];
+        return [['tar'], ['tar'], ['tar.gz'], ['tar.bz2'], ['tgz']];
     }
 
     /**
@@ -56,6 +56,7 @@ class PackExtractTest extends TestCase
         // an archive for it located in 'deep'
         $result = $this->taskPack("deeply.$archiveType")
             ->add(['deep' => 'some/deeply'])
+            ->exclude(['structu3.*.re'])
             ->run();
         $this->assertTrue($result->wasSuccessful(), $result->getMessage());
         $this->assertFileExists("deeply.$archiveType");
@@ -72,6 +73,8 @@ class PackExtractTest extends TestCase
         $this->assertDirectoryExists("extracted-$archiveType");
         $this->assertDirectoryExists("extracted-$archiveType/nested");
         $this->assertFileExists("extracted-$archiveType/nested/structu.re");
+        $this->assertFileNotExists("extracted-$archiveType/nested3/structu31.re");
+        $this->assertFileNotExists("extracted-$archiveType/nested3/structu32.re");
         // Next, we'll extract the same archive again, this time preserving
         // the top-level folder.
         $this->taskExtract("deeply.$archiveType")
@@ -81,10 +84,14 @@ class PackExtractTest extends TestCase
         $this->assertDirectoryExists("preserved-$archiveType");
         $this->assertDirectoryExists("preserved-$archiveType/deep/nested");
         $this->assertFileExists("preserved-$archiveType/deep/nested/structu.re");
+        $this->assertFileNotExists("preserved-$archiveType/deep/nested3/structu31.re");
+        $this->assertFileNotExists("preserved-$archiveType/deep/nested3/structu32.re");
         // Make another archive, this time composed of fanciful locations
         $result = $this->taskPack("composed.$archiveType")
             ->add(['a/b/existing_file' => 'some/deeply/existing_file'])
             ->add(['x/y/z/structu.re' => 'some/deeply/nested/structu.re'])
+            ->add(['missing_files' => 'some/deeply/nested3'])
+            ->exclude(['structu3.*.re'])
             ->run();
         $this->assertTrue($result->wasSuccessful(), $result->getMessage());
         $this->assertFileExists("composed.$archiveType");
@@ -98,6 +105,8 @@ class PackExtractTest extends TestCase
         $this->assertDirectoryExists("decomposed-$archiveType");
         $this->assertDirectoryExists("decomposed-$archiveType/x/y/z");
         $this->assertFileExists("decomposed-$archiveType/x/y/z/structu.re");
+        $this->assertFileNotExists("decomposed-$archiveType/missing_files/structu31.re");
+        $this->assertFileNotExists("decomposed-$archiveType/missing_files/structu32.re");
         $this->assertDirectoryExists("decomposed-$archiveType/a/b");
         $this->assertFileExists("decomposed-$archiveType/a/b/existing_file");
 


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x ] Has tests that cover changes
- [ x] Adds or fixes documentation

### Summary
Related to #961, allows to filter patterns when creating an archive.

### Description
Files or folders could be excluded by using patterns, it's a good way to clean your package before delivery without touching you project folder tree.

```php
<?php
$this->taskPack(<archiveFile>)
->add('project') 
->exclude(['dir/*.zip', '*.md'])
->run();
```

Good to know :
Zip allows regexp, glob or string, @see https://symfony.com/doc/current/components/finder.html#file-name. 
Tar, gz and bz2 allow only regexp @see https://pear.php.net/package/Archive_Tar/docs/latest/Archive_Tar/Archive_Tar.html#methodsetIgnoreList.
