### PR TITLE
Use proper use imports.

### DIFF
--- a/src/Task/ApiGen/ApiGen.php
+++ b/src/Task/ApiGen/ApiGen.php
@@ -6,6 +6,7 @@ use Robo\Contract\CommandInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
 use Traversable;
+use Robo\Common\ExecOneCommand;
 
 /**
  * Executes ApiGen command to generate documentation
@@ -23,7 +24,7 @@ use Traversable;
  */
 class ApiGen extends BaseTask implements CommandInterface
 {
-    use \Robo\Common\ExecOneCommand;
+    use ExecOneCommand;
 
     const BOOL_NO = 'no';
     const BOOL_YES = 'yes';

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -9,6 +9,8 @@ use Robo\Contract\SimulatedInterface;
 use Robo\Task\BaseTask;
 use Symfony\Component\Process\Process;
 use Robo\Result;
+use Robo\Common\CommandReceiver;
+use Robo\Common\ExecOneCommand;
 
 /**
  * Executes shell script. Closes it when running in background mode.
@@ -30,8 +32,8 @@ use Robo\Result;
  */
 class Exec extends BaseTask implements CommandInterface, PrintedInterface, SimulatedInterface
 {
-    use \Robo\Common\CommandReceiver;
-    use \Robo\Common\ExecOneCommand;
+    use CommandReceiver;
+    use ExecOneCommand;
 
     /**
      * @var static[]

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -8,6 +8,7 @@ use Robo\Result;
 use Robo\Task\BaseTask;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
+use Robo\Common\CommandReceiver;
 
 /**
  * Class ParallelExecTask
@@ -24,7 +25,7 @@ use Symfony\Component\Process\Process;
  */
 class ParallelExec extends BaseTask implements CommandInterface, PrintedInterface
 {
-    use \Robo\Common\CommandReceiver;
+    use CommandReceiver;
 
     /**
      * @var Process[]

--- a/src/Task/Bower/Base.php
+++ b/src/Task/Bower/Base.php
@@ -4,10 +4,11 @@ namespace Robo\Task\Bower;
 
 use Robo\Task\BaseTask;
 use Robo\Exception\TaskException;
+use Robo\Common\ExecOneCommand;
 
 abstract class Base extends BaseTask
 {
-    use \Robo\Common\ExecOneCommand;
+    use ExecOneCommand;
 
     /**
      * @var array

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -7,11 +7,12 @@ use Robo\Contract\PrintedInterface;
 use Robo\Result;
 use Robo\Contract\CommandInterface;
 use Robo\Exception\TaskException;
+use Robo\Common\CommandReceiver;
 
 abstract class CommandStack extends BaseTask implements CommandInterface, PrintedInterface
 {
     use ExecCommand;
-    use \Robo\Common\CommandReceiver;
+    use CommandReceiver;
 
     /**
      * @var string

--- a/src/Task/Composer/Base.php
+++ b/src/Task/Composer/Base.php
@@ -5,10 +5,11 @@ namespace Robo\Task\Composer;
 use Robo\Contract\CommandInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
+use Robo\Common\ExecOneCommand;
 
 abstract class Base extends BaseTask implements CommandInterface
 {
-    use \Robo\Common\ExecOneCommand;
+    use ExecOneCommand;
 
     /**
      * @var string

--- a/src/Task/Gulp/Base.php
+++ b/src/Task/Gulp/Base.php
@@ -5,10 +5,11 @@ namespace Robo\Task\Gulp;
 use Robo\Task\BaseTask;
 use Robo\Exception\TaskException;
 use Robo\Common\ProcessUtils;
+use Robo\Common\ExecOneCommand;
 
 abstract class Base extends BaseTask
 {
-    use \Robo\Common\ExecOneCommand;
+    use ExecOneCommand;
 
     /**
      * @var string

--- a/src/Task/Npm/Base.php
+++ b/src/Task/Npm/Base.php
@@ -4,10 +4,11 @@ namespace Robo\Task\Npm;
 
 use Robo\Task\BaseTask;
 use Robo\Exception\TaskException;
+use Robo\Common\ExecOneCommand;
 
 abstract class Base extends BaseTask
 {
-    use \Robo\Common\ExecOneCommand;
+    use ExecOneCommand;
 
     /**
      * @var string

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -5,6 +5,7 @@ namespace Robo\Task\Remote;
 use Robo\Contract\CommandInterface;
 use Robo\Task\BaseTask;
 use Robo\Exception\TaskException;
+use Robo\Common\ExecOneCommand;
 
 /**
  * Executes rsync in a flexible manner.
@@ -47,7 +48,7 @@ use Robo\Exception\TaskException;
  */
 class Rsync extends BaseTask implements CommandInterface
 {
-    use \Robo\Common\ExecOneCommand;
+    use ExecOneCommand;
 
     /**
      * @var string

--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -6,6 +6,8 @@ use Robo\Contract\CommandInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
 use Robo\Contract\SimulatedInterface;
+use Robo\Common\CommandReceiver;
+use Robo\Common\ExecOneCommand;
 
 /**
  * Runs multiple commands on a remote server.
@@ -43,8 +45,8 @@ use Robo\Contract\SimulatedInterface;
  */
 class Ssh extends BaseTask implements CommandInterface, SimulatedInterface
 {
-    use \Robo\Common\CommandReceiver;
-    use \Robo\Common\ExecOneCommand;
+    use CommandReceiver;
+    use ExecOneCommand;
 
     /**
      * @var null|string

--- a/src/Task/Testing/Atoum.php
+++ b/src/Task/Testing/Atoum.php
@@ -5,6 +5,7 @@ namespace Robo\Task\Testing;
 use Robo\Contract\CommandInterface;
 use Robo\Contract\PrintedInterface;
 use Robo\Task\BaseTask;
+use Robo\Common\ExecOneCommand;
 
 /**
  * Runs [atoum](http://atoum.org/) tests
@@ -21,7 +22,7 @@ use Robo\Task\BaseTask;
  */
 class Atoum extends BaseTask implements CommandInterface, PrintedInterface
 {
-    use \Robo\Common\ExecOneCommand;
+    use ExecOneCommand;
 
     /**
      * @var string

--- a/src/Task/Testing/Behat.php
+++ b/src/Task/Testing/Behat.php
@@ -5,6 +5,7 @@ namespace Robo\Task\Testing;
 use Robo\Contract\CommandInterface;
 use Robo\Contract\PrintedInterface;
 use Robo\Task\BaseTask;
+use Robo\Common\ExecOneCommand;
 
 /**
  * Executes Behat tests
@@ -21,7 +22,7 @@ use Robo\Task\BaseTask;
  */
 class Behat extends BaseTask implements CommandInterface, PrintedInterface
 {
-    use \Robo\Common\ExecOneCommand;
+    use ExecOneCommand;
 
     /**
      * @var string

--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -6,7 +6,7 @@ use Robo\Contract\PrintedInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
 use Robo\Contract\CommandInterface;
-use Symfony\Component\Process\Process;
+use Robo\Common\ExecOneCommand;
 
 /**
  * Executes Codeception tests
@@ -28,7 +28,7 @@ use Symfony\Component\Process\Process;
  */
 class Codecept extends BaseTask implements CommandInterface, PrintedInterface
 {
-    use \Robo\Common\ExecOneCommand;
+    use ExecOneCommand;
 
     /**
      * @var string

--- a/src/Task/Testing/PHPUnit.php
+++ b/src/Task/Testing/PHPUnit.php
@@ -5,6 +5,7 @@ namespace Robo\Task\Testing;
 use Robo\Contract\CommandInterface;
 use Robo\Contract\PrintedInterface;
 use Robo\Task\BaseTask;
+use Robo\Common\ExecOneCommand;
 
 /**
  * Runs PHPUnit tests
@@ -21,7 +22,7 @@ use Robo\Task\BaseTask;
  */
 class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
 {
-    use \Robo\Common\ExecOneCommand;
+    use ExecOneCommand;
 
     /**
      * @var string

--- a/src/Task/Testing/Phpspec.php
+++ b/src/Task/Testing/Phpspec.php
@@ -5,6 +5,7 @@ namespace Robo\Task\Testing;
 use Robo\Contract\PrintedInterface;
 use Robo\Task\BaseTask;
 use Robo\Contract\CommandInterface;
+use Robo\Common\ExecOneCommand;
 
 /**
  * Executes Phpspec tests
@@ -21,7 +22,7 @@ use Robo\Contract\CommandInterface;
  */
 class Phpspec extends BaseTask implements CommandInterface, PrintedInterface
 {
-    use \Robo\Common\ExecOneCommand;
+    use ExecOneCommand;
 
     /**
      * @var string


### PR DESCRIPTION
### Summary

I'm trying to create a binary phar of a custom project with [humbug/box](https://packagist.org/packages/humbug/box). My project depends on Robo.

During the compile process, Humbug will rename namespaces in order to avoid collisions. The problem is that when we import a `trait` with an absolute path, it fails.

In order to fix this, you have to import it properly using the proper `use` statement.
