### PR TITLE
Issue #1097 - ProgressIndicator uses the stdError

### DIFF
--- a/src/Common/ProgressIndicator.php
+++ b/src/Common/ProgressIndicator.php
@@ -2,6 +2,8 @@
 
 namespace Robo\Common;
 
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+
 /**
  * Wrapper around \Symfony\Component\Console\Helper\ProgressBar
  */
@@ -56,7 +58,9 @@ class ProgressIndicator
     public function __construct($progressBar, \Symfony\Component\Console\Output\OutputInterface $output)
     {
         $this->progressBar = $progressBar;
-        $this->output = $output;
+        $this->output = $output instanceof ConsoleOutputInterface ?
+            $output->getErrorOutput()
+            : $output;
     }
 
     /**


### PR DESCRIPTION
Issue #1097 - ProgressIndicator uses the stdError

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

One step closer, but this doesn't solve the problem when a progressBar and a log entry in the same line.
`2/4 [==============>-------------]  50% 2 secs/4 secs [info] my log entry`

But the stdOutput is clean (or cleaner), so it can be used in pipes.
`robo foo | other`

This modification removes the leading `0D 0A` characters from the stdOutput

