### PR TITLE
PHP 8.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,11 @@ jobs:
             dependencies: highest
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205, phar.readonly=false
 
+          - os: ubuntu-latest
+            php-version: "8.2"
+            dependencies: highest
+            php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205, phar.readonly=false
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -16,6 +16,11 @@ class Config extends ConfigOverlay implements GlobalOptionDefaultValuesInterface
     const DECORATED = 'options.decorated';
 
     /**
+     * @var array
+     */
+    protected $defaults;
+
+    /**
      * Create a new configuration object, and initialize it with
      * the provided nested array containing configuration data.
      */


### PR DESCRIPTION
### Overview
This pull request adds testing on PHP 8.2 and enables it in the tests.

### Summary
Fixes this issue: https://php.watch/versions/8.2/dynamic-properties-deprecated
