### PR TITLE
Fix composer example in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ class RoboFile extends \Robo\Tasks {
     function watchComposer(ConsoleIO $io)
     {
         // when composer.json changes `composer update` will be executed
-        $this->collectionBuilder($io)->taskWatch()->monitor('composer.json', function() {
+        $this->collectionBuilder($io)->taskWatch()->monitor('composer.json', function() use ($io) {
             $this->collectionBuilder($io)->taskComposerUpdate()->run();
         })->run();
     }


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [x] Adds or fixes documentation

### Summary
With php 8.1 the example code does not work

### Description
Variable `$io` is not visible in the context of the function. This commit fix the example.
