### PR TITLE
Escape SSH commands correctly

### DIFF
--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -261,13 +261,13 @@ class Ssh extends BaseTask implements CommandInterface, SimulatedInterface
      */
     protected function sshCommand($command)
     {
-        $command = $this->receiveCommand($command);
+        $command = static::escape($this->receiveCommand($command));
         $sshOptions = $this->arguments;
         $hostSpec = $this->hostname;
         if ($this->user) {
             $hostSpec = $this->user . '@' . $hostSpec;
         }
 
-        return "ssh{$sshOptions} {$hostSpec} '{$command}'";
+        return "ssh{$sshOptions} {$hostSpec} {$command}";
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Same as https://github.com/consolidation/Robo/pull/954 but for 3.0.

### Description
The fix is exactly the same.
