### PR TITLE
Skip PackPhar test if phar.readonly = 1

### DIFF
--- a/tests/integration/PackPharTest.php
+++ b/tests/integration/PackPharTest.php
@@ -24,6 +24,10 @@ class PackPharTest extends TestCase
 
     public function testAddStrippedFileContainingAnnotation()
     {
+        if (ini_get('phar.readonly') === '1') {
+            $this->markTestSkipped('phar.readonly = 1');
+        }
+
         $this->fixtures->createAndCdToSandbox();
 
         $pharFile = 'test.phar';


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary

I run tests on different version of PHP and PackPhar test failed because phar.readoly was set to '1'.
So I though that it would be nice if this test was skipped when it can't be executed in specific environment.