### PR TITLE
Added new 'composer show' task.

### DIFF
--- a/docs/tasks/Composer.md
+++ b/docs/tasks/Composer.md
@@ -328,6 +328,25 @@ $this->taskComposerRequire()->dependency('foo/bar', '^.2.4.8')->run();
 * `options(array $options, $separator = null)`  Pass multiple options to executable. The associative array contains
 * `optionList($option, $value = null, $separator = null)`  Pass an option with multiple values to executable. Value can be a string or array.
 
+## Show
+
+
+Composer Show
+
+``` php
+<?php
+// simple execution
+$this->taskComposerRequire()->dependency('foo/bar')->run();
+
+// inspect output
+$this->taskComposerRequire()->dependency('foo/bar')->format('json')->printOutput(false)->run();
+$dependencyInfo = $result->getOutputData();
+?>
+```
+
+* `dependency($project, $version = null)`  composer dependency
+* `format($format = 'json')`  adds `format` option to composer
+
 ## Update
 
 

--- a/src/Task/Composer/Show.php
+++ b/src/Task/Composer/Show.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Robo\Task\Composer;
+
+/**
+ * Composer Show
+ *
+ * ``` php
+ * <?php
+ *  // simple execution
+ *  $this->taskComposerRequire()->dependency('foo/bar')->run();
+ *
+ *  // inspect output
+ *  $this->taskComposerRequire()->dependency('foo/bar')->format('json')->printOutput(false)->run();
+ *  $dependencyInfo = $result->getOutputData();
+ * ?>
+ * ```
+ */
+class Show extends Base
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $action = 'show';
+
+    /**
+     * composer dependency
+     *
+     * @param string $project
+     *
+     * @return $this
+     */
+    public function dependency($project)
+    {
+        $project = (array)$project;
+
+        $this->args($project);
+        return $this;
+    }
+
+    /**
+     * adds `format` option to composer
+     *
+     * @param string $format
+     *
+     * @return $this
+     */
+    public function format($format = 'text')
+    {
+        $this->option('--format', $format);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run()
+    {
+        $command = $this->getCommand();
+        $this->printTaskInfo('Showing packages: {command}', ['command' => $command]);
+        return $this->executeCommand($command);
+    }
+}

--- a/src/Task/Composer/loadTasks.php
+++ b/src/Task/Composer/loadTasks.php
@@ -99,6 +99,16 @@ trait loadTasks
      *
      * @return \Robo\Task\Composer\CreateProject|\Robo\Collection\CollectionBuilder
      */
+    protected function taskComposerShow($pathToComposer = null)
+    {
+        return $this->task(Show::class, $pathToComposer);
+    }
+
+    /**
+     * @param null|string $pathToComposer
+     *
+     * @return \Robo\Task\Composer\CreateProject|\Robo\Collection\CollectionBuilder
+     */
     protected function taskCheckPlatformReqs($pathToComposer = null)
     {
         return $this->task(CheckPlatformReqs::class, $pathToComposer);


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [x] Adds or fixes documentation

### Summary
Added new 'composer show' task.

### Description
I am attempting to add some logic to my Robo commands based on the installed version of a dependency. The output from `composer show` would be useful in determining that.

I imagine I am likely missing some things before these changes would be accepted and I am happy to iterate with some feedback.

I created this branch/PR against `2.x` as that is what I am currently using on my projects due to [drush's dependency requirements](https://github.com/drush-ops/drush/blob/1af5fe0881809bd8baa37386748a0276747554d2/composer.json#L39), but if there is interest in accepting these submissions, I would be happy to recreate it against `3.x`.
