### PR TITLE
Add --no-exit option

### DIFF
--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -243,6 +243,15 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
     }
 
     /**
+     * @return $this
+     */
+    public function noExit()
+    {
+        $this->option("no-exit");
+        return $this;
+    }
+    
+    /**
      * @param string $failGroup
      * @return $this
      */


### PR DESCRIPTION
Add --no-exit option for 1.x version (to work with robo-paracept 0.4)

### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Add --no-exit option for 1.x version (to work with robo-paracept 0.4)

### Description
Add --no-exit option for 1.x version (to work with robo-paracept 0.4)
