### PR TITLE
Fix mkdir error in taskExtract on PHP 8

### DIFF
--- a/src/Task/Archive/Extract.php
+++ b/src/Task/Archive/Extract.php
@@ -105,7 +105,7 @@ class Extract extends BaseTask implements BuilderAwareInterface
 
         $destinationParentDir = dirname($this->to);
         if (!file_exists($destinationParentDir)) {
-          @mkdir($destinationParentDir);
+            @mkdir($destinationParentDir);
         }
 
         $this->startTimer();

--- a/src/Task/Archive/Extract.php
+++ b/src/Task/Archive/Extract.php
@@ -102,7 +102,11 @@ class Extract extends BaseTask implements BuilderAwareInterface
         // We will first extract to $extractLocation and then move to $this->to
         $extractLocation = static::getTmpDir();
         @mkdir($extractLocation);
-        @mkdir(dirname($this->to));
+
+        $destinationParentDir = dirname($this->to);
+        if (!file_exists($destinationParentDir)) {
+          @mkdir($destinationParentDir);
+        }
 
         $this->startTimer();
 


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
If you use `taskExtract` on PHP 8 with `error_reporting = E_ALL`, the task will always produce this error:
```
ERROR: mkdir(): File exists
in /vendor/consolidation/robo/src/Task/Archive/Extract.php:105
``` 
It happens because the line mentioned in the error message uses error suppression on `mkdir()` when trying to create a parent directory for the extraction destination folder:
```
@mkdir(dirname($this->to));
```
The parent folder will almost always exist, so an error will be emitted, and on PHP 8 the `@` operator does not work anymore for certain cases, such as the `E_ALL` level of error reporting.

This PR fixes the error.