### PR TITLE
add support for compileString() method in scssphp 1.5 and above

### DIFF
--- a/src/Task/Assets/Scss.php
+++ b/src/Task/Assets/Scss.php
@@ -64,7 +64,12 @@ class Scss extends CssPreprocessor
             $scss->setFormatter($this->compilerOptions['formatter']);
         }
 
-        return $scss->compile($scssCode);
+        if (method_exists($scss, 'compileString')) {
+            // "compileString()" is available since scssphp v1.5
+            return $scss->compileString($scssCode)->getCss();
+        } else {
+            return $scss->compile($scssCode);
+        }
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Add support for new `compileString()` method which returns a result object instead of string.

### Description
The SCSS task uses `Compiler::compile()` which is deprecated in current scssphp. 
Check, if `compileString()` is available and use it, if so.

This change does not break compatibility with `scssphp/scssphp ~1.0.0`, but eliminates the deprecation warning with 1.5 and above.

Could probably ease extension for source map, because the `CompilationResult` has a `getSourceMap()` method to access the output from the very same result object.