### PR TITLE
Add a way to access the original message in TaskExitException

### DIFF
--- a/src/Exception/TaskExitException.php
+++ b/src/Exception/TaskExitException.php
@@ -30,7 +30,8 @@ class TaskExitException extends \Exception
     /**
      * @return string
      */
-    public function getOriginalMessage() {
+    public function getOriginalMessage()
+    {
         return $this->originalMessage;
     }
 }

--- a/src/Exception/TaskExitException.php
+++ b/src/Exception/TaskExitException.php
@@ -6,6 +6,11 @@ class TaskExitException extends \Exception
 {
 
     /**
+     * @var string
+     */
+    private $originalMessage;
+
+    /**
      * TaskExitException constructor.
      *
      * @param string|object $class
@@ -14,9 +19,18 @@ class TaskExitException extends \Exception
      */
     public function __construct($class, $message, $status)
     {
+        $this->originalMessage = $message;
+
         if (is_object($class)) {
             $class = get_class($class);
         }
         parent::__construct("  in task $class \n\n  $message", $status);
+    }
+
+    /**
+     * @return string
+     */
+    public function getOriginalMessage() {
+        return $this->originalMessage;
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Add a new `TaskExitException::getOriginalMessage()` method that returns the original error message returned by a task.

### Description
`TaskExitException` prepends the class name to the message returned by the task.
However, it is sometimes useful to access the original message in a catch clause.

Our use case is that we have a CLI tool that returns a JSON error when failing and we want to parse it.

(Sorry, we are still stuck on 1.x because of https://github.com/boedah/robo-drush/issues/18. But the same patch could probably be applied to 2.x.)
