### PR TITLE
Changed taskExec to use symfony process placeholders

### DIFF
--- a/src/Common/CommandArguments.php
+++ b/src/Common/CommandArguments.php
@@ -43,6 +43,19 @@ trait CommandArguments
     }
 
     /**
+     * Escape a command line argument.
+     *
+     * @param string $argument
+     * @return string
+     *
+     * @deprecated Use \Robo\Common\ProcessUtils::escapeArgument() instead.
+     */
+    public function escape($argument)
+    {
+        return ProcessUtils::escapeArgument($argument);
+    }
+
+    /**
      * Pass argument to executable. It will be changed to a placeholder.
      *
      * @param string $arg

--- a/src/Common/CommandArguments.php
+++ b/src/Common/CommandArguments.php
@@ -50,7 +50,7 @@ trait CommandArguments
      *
      * @deprecated Use \Robo\Common\ProcessUtils::escapeArgument() instead.
      */
-    public function escape($argument)
+    public static function escape($argument)
     {
         return ProcessUtils::escapeArgument($argument);
     }

--- a/src/Common/CommandArguments.php
+++ b/src/Common/CommandArguments.php
@@ -29,7 +29,7 @@ trait CommandArguments
      * @param string|null $separator
      * @return void
      */
-    public function addArgument($argument, $key = null, $prefix = null, $separator = ' ')
+    protected function addArgument($argument, $key = null, $prefix = null, $separator = ' ')
     {
         if (is_null($key)) {
             $key = "arg" . md5($argument);

--- a/src/Common/CommandArguments.php
+++ b/src/Common/CommandArguments.php
@@ -15,7 +15,35 @@ trait CommandArguments
     protected $arguments = '';
 
     /**
-     * Pass argument to executable. Its value will be automatically escaped.
+     * @var array
+     */
+    protected $argumentsEnv = [];
+
+
+    /**
+     * Adds an argument and its placeholder value, to be executed
+     *
+     * @param string $argument
+     * @param string|null $key
+     * @param string|null $prefix
+     * @param string|null $separator
+     * @return void
+     */
+    public function addArgument($argument, $key = null, $prefix = null, $separator = ' ')
+    {
+        if (is_null($key)) {
+            $key = "arg" . md5($argument);
+        }
+
+        $this->arguments .= null == $prefix ? '' : $separator . $prefix;
+        if (!is_null($argument)) {
+            $this->arguments .= ' "${:' . $key . '}"';
+            $this->argumentsEnv[$key] = $argument;
+        }
+    }
+
+    /**
+     * Pass argument to executable. It will be changed to a placeholder.
      *
      * @param string $arg
      *
@@ -27,8 +55,8 @@ trait CommandArguments
     }
 
     /**
-     * Pass methods parameters as arguments to executable. Argument values
-     * are automatically escaped.
+     * Pass methods parameters as arguments to executable. Argument are
+     * automatically passed as placeholders
      *
      * @param string|string[] $args
      *
@@ -40,7 +68,10 @@ trait CommandArguments
         if (!is_array($args)) {
             $args = $func_args;
         }
-        $this->arguments .= ' ' . implode(' ', array_map('static::escape', $args));
+
+        foreach ($args as $arg) {
+            $this->addArgument($arg);
+        }
         return $this;
     }
 
@@ -59,24 +90,8 @@ trait CommandArguments
     }
 
     /**
-     * Escape the provided value, unless it contains only alphanumeric
-     * plus a few other basic characters.
-     *
-     * @param string $value
-     *
-     * @return string
-     */
-    public static function escape($value)
-    {
-        if (preg_match('/^[a-zA-Z0-9\/\.@~_-]+$/', $value)) {
-            return $value;
-        }
-        return ProcessUtils::escapeArgument($value);
-    }
-
-    /**
      * Pass option to executable. Options are prefixed with `--` , value can be provided in second parameter.
-     * Option values are automatically escaped.
+     * Option values are automatically passed as placeholders.
      *
      * @param string $option
      * @param string $value
@@ -89,15 +104,15 @@ trait CommandArguments
         if ($option !== null and strpos($option, '-') !== 0) {
             $option = "--$option";
         }
-        $this->arguments .= null == $option ? '' : " " . $option;
-        $this->arguments .= null == $value ? '' : $separator . static::escape($value);
+
+        $this->addArgument($value, null, $option, $separator);
         return $this;
     }
 
     /**
      * Pass multiple options to executable. The associative array contains
      * the key:value pairs that become `--key value`, for each item in the array.
-     * Values are automatically escaped.
+     * Values are passed as placeholders.
      *
      * @param array $options
      * @param string $separator

--- a/src/Common/CommandArguments.php
+++ b/src/Common/CommandArguments.php
@@ -52,6 +52,9 @@ trait CommandArguments
      */
     public static function escape($argument)
     {
+        if (preg_match('/^[a-zA-Z0-9\/\.@~_-]+$/', $argument)) {
+            return $argument;
+        }
         return ProcessUtils::escapeArgument($argument);
     }
 

--- a/src/Common/ProcessUtils.php
+++ b/src/Common/ProcessUtils.php
@@ -10,9 +10,9 @@ namespace Robo\Common;
 use Symfony\Component\Process\Exception\InvalidArgumentException;
 
 /**
- * ProcessUtils is a bunch of utility methods. We want to allow Robo 1.x
- * to work with Symfony 4.x while remaining backwards compatibility. This
- * requires us to replace some deprecated functionality removed in Symfony.
+ * ProcessUtils is a bunch of utility methods.
+ * These methods are usually private, and are needed to execute and escape
+ * some functions for display purposes
  */
 class ProcessUtils
 {
@@ -24,58 +24,47 @@ class ProcessUtils
     }
 
     /**
-     * Escapes a string to be used as a shell argument.
+     * Symfony Process has a private method to replace Placeholders in command lines,
+     * which we use to rebuild a Command Description.
      *
-     * This method is a copy of a method that was deprecated by Symfony 3.3 and
-     * removed in Symfony 4; it will be removed once there is an actual
-     * replacement for escapeArgument.
-     *
-     * @param string $argument
-     *   The argument that will be escaped.
-     *
-     * @return string
-     *   The escaped argument.
+     * @param string $commandline
+     * @param array $env
+     * @return void
      */
-    public static function escapeArgument($argument)
+    public static function replacePlaceholders(string $commandline, array $env)
     {
-        //Fix for PHP bug #43784 escapeshellarg removes % from given string
-        //Fix for PHP bug #49446 escapeshellarg doesn't work on Windows
-        //@see https://bugs.php.net/bug.php?id=43784
-        //@see https://bugs.php.net/bug.php?id=49446
-        if ('\\' === DIRECTORY_SEPARATOR) {
-            if ('' === $argument) {
-                return escapeshellarg($argument);
+        return preg_replace_callback('/"\$\{:([_a-zA-Z]++[_a-zA-Z0-9]*+)\}"/', function ($matches) use ($commandline, $env) {
+            if (!isset($env[$matches[1]]) || false === $env[$matches[1]]) {
+                throw new InvalidArgumentException(sprintf('Command line is missing a value for parameter "%s": ', $matches[1]).$commandline);
             }
 
-            $escapedArgument = '';
-            $quote = false;
-            foreach (preg_split('/(")/', $argument, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE) as $part) {
-                if ('"' === $part) {
-                    $escapedArgument .= '\\"';
-                } elseif (self::isSurroundedBy($part, '%')) {
-                    // Avoid environment variable expansion
-                    $escapedArgument .= '^%"' . substr($part, 1, -1) . '"^%';
-                } else {
-                    // escape trailing backslash
-                    if ('\\' === substr($part, -1)) {
-                        $part .= '\\';
-                    }
-                    $quote = true;
-                    $escapedArgument .= $part;
-                }
-            }
-            if ($quote) {
-                $escapedArgument = '"' . $escapedArgument . '"';
-            }
-
-            return $escapedArgument;
-        }
-
-        return "'" . str_replace("'", "'\\''", $argument) . "'";
+            return self::escapeArgument($env[$matches[1]]);
+        }, $commandline);
     }
 
-    private static function isSurroundedBy($arg, $char)
+    /**
+     * Used by Symfony Process to form the final command line, with escaped parameters.
+     * Robo uses placeholders to handle the process arguments without escaping the whole string.
+     *
+     * @param string|null $argument
+     * @return string
+     */
+    public static function escapeArgument(?string $argument): string
     {
-        return 2 < strlen($arg) && $char === $arg[0] && $char === $arg[strlen($arg) - 1];
+        if ('' === $argument || null === $argument) {
+            return '""';
+        }
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            return "'".str_replace("'", "'\\''", $argument)."'";
+        }
+        if (false !== strpos($argument, "\0")) {
+            $argument = str_replace("\0", '?', $argument);
+        }
+        if (!preg_match('/[\/()%!^"<>&|\s]/', $argument)) {
+            return $argument;
+        }
+        $argument = preg_replace('/(\\\\+)$/', '$1$1', $argument);
+
+        return '"'.str_replace(['"', '^', '%', '!', "\n"], ['""', '"^^"', '"^%"', '"^!"', '!LF!'], $argument).'"';
     }
 }

--- a/src/Common/ProcessUtils.php
+++ b/src/Common/ProcessUtils.php
@@ -29,7 +29,7 @@ class ProcessUtils
      *
      * @param string $commandline
      * @param array $env
-     * @return void
+     * @return string
      */
     public static function replacePlaceholders(string $commandline, array $env)
     {

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -11,6 +11,7 @@ use Symfony\Component\Process\Process;
 use Robo\Result;
 use Robo\Common\CommandReceiver;
 use Robo\Common\ExecOneCommand;
+use Robo\Common\ProcessUtils;
 
 /**
  * Executes shell script. Closes it when running in background mode.
@@ -98,8 +99,9 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
      */
     protected function getCommandDescription()
     {
-        return $this->getCommand();
+        return ProcessUtils::replacePlaceholders($this->getCommand(), $this->argumentsEnv);
     }
+
     /**
      * {@inheritdoc}
      */
@@ -132,7 +134,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
     {
         $this->hideProgressIndicator();
         // TODO: Symfony 4 requires that we supply the working directory.
-        $result_data = $this->execute(Process::fromShellCommandline($this->getCommand(), getcwd()));
+        $result_data = $this->execute(Process::fromShellCommandline($this->getCommand(), getcwd(), $this->argumentsEnv));
         $result = new Result(
             $this,
             $result_data->getExitCode(),

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -6,6 +6,7 @@ use Robo\Contract\CommandInterface;
 use Robo\Task\BaseTask;
 use Robo\Exception\TaskException;
 use Robo\Common\ExecOneCommand;
+use Robo\Common\ProcessUtils;
 
 /**
  * Executes rsync in a flexible manner.
@@ -430,6 +431,11 @@ class Rsync extends BaseTask implements CommandInterface
         $command = $this->getCommand();
 
         return $this->executeCommand($command);
+    }
+
+    public function getCommandDescription()
+    {
+        return ProcessUtils::replacePlaceholders($this->getCommand(), $this->argumentsEnv);
     }
 
     /**

--- a/tests/integration/ExecTest.php
+++ b/tests/integration/ExecTest.php
@@ -29,6 +29,10 @@ class ExecTest extends TestCase
 
     public function testMultipleEnvVars()
     {
+        if (strncasecmp(PHP_OS, 'WIN', 3) == 0) {
+          $this->markTestSkipped('Environment variables is not supported on Windows.');
+        }
+
         $task = $this->taskExec('env')->interactive(false);
         $task->env('FOO', 'BAR');
         $task->env('BAR', 'BAZ');

--- a/tests/phpunit/Common/CommandArgumentsTest.php
+++ b/tests/phpunit/Common/CommandArgumentsTest.php
@@ -13,58 +13,33 @@ class CommandArgumentsTest extends TestCase
     public function casesArgs() {
         return [
             'no arguments' => [
-                ' ',
-                ' ',
+                '',
+                '',
                 [],
             ],
             'empty string' => [
-                " ''",
                 ' ""',
-                [''],
+                ' ""',
+                [""],
             ],
             'space' => [
                 " ' '",
                 ' " "',
                 [' '],
             ],
-            'no escape - a' => [
-                " a",
-                " a",
-                ['a'],
-            ],
-            'no escape - A' => [
-                " A",
-                " A",
-                ['A'],
-            ],
-            'no escape - 0' => [
-                " 0",
-                " 0",
-                ['0'],
-            ],
-            'no escape - --' => [
-                " --",
-                " --",
-                ['--'],
-            ],
-            'no escape - @_~.' => [
-                " @_~.",
-                " @_~.",
-                ['@_~.'],
-            ],
             '$' => [
                 " 'a\$b'",
-                ' "a$b"',
+                ' a$b',
                 ['a$b'],
             ],
             '*' => [
                 " 'a*b'",
-                ' "a*b"',
+                ' a*b',
                 ['a*b'],
             ],
             'multi' => [
-                " '' a '\$PATH'",
-                ' "" a "$PATH"',
+                ' "" \'a\' \'$PATH\'',
+                ' "" a $PATH',
                 ['', 'a', '$PATH'],
             ],
         ];

--- a/tests/phpunit/Task/RsyncTest.php
+++ b/tests/phpunit/Task/RsyncTest.php
@@ -7,9 +7,9 @@ class RsyncTest extends TestCase
     // tests
     public function testRsync()
     {
-        $linuxCmd = 'rsync --recursive --exclude .git --exclude .svn --exclude .hg --checksum --whole-file --verbose --progress --human-readable --stats src/ \'dev@localhost:/var/www/html/app/\'';
+        $linuxCmd = "rsync --recursive --exclude '.git' --exclude '.svn' --exclude '.hg' --checksum --whole-file --verbose --progress --human-readable --stats 'src/' 'dev@localhost:/var/www/html/app/'";
 
-        $winCmd = 'rsync --recursive --exclude .git --exclude .svn --exclude .hg --checksum --whole-file --verbose --progress --human-readable --stats src/ "dev@localhost:/var/www/html/app/"';
+        $winCmd = 'rsync --recursive --exclude .git --exclude .svn --exclude .hg --checksum --whole-file --verbose --progress --human-readable --stats "src/" "dev@localhost:/var/www/html/app/"';
 
         $cmd = stripos(PHP_OS, 'WIN') === 0 ? $winCmd : $linuxCmd;
 
@@ -28,7 +28,7 @@ class RsyncTest extends TestCase
                 ->progress()
                 ->humanReadable()
                 ->stats()
-                ->getCommand()
+                ->getCommandDescription()
         );
 
         $linuxCmd = 'rsync \'src/foo bar/baz\' \'dev@localhost:/var/path/with/a space\'';
@@ -45,12 +45,12 @@ class RsyncTest extends TestCase
                 ->toHost('localhost')
                 ->toUser('dev')
                 ->toPath('/var/path/with/a space')
-                ->getCommand()
+                ->getCommandDescription()
         );
 
-        $linuxCmd = 'rsync src/foo src/bar \'dev@localhost:/var/path/with/a space\'';
+        $linuxCmd = "rsync 'src/foo' 'src/bar' 'dev@localhost:/var/path/with/a space'";
 
-        $winCmd = 'rsync src/foo src/bar "dev@localhost:/var/path/with/a space"';
+        $winCmd = 'rsync "src/foo" "src/bar" "dev@localhost:/var/path/with/a space"';
 
         $cmd = stripos(PHP_OS, 'WIN') === 0 ? $winCmd : $linuxCmd;
 
@@ -62,12 +62,12 @@ class RsyncTest extends TestCase
                 ->toHost('localhost')
                 ->toUser('dev')
                 ->toPath('/var/path/with/a space')
-                ->getCommand()
+                ->getCommandDescription()
         );
 
-        $linuxCmd = 'rsync --rsh \'ssh -i ~/.ssh/id_rsa\' src/foo \'dev@localhost:/var/path\'';
+        $linuxCmd = "rsync --rsh 'ssh -i ~/.ssh/id_rsa' 'src/foo' 'dev@localhost:/var/path'";
 
-        $winCmd = 'rsync --rsh "ssh -i ~/.ssh/id_rsa" src/foo "dev@localhost:/var/path"';
+        $winCmd = 'rsync --rsh "ssh -i ~/.ssh/id_rsa" "src/foo" "dev@localhost:/var/path"';
 
         $cmd = stripos(PHP_OS, 'WIN') === 0 ? $winCmd : $linuxCmd;
 
@@ -80,7 +80,7 @@ class RsyncTest extends TestCase
                 ->toUser('dev')
                 ->toPath('/var/path')
                 ->remoteShell('ssh -i ~/.ssh/id_rsa')
-                ->getCommand()
+                ->getCommandDescription()
         );
     }
 }

--- a/tests/src/Traits/Common/CommandArgumentsHost.php
+++ b/tests/src/Traits/Common/CommandArgumentsHost.php
@@ -3,6 +3,7 @@
 namespace Robo\Traits\Common;
 
 use Robo\Common\CommandArguments;
+use Robo\Common\ProcessUtils;
 
 class CommandArgumentsHost
 {
@@ -13,6 +14,6 @@ class CommandArgumentsHost
      */
     public function getArguments()
     {
-        return $this->arguments;
+        return ProcessUtils::replacePlaceholders($this->arguments, $this->argumentsEnv);
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [x] Breaks backwards compatibility
- [x] Has tests that cover changes
- [x] Adds or fixes documentation

### Summary
Changed taskExec to use symfony process placeholders

### Description
taskExec still used some deprecated functions that should have been deleted in Robo 2.0.
Since it didn't, and was throwing E_USER_DEPRECATED when trying to escape some specifics args/options, I've switched the feature to instead use placeholders and let Symfony Process handle the escaping itself.

Please note that :
- It now escaped arguments, simple or not : `a` is escaped to `'a'`, so it's technically not a perfect replacement. However, Symfony Process handles these use case itself, and probably already replaced them anyway even if Robo didn't. Some tests have been dropped as a result, since there's no longer a "no escape" case ;
- I've had to copy two functions from Symfony Process : mostly the `escapeArgument()`, and `replacePlaceholders()`. The former is still used in other part of the core (notably `taskOpenBrowser()` and git commits), while the latter is used for the `getCommandDescription()` to rebuild the executed command to output in the console, and in tests ;
- I've chosen to generate a hash of the arg using md5, since it's quick, will handle duplicate argument values, and is very unlikely to generate duplicates for strings the length of an argument ;
- While running the test suite on Windows, I've had to fix the environment variable set test case : `env` command isn't available on Win, so the test was always failing ;
- I've updated most comments mentioning the old arguments escaping behaviour, but I may have missed some.

Feel free to ask if you need any clarifications.