### PR TITLE
RunScript and Exec Composer tasks

### DIFF
--- a/docs/tasks/Composer.md
+++ b/docs/tasks/Composer.md
@@ -412,3 +412,82 @@ $this->taskComposerValidate()->run();
 * `options(array $options, $separator = null)`  Pass multiple options to executable. The associative array contains
 * `optionList($option, $value = null, $separator = null)`  Pass an option with multiple values to executable. Value can be a string or array.
 
+## RunScript
+
+
+Composer Run Script
+
+``` php
+<?php
+// simple execution
+$this->taskComposerRunScript()->arg('myscript')->run();
+
+// pass an option to the script
+$this->taskComposerRunScript()->arg('myscript')->scriptOption('foo')->run();
+?>
+```
+
+* `preferDist($preferDist = null)`  adds `prefer-dist` option to composer
+* `preferSource()`  adds `prefer-source` option to composer
+* `dev($dev = null)`  adds `dev` option to composer
+* `noDev()`  adds `no-dev` option to composer
+* `ansi($ansi = null)`  adds `ansi` option to composer
+* `noAnsi()`  adds `no-ansi` option to composer
+* `interaction($interaction = null)`   * `param bool` $interaction
+* `noInteraction()`  adds `no-interaction` option to composer
+* `optimizeAutoloader($optimize = null)`  adds `optimize-autoloader` option to composer
+* `ignorePlatformRequirements($ignore = null)`  adds `ignore-platform-reqs` option to composer
+* `disablePlugins($disable = null)`  disable plugins
+* `noScripts($disable = null)`  skip scripts
+* `workingDir($dir)`  adds `--working-dir $dir` option to composer
+* `buildCommand()`  Copy class fields into command options as directed.
+* `dir($dir)`  Changes working directory of command
+* `arg($arg)`  Pass argument to executable. Its value will be automatically escaped.
+* `args($args)`  Pass methods parameters as arguments to executable. Argument values
+* `rawArg($arg)`  Pass the provided string in its raw (as provided) form as an argument to executable.
+* `option($option, $value = null, $separator = null)`  Pass option to executable. Options are prefixed with `--` , value can be provided in second parameter.
+* `options(array $options, $separator = null)`  Pass multiple options to executable. The associative array contains
+* `optionList($option, $value = null, $separator = null)`  Pass an option with multiple values to executable. Value can be a string or array.
+* `scriptOption($option, $value = null, $separator = null)`  Pass option to the script. Options are prefixed with `--` , value can be provided in second parameter.
+
+## Exec
+
+
+Composer Exec
+
+``` php
+<?php
+// simple execution
+$this->taskComposerExec()->arg('mycommand')->run();
+
+// pass an option to the command
+$this->taskComposerExec()->arg('mycommand')->scriptOption('foo')->run();
+
+// execute a command installed globally
+$this->taskComposerExec('composer', true)->arg('mycommand')->run();
+
+?>
+```
+
+* `preferDist($preferDist = null)`  adds `prefer-dist` option to composer
+* `preferSource()`  adds `prefer-source` option to composer
+* `dev($dev = null)`  adds `dev` option to composer
+* `noDev()`  adds `no-dev` option to composer
+* `ansi($ansi = null)`  adds `ansi` option to composer
+* `noAnsi()`  adds `no-ansi` option to composer
+* `interaction($interaction = null)`   * `param bool` $interaction
+* `noInteraction()`  adds `no-interaction` option to composer
+* `optimizeAutoloader($optimize = null)`  adds `optimize-autoloader` option to composer
+* `ignorePlatformRequirements($ignore = null)`  adds `ignore-platform-reqs` option to composer
+* `disablePlugins($disable = null)`  disable plugins
+* `noScripts($disable = null)`  skip scripts
+* `workingDir($dir)`  adds `--working-dir $dir` option to composer
+* `buildCommand()`  Copy class fields into command options as directed.
+* `dir($dir)`  Changes working directory of command
+* `arg($arg)`  Pass argument to executable. Its value will be automatically escaped.
+* `args($args)`  Pass methods parameters as arguments to executable. Argument values
+* `rawArg($arg)`  Pass the provided string in its raw (as provided) form as an argument to executable.
+* `option($option, $value = null, $separator = null)`  Pass option to executable. Options are prefixed with `--` , value can be provided in second parameter.
+* `options(array $options, $separator = null)`  Pass multiple options to executable. The associative array contains
+* `optionList($option, $value = null, $separator = null)`  Pass an option with multiple values to executable. Value can be a string or array.
+* `scriptOption($option, $value = null, $separator = null)`  Pass option to the script. Options are prefixed with `--` , value can be provided in second parameter.

--- a/src/Task/Composer/Exec.php
+++ b/src/Task/Composer/Exec.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Robo\Task\Composer;
+
+/**
+ * Class Exec
+ *
+ * @package Robo\Task\Composer
+ */
+class Exec extends Base
+{
+
+    /**
+     * @var string
+     */
+    protected $action = 'exec';
+
+    /**
+     * Script options.
+     *
+     * @var array
+     */
+    protected $scriptOptions = [];
+
+    /**
+     * Add a script option.
+     *
+     * @param string $option Option name
+     * @param string|null $value Option value
+     *
+     * @return self
+     */
+    public function scriptOption(string $option, $value = null)
+    {
+        $this->scriptOptions[$option] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Add script options to command.
+     */
+    public function buildCommand()
+    {
+        parent::buildCommand();
+
+        $this->option('');
+        $this->options($this->scriptOptions);
+    }
+
+    /**
+     * Exec constructor.
+     *
+     * @param bool $global Run "composer global exec"
+     * @param null|string $pathToComposer Path to Composer executable
+     *
+     * @throws \Robo\Exception\TaskException
+     */
+    public function __construct($pathToComposer = null, $global = false)
+    {
+        parent::__construct($pathToComposer);
+
+        if ($global) {
+            $this->action = 'global ' . $this->action;
+        }
+    }
+
+    /**
+     * Run the command.
+     *
+     * @return \Robo\Result
+     */
+    public function run()
+    {
+        $command = $this->getCommand();
+        $this->printTaskInfo('Executing command: {command}', ['command' => $command]);
+        return $this->executeCommand($command);
+    }
+}

--- a/src/Task/Composer/RunScript.php
+++ b/src/Task/Composer/RunScript.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Robo\Task\Composer;
+
+/**
+ * Class RunScript
+ *
+ * @package Robo\Task\Composer
+ */
+class RunScript extends Base
+{
+
+    /**
+     * @var string
+     */
+    protected $action = 'run-script';
+
+
+    /**
+     * Script options.
+     *
+     * @var array
+     */
+    protected $scriptOptions = [];
+
+    /**
+     * Add a script option.
+     *
+     * @param string $option Option name
+     * @param string|null $value Option value
+     *
+     * @return self
+     */
+    public function scriptOption(string $option, $value = null)
+    {
+        $this->scriptOptions[$option] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Add script options to command.
+     */
+    public function buildCommand()
+    {
+        parent::buildCommand();
+
+        $this->option('');
+        $this->options($this->scriptOptions);
+    }
+
+    /**
+     * Run the command.
+     *
+     * @return \Robo\Result
+     */
+    public function run()
+    {
+        $command = $this->getCommand();
+        $this->printTaskInfo('Running script: {command}', ['command' => $command]);
+        return $this->executeCommand($command);
+    }
+}

--- a/src/Task/Composer/Tasks.php
+++ b/src/Task/Composer/Tasks.php
@@ -103,4 +103,27 @@ trait Tasks
     {
         return $this->task(CheckPlatformReqs::class, $pathToComposer);
     }
+
+    /**
+     * @param bool $global Run "composer global exec"
+     * @param null|string $pathToComposer Path to Composer executable
+     *
+     * @return \Robo\Task\Composer\Exec|\Robo\Collection\CollectionBuilder
+     */
+    protected function taskComposerExec($pathToComposer = null, $global = false)
+    {
+        return $this->task(Exec::class, $pathToComposer, $global);
+    }
+
+    /**
+     * Create a Composer script command.
+     *
+     * @param null|string $pathToComposer Path to Composer executable
+     *
+     * @return \Robo\Task\Composer\RunScript|\Robo\Collection\CollectionBuilder
+     */
+    protected function taskComposerRunScript($pathToComposer = null)
+    {
+        return $this->task(RunScript::class, $pathToComposer);
+    }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Adds new tasks that runs `composer run-script` and `composer exec`.

### Description
See https://github.com/consolidation/Robo/issues/958.

I wanted to add tests but it seems `ComposerTest` is outdated?
