### PR TITLE
[FEATURE] Allow phar path in --dir

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -524,13 +524,16 @@ class Runner implements ContainerAwareInterface
                 $this->roboClass = $className;
             }
         }
-        // Convert directory to a real path, but only if the
-        // path exists. We do not want to lose the original
-        // directory if the user supplied a bad value.
-        $realDir = realpath($this->dir);
-        if ($realDir) {
-            chdir($realDir);
-            $this->dir = $realDir;
+        
+        if (substr($this->dir, 0, 7) !== "phar://") {
+            // Convert directory to a real path, but only if the
+            // path exists. We do not want to lose the original
+            // directory if the user supplied a bad value.
+            $realDir = realpath($this->dir);
+            if ($realDir) {
+                chdir($realDir);
+                $this->dir = $realDir;
+            }
         }
 
         return $argv;


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Allows setting phar paths (e.g. `phar://file.phar`) as --dir option.

### Description
I'm building an own phar file that contains my RoboFile as well as the Robo dependencies.
I'd like to be able to load the RoboFile from my phar file. Right now I overwrite the method in Runner.