### PR TITLE
Add setProcessInput and deprecate setInput.

### DIFF
--- a/docs/tasks/Base.md
+++ b/docs/tasks/Base.md
@@ -21,6 +21,7 @@ if ($this->taskExec('phpunit .')->run()->wasSuccessful()) {
 
 * `simulate($context)`  {@inheritdoc}
 * `setOutput($output)`  Sets the Console Output.
+* `setProcessInput($output)`  Sets the input for the command. Similar to a pipe like `echo "input" | cat`. Usually followed by a call to `->interactive(false)` to avoid other inputs.
 * `dir($dir)`  Changes working directory of command
 * `arg($arg)`  Pass argument to executable. Its value will be automatically escaped.
 * `args($args)`  Pass methods parameters as arguments to executable. Argument values
@@ -49,7 +50,7 @@ $this->taskExecStack()
 * `executable($executable)`   * `param string` $executable
 * `exec($command)`   * `param string|string[]|CommandInterface` $command
 * `stopOnFail($stopOnFail = null)`   * `param bool` $stopOnFail
-* `result($result)` 
+* `result($result)`
 * `setOutput($output)`  Sets the Console Output.
 * `dir($dir)`  Changes working directory of command
 
@@ -94,7 +95,7 @@ $this->taskSymfonyCommand(new ModelGeneratorCommand())
 ```
 
 * `arg($arg, $value)`   * `param string` $arg
-* `opt($option, $value = null)` 
+* `opt($option, $value = null)`
 * `setOutput($output)`  Sets the Console Output.
 
 

--- a/docs/tasks/Base.md
+++ b/docs/tasks/Base.md
@@ -21,7 +21,7 @@ if ($this->taskExec('phpunit .')->run()->wasSuccessful()) {
 
 * `simulate($context)`  {@inheritdoc}
 * `setOutput($output)`  Sets the Console Output.
-* `setProcessInput($output)`  Sets the input for the command. Similar to a pipe like `echo "input" | cat`. Usually followed by a call to `->interactive(false)` to avoid other inputs.
+* `setProcessInput($input)`  Sets the input for the command. Similar to a pipe like `echo "input" | cat`.
 * `dir($dir)`  Changes working directory of command
 * `arg($arg)`  Pass argument to executable. Its value will be automatically escaped.
 * `args($args)`  Pass methods parameters as arguments to executable. Argument values

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -215,10 +215,25 @@ trait ExecTrait
      *
      * @return $this
      */
-    public function setInput($input)
+    public function setProcessInput($input)
     {
         $this->input = $input;
         return $this;
+    }
+
+    /**
+     * Pass an input to the process. Can be resource created with fopen() or string
+     *
+     * @param resource|string $input
+     *
+     * @return $this
+     *
+     * @deprecated
+     */
+    public function setInput($input)
+    {
+        trigger_error('setInput() is deprecated. Please use setProcessInput(().', E_USER_DEPRECATED);
+        return $this->setProcessInput($input);
     }
 
     /**

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -218,6 +218,8 @@ trait ExecTrait
     public function setProcessInput($input)
     {
         $this->input = $input;
+        // A tty should not be allocated when the input is provided.
+        $this->interactive(false);
         return $this;
     }
 

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -235,7 +235,8 @@ trait ExecTrait
     public function setInput($input)
     {
         trigger_error('setInput() is deprecated. Please use setProcessInput(().', E_USER_DEPRECATED);
-        return $this->setProcessInput($input);
+        $this->input = $input;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [x] Adds documentation

### Summary
Use a different method name to set the input for a process as the current one is overridden by the `InputAwareTrait` used by the `CollectionBuilder`

### Description
I was trying to provide a docker-compose.yml file via stdin by doing
```php
$this
  ->taskExec('docker-compose')
  ->setInput($YamlFileContents)
  ->interactive(false)
  ->option('file', '/dev/stdin')
  ->arg('up')
  ->option('detach')
  ->run();
```
but the `setInput()` that ends up being called is not the one on the `ExecTrait` so I propose to deprecate setInput as it wasn't working anyway and add a new method name that is more descriptive.

I am not sure that `interactive` should also be set to false automatically when you provide input for the process but that can be a discussion for another issue.