### PR TITLE
Replace scandir() with symfony finder

### DIFF
--- a/src/Task/Logfile/RotateLog.php
+++ b/src/Task/Logfile/RotateLog.php
@@ -3,6 +3,7 @@
 namespace Robo\Task\Logfile;
 
 use Robo\Result;
+use Symfony\Component\Finder\Finder;
 
 /**
  * Rotates a log (or any other) file
@@ -84,8 +85,7 @@ class RotateLog extends BaseLogfile
     private function process(): self
     {
         $rotation = 0;
-        foreach (scandir($this->logfile->getPath(), SCANDIR_SORT_DESCENDING) as $origin) {
-            $origin = new \SplFileInfo($this->logfile->getPath().'/'.$origin);
+        foreach ($this->createFinder() as $origin) {
             if ($origin->isFile() && $this->isLogfile($origin)) {
                 if ($this->version($origin) < $this->keep) {
                     $rotated = $this->rotate($origin);
@@ -159,5 +159,17 @@ class RotateLog extends BaseLogfile
         $this->filesystem->rename($origin->getPathname(), $rotated);
 
         return $rotated;
+    }
+
+    /**
+     * @return Finder
+     */
+    private function createFinder(): Finder
+    {
+        return (new Finder())->files()
+            ->depth(0)
+            ->sortByName()
+            ->reverseSorting()
+            ->in($this->logfile->getPath());
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Replace scandir() with symfony Finder.
