### PR TITLE
Stop using deprecated "printed()" method in taskExec and use recommen…

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -392,7 +392,7 @@ class RoboFile extends \Robo\Tasks
             ->taskComposerInstall()
                 ->dir($roboBuildDir)
                 ->noScripts()
-                ->printed(true)
+                ->printOutput(true)
                 ->run();
 
         // Exit if the preparation step failed

--- a/examples/src/Robo/Plugin/Commands/ExampleCommands.php
+++ b/examples/src/Robo/Plugin/Commands/ExampleCommands.php
@@ -139,7 +139,7 @@ class ExampleCommands extends \Robo\Tasks
         $dir = dirname(dirname(dirname(dirname(dirname(__DIR__)))));
         $para = $this->collectionBuilder($io)
             ->taskParallelExec()
-                ->printed($options['printed'])
+                ->printOutput($options['printed'])
                 ->process("php $dir/tests/_data/parascript.php hey 4")
                 ->process("php $dir/tests/_data/parascript.php hoy 3")
                 ->process("php $dir/tests/_data/parascript.php gou 2")

--- a/src/Task/Assets/ImageMinify.php
+++ b/src/Task/Assets/ImageMinify.php
@@ -478,7 +478,7 @@ class ImageMinify extends BaseTask
         // execute the command
         $exec = new Exec($command);
 
-        return $exec->inflect($this)->printed(false)->run();
+        return $exec->inflect($this)->printOutput(false)->run();
     }
 
     /**


### PR DESCRIPTION
…ded "printOutput()" instead.

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Stop using deprecated method.