### PR TITLE
Do not allow tests to pass a container in to initTestTasksTrait.

### DIFF
--- a/tests/src/Traits/TestTasksTrait.php
+++ b/tests/src/Traits/TestTasksTrait.php
@@ -15,20 +15,13 @@ trait TestTasksTrait
     protected $capturedOutput;
     protected $logger;
 
-    public function initTestTasksTrait($commandClass = null, $container = null, $input = null)
+    public function initTestTasksTrait($commandClass = null)
     {
-        if (!$container) {
-            $container = Robo::createDefaultContainer();
-        }
         $this->capturedOutput = '';
         $this->testPrinter = new BufferedOutput(OutputInterface::VERBOSITY_DEBUG);
 
-        $app = Robo::createDefaultApplication();
-        $config = new \Robo\Config();
-        \Robo\Robo::configureContainer($container, $app, $config, $input, $this->testPrinter);
-
-        // Set the application dispatcher
-        $app->setDispatcher($container->get('eventDispatcher'));
+        Robo::unsetContainer();
+        $container = Robo::createDefaultContainer(null, $this->testPrinter);
         $this->logger = $container->get('logger');
 
         // Use test class as command class if a specific one is not provided


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Clean up initTestTasksTrait. This PR breaks b/c only with the unstable 2.x branch; we'd rather not allow tests to specify the container or $input object that should go into the container.

@lpeabody Robo core does not need either of those items injected. Can you fix up your tests to not depend on passing the container or input to initTestTasksTrait?