### PR TITLE
Fix null return in createContainer.

### DIFF
--- a/src/Robo.php
+++ b/src/Robo.php
@@ -162,7 +162,7 @@ class Robo
 
         // Set up our dependency injection container.
         $container = new Container();
-        return static::configureContainer($container, $app, $config, $unusedInput, $unusedOutput, $classLoader);
+        static::configureContainer($container, $app, $config, $unusedInput, $unusedOutput, $classLoader);
 
         return $container;
     }


### PR DESCRIPTION
### Overview
This pull request:

- Fixes a bug

### Summary
Fix the createContainer method always returning null instead of the container.

### Description
I believe is just some unintended return.
