### PR TITLE
[GenerateMarkdownDoc] Use var_export for rendering default param values

### DIFF
--- a/src/Task/Development/GenerateMarkdownDoc.php
+++ b/src/Task/Development/GenerateMarkdownDoc.php
@@ -685,7 +685,7 @@ class GenerateMarkdownDoc extends BaseTask implements BuilderAwareInterface
             if ($param->allowsNull()) {
                 $text .= ' = null';
             } else {
-                $text .= ' = ' . str_replace("\n", ' ', print_r($param->getDefaultValue(), true));
+                $text .= ' = ' . str_replace("\n", ' ', var_export($param->getDefaultValue(), true));
             }
         }
 


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
`print_r` is completely unsuitable for printing Boolean values because it renders false as empty string and true as 1. So I replaced it with `var_export`.

### Description
Fixes #1119 
