### PR TITLE
TaskInterface::Run() should always return a Result.

### DIFF
--- a/src/Task/File/Replace.php
+++ b/src/Task/File/Replace.php
@@ -136,8 +136,7 @@ class Replace extends BaseTask
     public function run()
     {
         if (!file_exists($this->filename)) {
-            $this->printTaskError('File {filename} does not exist', ['filename' => $this->filename]);
-            return false;
+            return Result::error($this, 'File {filename} does not exist', ['filename' => $this->filename]);
         }
 
         $text = file_get_contents($this->filename);


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
When running the `ReplaceTask` on a file that doesn't exist, the following error is thrown since in this case `FALSE` is returned instead of the expected `Result::error()`:

```
Warning: get_class() expects parameter 1 to be object, bool given in /home/pieter/v/event-venue/vendor/consolidation/robo/src/Result.php on line 63
 [error]  Task Robo\Task\File\Replace returned a  instead of a \Robo\Result.
```