### PR TITLE
Image Minify: Skip files without minifier & replace faulty message

### DIFF
--- a/src/Task/Assets/ImageMinify.php
+++ b/src/Task/Assets/ImageMinify.php
@@ -216,15 +216,15 @@ class ImageMinify extends BaseTask
         }
 
         $amount = (count($files) == 1 ? 'image' : 'images');
-        $message = "Minified {filecount} out of {filetotal} $amount into {destination}";
+        $message = 'Minified {filecount} out of {filetotal} ' . $amount . ' into {destination}';
         $context = ['filecount' => count($this->results['success']), 'filetotal' => count($files), 'destination' => $this->to];
 
-        if (count($this->results['success']) == count($files)) {
-            $this->printTaskSuccess($message, $context);
+        $this->printTaskInfo($message, $context);
 
-            return Result::success($this, $message, $context);
+        if (count($this->results['success']) == count($files)) {
+            return Result::success($this, ucfirst($amount) . ' minified.');
         } else {
-            return Result::error($this, $message, $context);
+            return Result::error($this, ucfirst($amount) . ' minification failed.');
         }
     }
 

--- a/src/Task/Assets/ImageMinify.php
+++ b/src/Task/Assets/ImageMinify.php
@@ -389,6 +389,12 @@ class ImageMinify extends BaseTask
                         $minifier = 'svgo';
                         break;
                 }
+
+                // Skip files without available minifier
+                if ($minifier === '') {
+                    $this->results['error'][] = $from;
+                    continue;
+                }
             } else {
                 if (!in_array($this->minifier, $this->minifiers, true)
                     && !is_callable(strtr($this->minifier, '-', '_'))

--- a/tests/integration/AssetsTest.php
+++ b/tests/integration/AssetsTest.php
@@ -76,4 +76,15 @@ class AssetsTest extends TestCase
         $this->assertLessThan($initialFileSize, $minifiedFileSize, 'Minified file is smaller than the source file');
         $this->assertGreaterThan(0, $minifiedFileSize, 'Minified file is not empty');
     }
+
+    public function testImageMinificationErrors()
+    {
+        $this->fixtures->createAndCdToSandbox();
+
+        // fails because file is not an image
+        $result = $this->taskImageMinify($this->fixtures->dataFile('sample.css'))
+            ->to(realpath('') . '/dist')
+            ->run();
+        $this->assertFalse($result->wasSuccessful(), $result->getMessage());
+    }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Fixes a faulty error message in case the image minifier processes all files,
and does not crash before, but some images can not be minified.

Also skip the minification process for all files which have no minifier set.
This allows to continue the task and not stop the minification process
for all files.

### Description
In case of an error the message contains placeholders which
are not replaced anymore downstream
(`Minified {filecount} out of {filetotal} images into {destination}`).
Print the result message as info and then return a short task message
without placeholders instead.

Early return for all files which have no minifier set,
to avoid fatal error with ambigous error message
“Minifier method  cannot be found!”.
For example when webp images exist in the image directory.
The files are added to the error list right away,
to that the task may continue to minify other images and
show a result message (“Minified X of Y files”) at the end.
