### PR TITLE
[GenerateMarkdownDoc] Don't crash if method uses union type parameter

### DIFF
--- a/src/Task/Development/GenerateMarkdownDoc.php
+++ b/src/Task/Development/GenerateMarkdownDoc.php
@@ -674,11 +674,13 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
     {
         $text = "";
         $paramType = $param->getType();
-        if (($paramType != null) && ($paramType->getName() == 'array')) {
-            $text .= 'array ';
-        }
-        if (($paramType != null) && ($paramType->getName() == 'callable')) {
-            $text .= 'callable ';
+        if ($paramType instanceof \ReflectionNamedType) {
+            if ($paramType->getName() === 'array') {
+                $text .= 'array ';
+            }
+            if (($paramType->getName() === 'callable')) {
+                $text .= 'callable ';
+            }
         }
         $text .= '$' . $param->name;
         if ($param->isDefaultValueAvailable()) {

--- a/tests/_data/ClassWithUnionParam.php
+++ b/tests/_data/ClassWithUnionParam.php
@@ -1,0 +1,14 @@
+<?php
+
+use Robo\Result;
+
+/**
+ * A test file. Used for testing documentation generation.
+ */
+class ClassWithUnionParam
+{
+    final public static function executeTask(Robo\Task\Composer\Install|Robo\Task\Composer\Update $task): string|array
+    {
+        return [];
+    }
+}

--- a/tests/integration/GenerateMarkdownDocTest.php
+++ b/tests/integration/GenerateMarkdownDocTest.php
@@ -97,4 +97,27 @@ class GenerateMarkdownDocTest extends TestCase
         $this->assertStringContainsString('Set the destination file', $contents);
     }
 
+    public function testMarkdownOfUnionType()
+    {
+        if (version_compare(PHP_VERSION, '8.0') < 0) {
+            $this->markTestSkipped('Requires PHP 8.0');
+        }
+
+        $sourceFile = $this->fixtures->dataFile('ClassWithUnionParam.php');
+        $this->assertFileExists($sourceFile);
+        include $sourceFile;
+        $this->assertTrue(class_exists('ClassWithUnionParam'));
+
+        $collection = $this->collectionBuilderForTest();
+        $taskGenerator = $collection->taskGenDoc("ClassWithUnionParam.md");
+        $taskGenerator->docClass('ClassWithUnionParam');
+        $result = $collection->run();
+        $this->assertTrue($result->wasSuccessful(), $result->getMessage());
+
+        $this->assertFileExists('ClassWithUnionParam.md');
+
+        $contents = file_get_contents('ClassWithUnionParam.md');
+        $this->assertStringContainsString('A test file. Used for testing documentation generation.', $contents);
+        $this->assertStringContainsString('#### *final public static* executeTask($task)', $contents);
+    }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
This is a bare minimum fix for union type support in GenerateMarkdownDoc task.

### Description
Fixes #1117 
