### PR TITLE
Allow to reset the timer

### DIFF
--- a/src/Common/TimeKeeper.php
+++ b/src/Common/TimeKeeper.php
@@ -9,12 +9,12 @@ class TimeKeeper
     const DAY = 86400;
 
     /**
-     * @var float
+     * @var float|null
      */
     protected $startedAt;
 
     /**
-     * @var float
+     * @var float|null
      */
     protected $finishedAt;
 
@@ -30,6 +30,11 @@ class TimeKeeper
     public function stop()
     {
         $this->finishedAt = microtime(true);
+    }
+
+    public function reset()
+    {
+        $this->startedAt = $this->finishedAt = null;
     }
 
     /**

--- a/src/Common/Timer.php
+++ b/src/Common/Timer.php
@@ -5,7 +5,7 @@ namespace Robo\Common;
 trait Timer
 {
     /**
-     * @var \Robo\Common\TimeKeeper
+     * @var \Robo\Common\TimeKeeper|null
      */
     protected $timer;
 
@@ -23,6 +23,11 @@ trait Timer
             return;
         }
         $this->timer->stop();
+    }
+
+    protected function resetTimer()
+    {
+        $this->timer->reset();
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [x] Adds or fixes documentation

### Summary
This change allows to reset the timer.

### Description
Starting, stopping, and then starting the timer again works like pause/resume feature. However, there are cases when I need to reset the timer to measure the time it takes to complete each step.