### PR TITLE
Use of "self" in callables is deprecated - php8.2 fix for Exec.php

### DIFF
--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -63,7 +63,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
             return;
         }
 
-        $stopRunningJobs = Closure::fromCallable(['self', 'stopRunningJobs']);
+        $stopRunningJobs = Closure::fromCallable(self::class.'::stopRunningJobs');
 
         if (function_exists('pcntl_signal')) {
             pcntl_signal(SIGTERM, $stopRunningJobs);


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Short overview of what changed.

### Description
Any additional information.
