### PR TITLE
Fixing PHPDoc block @param on BuilderAwareTrait::collectionBuilder

### DIFF
--- a/src/Common/BuilderAwareTrait.php
+++ b/src/Common/BuilderAwareTrait.php
@@ -40,7 +40,7 @@ trait BuilderAwareTrait
     /**
      * @return \Robo\Collection\CollectionBuilder
      *
-     * @param \Robo\Symfony\ConsoleIO
+     * @param \Robo\Symfony\ConsoleIO $io
      */
     protected function collectionBuilder($io = null)
     {


### PR DESCRIPTION
This docblock annotation is missing the parameter's name, which Psalm complains about when analyzing code that uses this.

### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Fixing small docblock annotation ommission.

### Description

No code changes here, just a docblock annotation fix to make Psalm happy.