### PR TITLE
Fix `Process::inheritEnvironmentVariables()` deprecation error

### DIFF
--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -374,11 +374,6 @@ trait ExecTrait
         }
 
         if (isset($this->env)) {
-            // Symfony 4 will inherit environment variables by default, but until
-            // then, manually ensure they are inherited.
-            if (method_exists($this->process, 'inheritEnvironmentVariables')) {
-                $this->process->inheritEnvironmentVariables();
-            }
             $this->process->setEnv($this->env);
         }
 

--- a/tests/integration/ExecTest.php
+++ b/tests/integration/ExecTest.php
@@ -56,13 +56,6 @@ class ExecTest extends TestCase
 
     public function testInheritEnv()
     {
-        // Symfony < 3.2.1 does not inherit environment variables, so there's
-        // nothing to test if the function doesn't exist.
-        if (!method_exists('Symfony\Component\Process\Process', 'inheritEnvironmentVariables')) {
-            $this->markTestSkipped(
-                'Inheriting of environment variables is not supported.'
-            );
-        }
         // With no environment variables set, count how many environment
         // variables are present.
         $task = $this->taskExec('env | wc -l')->interactive(false);


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
We're running into the following error when using env():

> ERROR: The "Symfony\Component\Process\Process::inheritEnvironmentVariables()" method is deprecated since Symfony 4.4, env variables are always inherited.

The method call can be safely removed as the current required version of `symfony/process` is "^4.4.9 || ^5 || ^6".
