### PR TITLE
Fixes #978: Do not call ignorelist on the archive if it is empty.

### DIFF
--- a/src/Task/Archive/Pack.php
+++ b/src/Task/Archive/Pack.php
@@ -206,7 +206,9 @@ class Pack extends BaseTask implements PrintedInterface
         }
 
         $tar_object = new \Archive_Tar($archiveFile);
-        $tar_object->setIgnoreList($this->ignoreList);
+        if (!empty($this->ignoreList)) {
+            $tar_object->setIgnoreList($this->ignoreList);
+        }
         foreach ($items as $placementLocation => $filesystemLocation) {
             $p_remove_dir = $filesystemLocation;
             $p_add_dir = $placementLocation;
@@ -259,9 +261,12 @@ class Pack extends BaseTask implements PrintedInterface
         foreach ($items as $placementLocation => $filesystemLocation) {
             if (is_dir($filesystemLocation)) {
                 $finder = new Finder();
-                // Add slashes so Symfony Finder patterns work like Archive_Tar ones.
-                $zipIgnoreList = preg_filter('/^|$/', '/', $this->ignoreList);
-                $finder->files()->in($filesystemLocation)->ignoreDotFiles(false)->notName($zipIgnoreList)->notPath($zipIgnoreList);
+                $finder->files()->in($filesystemLocation)->ignoreDotFiles(false);
+                if (!empty($this->ignoreList)) {
+                    // Add slashes so Symfony Finder patterns work like Archive_Tar ones.
+                    $zipIgnoreList = preg_filter('/^|$/', '/', $this->ignoreList);
+                    $finder->notName($zipIgnoreList)->notPath($zipIgnoreList);
+                }
 
                 foreach ($finder as $file) {
                     // Replace Windows slashes or resulting zip will have issues on *nixes.


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Apparently archives with no ignore list are now empty. I guess that all the tests set an ignore list, but have not fully investigated in order to get a quick release out.