### PR TITLE
Deprecations for PHP 8.1

### DIFF
--- a/src/Common/ConfigAwareTrait.php
+++ b/src/Common/ConfigAwareTrait.php
@@ -70,7 +70,7 @@ trait ConfigAwareTrait
     private static function getClassKey($key)
     {
         $configPrefix = static::configPrefix();                            // task.
-        $configClass = static::configClassIdentifier(get_called_class());  // PARTIAL_NAMESPACE.CLASSNAME
+        $configClass = static::configClassIdentifier(static::class);       // PARTIAL_NAMESPACE.CLASSNAME
         $configPostFix = static::configPostfix();                          // .settings
 
         return sprintf('%s%s%s.%s', $configPrefix, $configClass, $configPostFix, $key);


### PR DESCRIPTION
In scope of PHP8.1 compatibility static analysis it was discovered some deprecations in webflo/drupal-finder codebase: 
  - line 73 vendor/consolidation/robo/src/Common/ConfigAwareTrait.php get_called_class() without argument (tag 4.0.2) 
Proposed change: replacing get_called_class() with static::class