### PR TITLE
[FEATURE] Replace lurker package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,7 @@
     },
     "suggest": {
         "pear/archive_tar": "Allows tar archives to be created and extracted in taskPack and taskExtract, respectively.",
-        "henrikbjorn/lurker": "For monitoring filesystem changes in taskWatch",
+        "totten/lurkerlite": "For monitoring filesystem changes in taskWatch",
         "patchwork/jsqueeze": "For minifying JS files in taskMinify",
         "natxet/cssmin": "For minifying CSS files in taskMinify"
     },

--- a/src/Task/Base/Watch.php
+++ b/src/Task/Base/Watch.php
@@ -101,7 +101,7 @@ class Watch extends BaseTask
     public function run()
     {
         if (!class_exists('Lurker\\ResourceWatcher')) {
-            return Result::errorMissingPackage($this, 'ResourceWatcher', 'henrikbjorn/lurker');
+            return Result::errorMissingPackage($this, 'ResourceWatcher', 'totten/lurkerlite');
         }
 
         $watcher = new ResourceWatcher();


### PR DESCRIPTION
### Overview

This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary

The watch task requires the package »henrikbjorn/lurker«.
The dependencies of this package dont allow using Symfony 4.
Last release of this package was 2016-03-16. So its abdandoned.

Use the drop-in replacement package totten/lurkerlite instead.
Installing this packsge will remove »henrikbjorn/lurker« automatically.

Since the package is a designated drop-in replacement all existing
methods in robo may stay the same.

### Description

Closes #459 #956 #973