### PR TITLE
Issue #1102 - Makes \Robo\Config\Config compatible with \Dflydev\DotAccessData\Data

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -19,7 +19,7 @@ class Config extends ConfigOverlay implements GlobalOptionDefaultValuesInterface
      * Create a new configuration object, and initialize it with
      * the provided nested array containing configuration data.
      */
-    public function __construct(array $data = null)
+    public function __construct(array $data = [])
     {
         parent::__construct();
 


### PR DESCRIPTION
Issue #1102

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation
