### PR TITLE
Issue #1088 - Use TaskAccessor trait in Task\Archive\Extract

### DIFF
--- a/src/Task/Archive/Extract.php
+++ b/src/Task/Archive/Extract.php
@@ -4,10 +4,9 @@ namespace Robo\Task\Archive;
 
 use Robo\Result;
 use Robo\Task\BaseTask;
-use Robo\Task\Filesystem\FilesystemStack;
-use Robo\Task\Filesystem\DeleteDir;
+use Robo\Task\Filesystem\Tasks as FilesystemTaskLoader;
 use Robo\Contract\BuilderAwareInterface;
-use Robo\Common\BuilderAwareTrait;
+use Robo\TaskAccessor;
 
 /**
  * Extracts an archive.
@@ -34,7 +33,8 @@ use Robo\Common\BuilderAwareTrait;
  */
 class Extract extends BaseTask implements BuilderAwareInterface
 {
-    use BuilderAwareTrait;
+    use TaskAccessor;
+    use FilesystemTaskLoader;
 
     /**
      * @var string
@@ -131,16 +131,14 @@ class Extract extends BaseTask implements BuilderAwareInterface
             $filesInExtractLocation = glob("$extractLocation/*");
             $hasEncapsulatingFolder = ((count($filesInExtractLocation) == 1) && is_dir($filesInExtractLocation[0]));
             if ($hasEncapsulatingFolder && !$this->preserveTopDirectory) {
-                $result = (new FilesystemStack())
-                    ->inflect($this)
+                $this
+                    ->taskFilesystemStack()
                     ->rename($filesInExtractLocation[0], $this->to)
-                    ->run();
-                (new DeleteDir($extractLocation))
-                    ->inflect($this)
+                    ->remove($extractLocation)
                     ->run();
             } else {
-                $result = (new FilesystemStack())
-                    ->inflect($this)
+                $this
+                    ->taskFilesystemStack()
                     ->rename($extractLocation, $this->to)
                     ->run();
             }


### PR DESCRIPTION
Issue #1088

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation


### Summary
Use TaskAccessor trait instead of `new \Robo\Task\Filesystem\FilesystemStack()`

