### PR TITLE
Don't use try:exec for testing the CommandTester trait.

### DIFF
--- a/tests/integration/CommandTesterTest.php
+++ b/tests/integration/CommandTesterTest.php
@@ -22,12 +22,4 @@ class CommandTestertTest extends TestCase
         $this->assertContains("PHP", $tryInputOutput);
         $this->assertContains("1234", $tryInputOutput);
     }
-
-    public function testTesterWithOptions()
-    {
-        list($execOutput, $statusCode) = $this->executeCommand('try:exec', []);
-        $this->assertEquals(0, $statusCode);
-        list($execOutput, $statusCode) = $this->executeCommand('try:exec', [], ['--error']);
-        $this->assertNotEquals(0, $statusCode);
-    }
 }


### PR DESCRIPTION


### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Removes test which greatly reduces time of test completion, and it doesn't really add value.
