### PR TITLE
Replace jsqueeze

### DIFF
--- a/.scenarios.lock/php71/composer.json
+++ b/.scenarios.lock/php71/composer.json
@@ -41,13 +41,13 @@
     },
     "require-dev": {
         "g1a/composer-test-scenarios": "^3",
-        "phpunit/phpunit": "^6.5.14",
         "natxet/cssmin": "3.0.4",
-        "patchwork/jsqueeze": "^2",
         "pear/archive_tar": "^1.4.4",
         "php-coveralls/php-coveralls": "^2.2",
         "phpdocumentor/reflection-docblock": "^4.3.2",
-        "squizlabs/php_codesniffer": "^3"
+        "phpunit/phpunit": "^6.5.14",
+        "squizlabs/php_codesniffer": "^3",
+        "tedivm/jshrink": "^1.3"
     },
     "scripts": {
         "cs": "./robo sniff",

--- a/.scenarios.lock/php71/composer.lock
+++ b/.scenarios.lock/php71/composer.lock
@@ -3830,6 +3830,5 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1.3"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }

--- a/.scenarios.lock/php71/composer.lock
+++ b/.scenarios.lock/php71/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa0a0fa179daa3a215764d49aad94023",
+    "content-hash": "3b13b08c282a8b757640765f582ab144",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -1281,6 +1281,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-11-27T05:48:46+00:00"
         },
         {
@@ -3105,53 +3106,6 @@
             "time": "2015-09-25T11:13:11+00:00"
         },
         {
-            "name": "patchwork/jsqueeze",
-            "version": "v2.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tchwork/jsqueeze.git",
-                "reference": "693d64850eab2ce6a7c8f7cf547e1ab46e69d542"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tchwork/jsqueeze/zipball/693d64850eab2ce6a7c8f7cf547e1ab46e69d542",
-                "reference": "693d64850eab2ce6a7c8f7cf547e1ab46e69d542",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Patchwork\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "(Apache-2.0 or GPL-2.0)"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                }
-            ],
-            "description": "Efficient JavaScript minification in PHP",
-            "homepage": "https://github.com/tchwork/jsqueeze",
-            "keywords": [
-                "compression",
-                "javascript",
-                "minification"
-            ],
-            "time": "2016-04-19T09:28:22+00:00"
-        },
-        {
             "name": "pear/archive_tar",
             "version": "1.4.9",
             "source": {
@@ -3817,6 +3771,52 @@
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
             "time": "2020-03-27T16:54:36+00:00"
+        },
+        {
+            "name": "tedivm/jshrink",
+            "version": "v1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tedious/JShrink.git",
+                "reference": "566e0c731ba4e372be2de429ef7d54f4faf4477a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tedious/JShrink/zipball/566e0c731ba4e372be2de429ef7d54f4faf4477a",
+                "reference": "566e0c731ba4e372be2de429ef7d54f4faf4477a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6|^7.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.8",
+                "php-coveralls/php-coveralls": "^1.1.0",
+                "phpunit/phpunit": "^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JShrink": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Hafner",
+                    "email": "tedivm@tedivm.com"
+                }
+            ],
+            "description": "Javascript Minifier built in PHP",
+            "homepage": "http://github.com/tedious/JShrink",
+            "keywords": [
+                "javascript",
+                "minifier"
+            ],
+            "time": "2019-06-28T18:11:46+00:00"
         }
     ],
     "aliases": [],
@@ -3830,5 +3830,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1.3"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/.scenarios.lock/symfony4/composer.json
+++ b/.scenarios.lock/symfony4/composer.json
@@ -40,13 +40,13 @@
     },
     "require-dev": {
         "g1a/composer-test-scenarios": "^3",
-        "phpunit/phpunit": "^6.5.14",
         "natxet/cssmin": "3.0.4",
-        "patchwork/jsqueeze": "^2",
         "pear/archive_tar": "^1.4.4",
         "php-coveralls/php-coveralls": "^2.2",
         "phpdocumentor/reflection-docblock": "^4.3.2",
-        "squizlabs/php_codesniffer": "^3"
+        "phpunit/phpunit": "^6.5.14",
+        "squizlabs/php_codesniffer": "^3",
+        "tedivm/jshrink": "^1.3"
     },
     "scripts": {
         "cs": "./robo sniff",

--- a/.scenarios.lock/symfony4/composer.lock
+++ b/.scenarios.lock/symfony4/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "101f445f41050bbe497c5b591bc66a3b",
+    "content-hash": "3532d106acc294141c575c88039673a3",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -3282,54 +3282,6 @@
             "time": "2018-07-02T15:55:56+00:00"
         },
         {
-            "name": "patchwork/jsqueeze",
-            "version": "v2.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tchwork/jsqueeze.git",
-                "reference": "693d64850eab2ce6a7c8f7cf547e1ab46e69d542"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tchwork/jsqueeze/zipball/693d64850eab2ce6a7c8f7cf547e1ab46e69d542",
-                "reference": "693d64850eab2ce6a7c8f7cf547e1ab46e69d542",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Patchwork\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "(Apache-2.0 or GPL-2.0)"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                }
-            ],
-            "description": "Efficient JavaScript minification in PHP",
-            "homepage": "https://github.com/tchwork/jsqueeze",
-            "keywords": [
-                "compression",
-                "javascript",
-                "minification"
-            ],
-            "abandoned": true,
-            "time": "2016-04-19T09:28:22+00:00"
-        },
-        {
             "name": "pear/archive_tar",
             "version": "1.4.10",
             "source": {
@@ -4295,6 +4247,52 @@
                 }
             ],
             "time": "2020-09-27T03:36:23+00:00"
+        },
+        {
+            "name": "tedivm/jshrink",
+            "version": "v1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tedious/JShrink.git",
+                "reference": "566e0c731ba4e372be2de429ef7d54f4faf4477a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tedious/JShrink/zipball/566e0c731ba4e372be2de429ef7d54f4faf4477a",
+                "reference": "566e0c731ba4e372be2de429ef7d54f4faf4477a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6|^7.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.8",
+                "php-coveralls/php-coveralls": "^1.1.0",
+                "phpunit/phpunit": "^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JShrink": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Hafner",
+                    "email": "tedivm@tedivm.com"
+                }
+            ],
+            "description": "Javascript Minifier built in PHP",
+            "homepage": "http://github.com/tedious/JShrink",
+            "keywords": [
+                "javascript",
+                "minifier"
+            ],
+            "time": "2019-06-28T18:11:46+00:00"
         }
     ],
     "aliases": [],

--- a/composer.json
+++ b/composer.json
@@ -36,13 +36,13 @@
     },
     "require-dev": {
         "g1a/composer-test-scenarios": "^3",
-        "phpunit/phpunit": "^6.5.14",
         "natxet/cssmin": "3.0.4",
-        "patchwork/jsqueeze": "^2",
         "pear/archive_tar": "^1.4.4",
         "php-coveralls/php-coveralls": "^2.2",
         "phpdocumentor/reflection-docblock": "^4.3.2",
-        "squizlabs/php_codesniffer": "^3"
+        "phpunit/phpunit": "^6.5.14",
+        "squizlabs/php_codesniffer": "^3",
+        "tedivm/jshrink": "^1.3"
     },
     "scripts": {
         "cs": "./robo sniff",
@@ -94,7 +94,7 @@
     "suggest": {
         "pear/archive_tar": "Allows tar archives to be created and extracted in taskPack and taskExtract, respectively.",
         "henrikbjorn/lurker": "For monitoring filesystem changes in taskWatch",
-        "patchwork/jsqueeze": "For minifying JS files in taskMinify",
+        "tedivm/jshrink": "For minifying JS files in taskMinify",
         "natxet/cssmin": "For minifying CSS files in taskMinify"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b7cc6885d6e20ad64e9bcbfb341fec8",
+    "content-hash": "115b8ad2fb9a0290a91553ce588e2f2a",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -2234,54 +2234,6 @@
             "time": "2018-07-02T15:55:56+00:00"
         },
         {
-            "name": "patchwork/jsqueeze",
-            "version": "v2.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tchwork/jsqueeze.git",
-                "reference": "693d64850eab2ce6a7c8f7cf547e1ab46e69d542"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tchwork/jsqueeze/zipball/693d64850eab2ce6a7c8f7cf547e1ab46e69d542",
-                "reference": "693d64850eab2ce6a7c8f7cf547e1ab46e69d542",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Patchwork\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "(Apache-2.0 or GPL-2.0)"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                }
-            ],
-            "description": "Efficient JavaScript minification in PHP",
-            "homepage": "https://github.com/tchwork/jsqueeze",
-            "keywords": [
-                "compression",
-                "javascript",
-                "minification"
-            ],
-            "abandoned": true,
-            "time": "2016-04-19T09:28:22+00:00"
-        },
-        {
             "name": "pear/archive_tar",
             "version": "1.4.9",
             "source": {
@@ -4436,6 +4388,52 @@
                 }
             ],
             "time": "2020-08-26T08:30:57+00:00"
+        },
+        {
+            "name": "tedivm/jshrink",
+            "version": "v1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tedious/JShrink.git",
+                "reference": "566e0c731ba4e372be2de429ef7d54f4faf4477a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tedious/JShrink/zipball/566e0c731ba4e372be2de429ef7d54f4faf4477a",
+                "reference": "566e0c731ba4e372be2de429ef7d54f4faf4477a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6|^7.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.8",
+                "php-coveralls/php-coveralls": "^1.1.0",
+                "phpunit/phpunit": "^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JShrink": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Hafner",
+                    "email": "tedivm@tedivm.com"
+                }
+            ],
+            "description": "Javascript Minifier built in PHP",
+            "homepage": "http://github.com/tedious/JShrink",
+            "keywords": [
+                "javascript",
+                "minifier"
+            ],
+            "time": "2019-06-28T18:11:46+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/docs/tasks/Assets.md
+++ b/docs/tasks/Assets.md
@@ -119,15 +119,13 @@ $this->taskMinify('web/assets/theme.css')
 Please install additional packages to use this task:
 
 ```
-composer require patchwork/jsqueeze:^2.0
+composer require tedivm/jshrink:^1.3
 composer require natxet/cssmin:^3.0
 ```
 
 * `to($dst)`  Sets destination. Tries to guess type from it.
 * `type($type)`  Sets type with validation.
-* `singleLine($singleLine)`  Single line option for the JS minimisation.
-* `keepImportantComments($keepImportantComments)`  keepImportantComments option for the JS minimisation.
-* `specialVarRx($specialVarRx)`  Set specialVarRx option for the JS minimisation.
+* `flaggedComments($flaggedComments)`  Set flaggedComments option for the JS minimisation.
 * `__toString()`  @return string
 
 ## Scss

--- a/src/Task/Assets/Minify.php
+++ b/src/Task/Assets/Minify.php
@@ -17,7 +17,7 @@ use Robo\Task\BaseTask;
  * Please install additional packages to use this task:
  *
  * ```
- * composer require patchwork/jsqueeze:^2.0
+ * composer require tedivm/jshrink:^1.3
  * composer require natxet/cssmin:^3.0
  * ```
  */
@@ -46,10 +46,8 @@ class Minify extends BaseTask
     /**
      * @var bool[]
      */
-    protected $squeezeOptions = [
-        'singleLine' => true,
-        'keepImportantComments' => true,
-        'specialVarRx' => false,
+    protected $jsShrinkOptions = [
+        'flaggedComments' => true,
     ];
 
     /**
@@ -170,21 +168,15 @@ class Minify extends BaseTask
                 break;
 
             case 'js':
-                if (!class_exists('\JSqueeze') && !class_exists('\Patchwork\JSqueeze')) {
-                    return Result::errorMissingPackage($this, 'Patchwork\JSqueeze', 'patchwork/jsqueeze');
+                if (!class_exists('\JShrink\Minifier')) {
+                    return Result::errorMissingPackage($this, 'JShrink', 'tedivm/jshrink');
                 }
 
-                if (class_exists('\JSqueeze')) {
-                    $jsqueeze = new \JSqueeze();
-                } else {
-                    $jsqueeze = new \Patchwork\JSqueeze();
-                }
-
-                return $jsqueeze->squeeze(
+                return \JShrink\Minifier::minify(
                     $this->text,
-                    $this->squeezeOptions['singleLine'],
-                    $this->squeezeOptions['keepImportantComments'],
-                    $this->squeezeOptions['specialVarRx']
+                    [
+                        'flaggedComments' => $this->jsShrinkOptions['flaggedComments'],
+                    ]
                 );
                 break;
         }
@@ -193,41 +185,15 @@ class Minify extends BaseTask
     }
 
     /**
-     * Single line option for the JS minimisation.
+     * flaggedComments option for the JS minimisation.
      *
-     * @param bool $singleLine
-     *
-     * @return $this
-     */
-    public function singleLine($singleLine)
-    {
-        $this->squeezeOptions['singleLine'] = (bool)$singleLine;
-        return $this;
-    }
-
-    /**
-     * keepImportantComments option for the JS minimisation.
-     *
-     * @param bool $keepImportantComments
+     * @param bool $flaggedComments
      *
      * @return $this
      */
-    public function keepImportantComments($keepImportantComments)
+    public function flaggedComments($flaggedComments)
     {
-        $this->squeezeOptions['keepImportantComments'] = (bool)$keepImportantComments;
-        return $this;
-    }
-
-    /**
-     * Set specialVarRx option for the JS minimisation.
-     *
-     * @param bool $specialVarRx
-     *
-     * @return $this
-     */
-    public function specialVarRx($specialVarRx)
-    {
-        $this->squeezeOptions['specialVarRx'] = (bool)$specialVarRx;
+        $this->jsShrinkOptions['flaggedComments'] = (bool)$flaggedComments;
         return $this;
     }
 


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [x] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Replace abandonned `patchwork/jsqueeze` library by a maintained library.

### Description
`patchwork/jsqueeze` library is abandonned. I propose to replace it by `tedivm/jshrink`, which seems to be one of the more used library for JS minification, according to Packagist statistics.

This library has a BSD-3 license.