### PR TITLE
Fixes BUG #974: Make sure that output from ExecTrait is passed through

### DIFF
--- a/examples/src/Robo/Plugin/Commands/ExampleCommands.php
+++ b/examples/src/Robo/Plugin/Commands/ExampleCommands.php
@@ -117,6 +117,18 @@ class ExampleCommands extends \Robo\Tasks
     }
 
     /**
+     * Demonstrates capturing output from taskExec
+     *
+     * @param ConsoleIO $io
+     */
+    public function tryCaptureExec(ConsoleIO $io)
+    {
+        $result = $this->taskExec('echo')->args(['one', 'two', 'three'])->printOutput(false)->run();
+
+        $io->writeln('Captured output from exec >>> ' . $result->getOutputData());
+    }
+
+    /**
      * Demonstrates parallel execution.
      *
      * @option $printed Print the output of each process.

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -369,11 +369,13 @@ trait ExecTrait
             $this->process->run();
             $this->stopTimer();
             $output = rtrim($this->process->getOutput());
-            return new ResultData(
+            $result = new ResultData(
                 $this->process->getExitCode(),
                 $output,
                 $this->getResultData()
             );
+            $result->provideOutputdata();
+            return $result;
         }
 
         if (!$this->background && $this->isPrinted) {

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -110,13 +110,14 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
         $this->hideProgressIndicator();
         // TODO: Symfony 4 requires that we supply the working directory.
         $result_data = $this->execute(Process::fromShellCommandline($this->getCommand(), getcwd()));
-        return new Result(
+        $result = new Result(
             $this,
             $result_data->getExitCode(),
             $result_data->getMessage(),
             $result_data->getData()
         );
         $this->showProgressIndicator();
+        return $result;
     }
 }
 


### PR DESCRIPTION
… when "printOutput(false)" is called.

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Did not test the exact scenario from the original report, but this should do the trick.

See new example for canonical way to capture output from taskExec.
