### PR TITLE
Support saving and restoring state.

### DIFF
--- a/.scenarios.lock/symfony4/composer.json
+++ b/.scenarios.lock/symfony4/composer.json
@@ -33,7 +33,7 @@
         "php": ">=7.1.3",
         "consolidation/config": "^1.2.1|^2",
         "consolidation/log": "^1.1.1|^2.0.1",
-        "consolidation/annotated-command": "dev-save-and-restore-state",
+        "consolidation/annotated-command": "^4.2.1",
         "consolidation/output-formatters": "^4.1.1",
         "consolidation/self-update": "^1.2",
         "league/container": "^2.4.1"

--- a/.scenarios.lock/symfony4/composer.json
+++ b/.scenarios.lock/symfony4/composer.json
@@ -33,7 +33,7 @@
         "php": ">=7.1.3",
         "consolidation/config": "^1.2.1|^2",
         "consolidation/log": "^1.1.1|^2.0.1",
-        "consolidation/annotated-command": "^4.2",
+        "consolidation/annotated-command": "dev-save-and-restore-state",
         "consolidation/output-formatters": "^4.1.1",
         "consolidation/self-update": "^1.2",
         "league/container": "^2.4.1"

--- a/.scenarios.lock/symfony4/composer.lock
+++ b/.scenarios.lock/symfony4/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e11dcde7596d2f66c81b309b320dcfb",
+    "content-hash": "075f9765270442df43aba1ae412c2979",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "4.2.0",
+            "version": "dev-save-and-restore-state",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "4f7a58b7545e3a6b94d51778cc5b298377265e21"
+                "reference": "d1eb96e4da3e711629442c90ae0fc2a6816a0bcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/4f7a58b7545e3a6b94d51778cc5b298377265e21",
-                "reference": "4f7a58b7545e3a6b94d51778cc5b298377265e21",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/d1eb96e4da3e711629442c90ae0fc2a6816a0bcc",
+                "reference": "d1eb96e4da3e711629442c90ae0fc2a6816a0bcc",
                 "shasum": ""
             },
             "require": {
@@ -68,7 +68,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2020-08-27T17:06:02+00:00"
+            "time": "2020-08-29T15:29:29+00:00"
         },
         {
             "name": "consolidation/config",
@@ -4323,7 +4323,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "consolidation/annotated-command": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/.scenarios.lock/symfony4/composer.lock
+++ b/.scenarios.lock/symfony4/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "075f9765270442df43aba1ae412c2979",
+    "content-hash": "e1d542ed4ce7d5569b74a3504e5976ac",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "dev-save-and-restore-state",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "d1eb96e4da3e711629442c90ae0fc2a6816a0bcc"
+                "reference": "ef6b7e662ce2d8b0af9004307bdf26350aad4df1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/d1eb96e4da3e711629442c90ae0fc2a6816a0bcc",
-                "reference": "d1eb96e4da3e711629442c90ae0fc2a6816a0bcc",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/ef6b7e662ce2d8b0af9004307bdf26350aad4df1",
+                "reference": "ef6b7e662ce2d8b0af9004307bdf26350aad4df1",
                 "shasum": ""
             },
             "require": {
@@ -68,7 +68,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2020-08-29T15:29:29+00:00"
+            "time": "2020-08-30T17:37:39+00:00"
         },
         {
             "name": "consolidation/config",
@@ -4323,9 +4323,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "consolidation/annotated-command": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/LICENSE
+++ b/LICENSE
@@ -21,26 +21,26 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 DEPENDENCY LICENSES:
 
-Name                                 Version                             License
-consolidation/annotated-command      dev-save-and-restore-state d1eb96e  MIT
-consolidation/config                 2.0.0                               MIT
-consolidation/log                    2.0.1                               MIT
-consolidation/output-formatters      4.1.1                               MIT
-consolidation/self-update            1.2.0                               MIT
-container-interop/container-interop  1.2.0                               MIT
-dflydev/dot-access-data              v1.1.0                              MIT
-grasmash/expander                    1.0.0                               MIT
-league/container                     2.4.1                               MIT
-psr/container                        1.0.0                               MIT
-psr/log                              1.1.3                               MIT
-symfony/console                      v4.4.11                             MIT
-symfony/event-dispatcher             v4.4.11                             MIT
-symfony/event-dispatcher-contracts   v1.1.9                              MIT
-symfony/filesystem                   v4.4.11                             MIT
-symfony/finder                       v4.4.11                             MIT
-symfony/polyfill-ctype               v1.18.1                             MIT
-symfony/polyfill-mbstring            v1.18.1                             MIT
-symfony/polyfill-php73               v1.18.1                             MIT
-symfony/polyfill-php80               v1.18.1                             MIT
-symfony/process                      v4.4.11                             MIT
-symfony/service-contracts            v1.1.9                              MIT
+Name                                 Version  License
+consolidation/annotated-command      4.2.1    MIT
+consolidation/config                 2.0.0    MIT
+consolidation/log                    2.0.1    MIT
+consolidation/output-formatters      4.1.1    MIT
+consolidation/self-update            1.2.0    MIT
+container-interop/container-interop  1.2.0    MIT
+dflydev/dot-access-data              v1.1.0   MIT
+grasmash/expander                    1.0.0    MIT
+league/container                     2.4.1    MIT
+psr/container                        1.0.0    MIT
+psr/log                              1.1.3    MIT
+symfony/console                      v4.4.11  MIT
+symfony/event-dispatcher             v4.4.11  MIT
+symfony/event-dispatcher-contracts   v1.1.9   MIT
+symfony/filesystem                   v4.4.11  MIT
+symfony/finder                       v4.4.11  MIT
+symfony/polyfill-ctype               v1.18.1  MIT
+symfony/polyfill-mbstring            v1.18.1  MIT
+symfony/polyfill-php73               v1.18.1  MIT
+symfony/polyfill-php80               v1.18.1  MIT
+symfony/process                      v4.4.11  MIT
+symfony/service-contracts            v1.1.9   MIT

--- a/LICENSE
+++ b/LICENSE
@@ -21,26 +21,26 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 DEPENDENCY LICENSES:
 
-Name                                 Version  License
-consolidation/annotated-command      4.2.0    MIT
-consolidation/config                 2.0.0    MIT
-consolidation/log                    2.0.1    MIT
-consolidation/output-formatters      4.1.1    MIT
-consolidation/self-update            1.2.0    MIT
-container-interop/container-interop  1.2.0    MIT
-dflydev/dot-access-data              v1.1.0   MIT
-grasmash/expander                    1.0.0    MIT
-league/container                     2.4.1    MIT
-psr/container                        1.0.0    MIT
-psr/log                              1.1.3    MIT
-symfony/console                      v4.4.11  MIT
-symfony/event-dispatcher             v4.4.11  MIT
-symfony/event-dispatcher-contracts   v1.1.9   MIT
-symfony/filesystem                   v4.4.11  MIT
-symfony/finder                       v4.4.11  MIT
-symfony/polyfill-ctype               v1.18.1  MIT
-symfony/polyfill-mbstring            v1.18.1  MIT
-symfony/polyfill-php73               v1.18.1  MIT
-symfony/polyfill-php80               v1.18.1  MIT
-symfony/process                      v4.4.11  MIT
-symfony/service-contracts            v1.1.9   MIT
+Name                                 Version                             License
+consolidation/annotated-command      dev-save-and-restore-state d1eb96e  MIT
+consolidation/config                 2.0.0                               MIT
+consolidation/log                    2.0.1                               MIT
+consolidation/output-formatters      4.1.1                               MIT
+consolidation/self-update            1.2.0                               MIT
+container-interop/container-interop  1.2.0                               MIT
+dflydev/dot-access-data              v1.1.0                              MIT
+grasmash/expander                    1.0.0                               MIT
+league/container                     2.4.1                               MIT
+psr/container                        1.0.0                               MIT
+psr/log                              1.1.3                               MIT
+symfony/console                      v4.4.11                             MIT
+symfony/event-dispatcher             v4.4.11                             MIT
+symfony/event-dispatcher-contracts   v1.1.9                              MIT
+symfony/filesystem                   v4.4.11                             MIT
+symfony/finder                       v4.4.11                             MIT
+symfony/polyfill-ctype               v1.18.1                             MIT
+symfony/polyfill-mbstring            v1.18.1                             MIT
+symfony/polyfill-php73               v1.18.1                             MIT
+symfony/polyfill-php80               v1.18.1                             MIT
+symfony/process                      v4.4.11                             MIT
+symfony/service-contracts            v1.1.9                              MIT

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=7.1.3",
         "consolidation/config": "^1.2.1|^2",
         "consolidation/log": "^1.1.1|^2.0.1",
-        "consolidation/annotated-command": "^4.2",
+        "consolidation/annotated-command": "dev-save-and-restore-state",
         "consolidation/output-formatters": "^4.1.1",
         "consolidation/self-update": "^1.2",
         "league/container": "^2.4.1",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=7.1.3",
         "consolidation/config": "^1.2.1|^2",
         "consolidation/log": "^1.1.1|^2.0.1",
-        "consolidation/annotated-command": "dev-save-and-restore-state",
+        "consolidation/annotated-command": "^4.2.1",
         "consolidation/output-formatters": "^4.1.1",
         "consolidation/self-update": "^1.2",
         "league/container": "^2.4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c556537aca11baf9611f413aab5afa1a",
+    "content-hash": "f2b2037af88db17cb8f8f25c87798258",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "4.2.0",
+            "version": "dev-save-and-restore-state",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "4f7a58b7545e3a6b94d51778cc5b298377265e21"
+                "reference": "d1eb96e4da3e711629442c90ae0fc2a6816a0bcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/4f7a58b7545e3a6b94d51778cc5b298377265e21",
-                "reference": "4f7a58b7545e3a6b94d51778cc5b298377265e21",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/d1eb96e4da3e711629442c90ae0fc2a6816a0bcc",
+                "reference": "d1eb96e4da3e711629442c90ae0fc2a6816a0bcc",
                 "shasum": ""
             },
             "require": {
@@ -68,7 +68,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2020-08-27T17:06:02+00:00"
+            "time": "2020-08-29T15:29:29+00:00"
         },
         {
             "name": "consolidation/config",
@@ -4560,7 +4560,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "consolidation/annotated-command": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2b2037af88db17cb8f8f25c87798258",
+    "content-hash": "a3cfe3630771a17f21b837039f3b3243",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "dev-save-and-restore-state",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "d1eb96e4da3e711629442c90ae0fc2a6816a0bcc"
+                "reference": "ef6b7e662ce2d8b0af9004307bdf26350aad4df1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/d1eb96e4da3e711629442c90ae0fc2a6816a0bcc",
-                "reference": "d1eb96e4da3e711629442c90ae0fc2a6816a0bcc",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/ef6b7e662ce2d8b0af9004307bdf26350aad4df1",
+                "reference": "ef6b7e662ce2d8b0af9004307bdf26350aad4df1",
                 "shasum": ""
             },
             "require": {
@@ -68,7 +68,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2020-08-29T15:29:29+00:00"
+            "time": "2020-08-30T17:37:39+00:00"
         },
         {
             "name": "consolidation/config",
@@ -4560,9 +4560,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "consolidation/annotated-command": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Consolidation\AnnotatedCommand\State\SavableState;
+use Consolidation\AnnotatedCommand\State\State;
 
 trait IO
 {
@@ -18,6 +20,39 @@ trait IO
      * @var \Symfony\Component\Console\Style\SymfonyStyle
      */
     protected $io;
+
+    public function currentState()
+    {
+        return new class($this, $this->input, $this->output, $this->io) implements State {
+            protected $obj;
+            protected $input;
+            protected $output;
+            protected $io;
+
+            public function __construct($obj, $input, $output, $io)
+            {
+                $this->obj = $obj;
+                $this->input = $input;
+                $this->output = $output;
+                $this->io = $io;
+            }
+
+            public function restore()
+            {
+                $this->obj->restoreState($this->input, $this->output, $this->io);
+            }
+        };
+    }
+
+    // This should typically only be called by State::restore()
+    public function restoreState(InputInterface $input = null, OutputInterface $output = null, SymfonyStyle $io = null)
+    {
+        $this->setInput($input);
+        $this->setOutput($output);
+        $this->io = $io;
+
+        return $this;
+    }
 
     public function setInput(InputInterface $input)
     {

--- a/src/Common/SaveIOStateTrait.php
+++ b/src/Common/SaveIOStateTrait.php
@@ -1,6 +1,0 @@
-<?php
-
-trait SaveIOStateTrait
-{
-
-}

--- a/src/Common/SaveIOStateTrait.php
+++ b/src/Common/SaveIOStateTrait.php
@@ -1,0 +1,6 @@
+<?php
+
+trait SaveIOStateTrait
+{
+
+}

--- a/src/Contract/IOAwareInterface.php
+++ b/src/Contract/IOAwareInterface.php
@@ -7,7 +7,8 @@
 namespace Robo\Contract;
 
 use Symfony\Component\Console\Input\InputAwareInterface;
+use Consolidation\AnnotatedCommand\State\SavableState;
 
-interface IOAwareInterface extends OutputAwareInterface, InputAwareInterface
+interface IOAwareInterface extends OutputAwareInterface, InputAwareInterface, SavableState
 {
 }

--- a/tests/integration/CommandTesterTest.php
+++ b/tests/integration/CommandTesterTest.php
@@ -17,9 +17,9 @@ class CommandTestertTest extends TestCase
     public function testInputApis()
     {
         list($tryInputOutput, $statusCode) = $this->executeCommand('try:input', ["I'm great!", "yes", "PHP", "1234"]);
-        $this->assertEquals(0, $statusCode);
         $this->assertContains("I'm great!", $tryInputOutput);
         $this->assertContains("PHP", $tryInputOutput);
         $this->assertContains("1234", $tryInputOutput);
+        $this->assertEquals(0, $statusCode);
     }
 }

--- a/tests/integration/RunnerTest.php
+++ b/tests/integration/RunnerTest.php
@@ -105,6 +105,7 @@ EOT;
 
         $expected = <<<EOT
  This is the command-event hook for the test:command-event command.
+
  This is the main method for the test:command-event command.
  This is the post-command hook for the test:command-event command.
 EOT;


### PR DESCRIPTION
#966 / #968 were actually fairly dangerous, as they could corrupt the current commandfile instance state. This is an attempt to rectify that.

@lpeabody : Do you have any idea why CommandTesterTest takes 10s to run? None of the other tests take so long. It seems that all of the time is in the `execute` method. Have not traced it beyond that.