### PR TITLE
Issue #1135 - PHP 8.2 - Fix Use of "self" in callables is deprecated

### DIFF
--- a/src/Common/CommandArguments.php
+++ b/src/Common/CommandArguments.php
@@ -40,7 +40,7 @@ trait CommandArguments
         if (!is_array($args)) {
             $args = $func_args;
         }
-        $this->arguments .= ' ' . implode(' ', array_map('static::escape', $args));
+        $this->arguments .= ' ' . implode(' ', array_map([static::class, 'escape'], $args));
         return $this;
     }
 

--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -63,7 +63,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface, Simul
             return;
         }
 
-        $stopRunningJobs = Closure::fromCallable(['self', 'stopRunningJobs']);
+        $stopRunningJobs = Closure::fromCallable(self::class.'::stopRunningJobs');
 
         if (function_exists('pcntl_signal')) {
             pcntl_signal(SIGTERM, $stopRunningJobs);

--- a/tests/phpunit/Task/ExecTest.php
+++ b/tests/phpunit/Task/ExecTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace phpunit\Task;
+
+use PHPUnit\Framework\TestCase;
+
+class ExecTest extends TestCase
+{
+
+    // tests
+    public function testBasicCommand()
+    {
+        $this->assertSame(
+            'ls',
+            (new \Robo\Task\Base\Exec('ls'))
+                ->getCommand()
+        );
+    }
+}


### PR DESCRIPTION
### Overview

This pull request:

Issue #1135 

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [ ] Adds or fixes documentation


### Summary

The problem is that the `convertDeprecationsToExceptions` is disabled by default in the `phpunit.dist.xml`. I have to enable it manually, but when I do so, a lot of deprecation messages come from the dependencies as well.
