### PR TITLE
PackPhar: Don't strip PHP8 attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,12 @@ jobs:
           - os: ubuntu-latest
             php-version: "7.1"
             dependencies: lowest
+            php-ini-values: assert.exception=1, zend.assertions=1, phar.readonly=false
 
           - os: ubuntu-latest
             php-version: "7.4"
             dependencies: highest
+            php-ini-values: assert.exception=1, zend.assertions=1, phar.readonly=false
 
           - os: ubuntu-latest
             php-version: "8.0"
@@ -132,7 +134,7 @@ jobs:
 
       - name: Make sure composer.json is valid before we start modifyig it
         run: composer validate
-        
+
       - name: Clear platform php configuration in case we need to update phpunit
         run: composer config --unset platform.php
 
@@ -152,7 +154,7 @@ jobs:
 
       - name: Run tests with phpunit
         run: composer unit
-      
+
       - name: Publish code coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.php-version == '8.0'
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           - "7.4"
 
         php-ini-values:
-          - assert.exception=1, zend.assertions=1
+          - assert.exception=1, zend.assertions=1, phar.readonly=false
 
         dependencies:
           - locked
@@ -100,7 +100,7 @@ jobs:
           - os: ubuntu-latest
             php-version: "8.0"
             dependencies: highest
-            php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
+            php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205, phar.readonly=false
 
     steps:
       - name: Checkout

--- a/src/Task/Development/PackPhar.php
+++ b/src/Task/Development/PackPhar.php
@@ -233,8 +233,12 @@ EOF;
             if (is_string($token)) {
                 $output .= $token;
             } elseif (in_array($token[0], array(T_COMMENT, T_DOC_COMMENT))) {
-                // $output .= $token[1];
-                $output .= str_repeat("\n", substr_count($token[1], "\n"));
+                if (substr($token[1], 0, 2) === '#[') {
+                    // Don't strip annotations
+                    $output .= $token[1];
+                } else {
+                    $output .= str_repeat("\n", substr_count($token[1], "\n"));
+                }
             } elseif (T_WHITESPACE === $token[0]) {
                 // reduce wide spaces
                 $whitespace = preg_replace('{[ \t]+}', ' ', $token[1]);

--- a/tests/_data/TestedRoboFile.php
+++ b/tests/_data/TestedRoboFile.php
@@ -5,6 +5,7 @@ class TestedRoboFile extends \Robo\Tasks
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function hello($name = null, $opts = ['yell' => false, 'to' => null]) {
     }
 

--- a/tests/integration/PackPharTest.php
+++ b/tests/integration/PackPharTest.php
@@ -1,0 +1,41 @@
+<?php
+namespace Robo;
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use Robo\Traits\TestTasksTrait;
+
+class PackPharTest extends TestCase
+{
+    use TestTasksTrait;
+    use Task\Development\Tasks;
+
+    protected $fixtures;
+
+    public function setUp(): void
+    {
+        $this->fixtures = new Fixtures();
+        $this->initTestTasksTrait();
+    }
+
+    public function tearDown(): void
+    {
+        $this->fixtures->cleanup();
+    }
+
+    public function testAddStrippedFileContainingAnnotation()
+    {
+        $this->fixtures->createAndCdToSandbox();
+
+        $pharFile = 'test.phar';
+        $this->taskPackPhar($pharFile)
+            ->addStripped(
+                'annotated.php',
+                $this->fixtures->dataFile('TestedRoboFile.php'))
+            ->run();
+
+        $phar = new \Phar($pharFile);
+
+        $fileContent = $phar['annotated.php']->getContent();
+        $this->assertStringContainsString('#[\ReturnTypeWillChange]', $fileContent, 'Annotation was stripped');
+    }
+}


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary

PackPhar::addStripped removes all comments from file, including PHP8 attributes, when used on PHP7.  
This change makes addStripped keep the attributes.