### PR TITLE
Allow composer require --no-update

### DIFF
--- a/docs/tasks/Composer.md
+++ b/docs/tasks/Composer.md
@@ -702,6 +702,9 @@ $this->taskComposerRequire()->dependency('foo/bar', '^.2.4.8')->run();
 * `noSuggest($noSuggest = null)`
 
  * `param bool` $noSuggest
+* `noUpdate($noUpdate = null)`
+
+ * `param bool` $noUpdate
 * `preferDist($preferDist = null)`
 
  * `param bool` $preferDist

--- a/docs/tasks/Composer.md
+++ b/docs/tasks/Composer.md
@@ -702,9 +702,7 @@ $this->taskComposerRequire()->dependency('foo/bar', '^.2.4.8')->run();
 * `noSuggest($noSuggest = null)`
 
  * `param bool` $noSuggest
-* `noUpdate($noUpdate = null)`
-
- * `param bool` $noUpdate
+* `noUpdate()`
 * `preferDist($preferDist = null)`
 
  * `param bool` $preferDist

--- a/src/Task/Composer/Remove.php
+++ b/src/Task/Composer/Remove.php
@@ -20,6 +20,20 @@ class Remove extends Base
     protected $action = 'remove';
 
     /**
+     * 'remove' is a keyword, so it cannot be a method name.
+     *
+     * @param array|string $project
+     *
+     * @return $this
+     */
+    public function dependency(array|string $project): self
+    {
+        $project = (array)$project;
+        $this->args($project);
+        return $this;
+    }
+
+    /**
      * @param bool $dev
      *
      * @return $this

--- a/src/Task/Composer/RequireDependency.php
+++ b/src/Task/Composer/RequireDependency.php
@@ -57,6 +57,19 @@ class RequireDependency extends Base
     }
 
     /**
+     * adds `no-update` option to composer
+     *
+     * @param bool $noUpdate
+     *
+     * @return $this
+     */
+    public function noUpdate($noSuggest = true)
+    {
+        $this->option('--no-update');
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function run()

--- a/src/Task/Composer/RequireDependency.php
+++ b/src/Task/Composer/RequireDependency.php
@@ -59,11 +59,9 @@ class RequireDependency extends Base
     /**
      * adds `no-update` option to composer
      *
-     * @param bool $noUpdate
-     *
      * @return $this
      */
-    public function noUpdate($noSuggest = true)
+    public function noUpdate(): self
     {
         $this->option('--no-update');
         return $this;

--- a/tests/unit/Task/ComposerTest.php
+++ b/tests/unit/Task/ComposerTest.php
@@ -212,13 +212,17 @@ class ComposerTest extends \Codeception\TestCase\Test
     public function testComposerRemove()
     {
         $this->assertEquals(
-            'composer remove --no-interaction',
-            (new \Robo\Task\Composer\Remove('composer'))->setConfig(new \Robo\Config())->getCommand()
-        );
-        $this->assertEquals(
-            'composer remove --dev --no-progress --no-update --no-interaction',
+            $this->adjustQuotes("composer remove 'foo/bar' 'baz/qux' --no-interaction"),
             (new \Robo\Task\Composer\Remove('composer'))
                 ->setConfig(new \Robo\Config())
+                ->dependency(['foo/bar', 'baz/qux'])
+                ->getCommand()
+        );
+        $this->assertEquals(
+            $this->adjustQuotes("composer remove 'foo/bar' --dev --no-progress --no-update --no-interaction"),
+            (new \Robo\Task\Composer\Remove('composer'))
+                ->setConfig(new \Robo\Config())
+                ->dependency('foo/bar')
                 ->dev()
                 ->noProgress()
                 ->noUpdate()

--- a/tests/unit/Task/ComposerTest.php
+++ b/tests/unit/Task/ComposerTest.php
@@ -355,6 +355,16 @@ class ComposerTest extends \Codeception\TestCase\Test
                 ->dependency(['a/b', 'x/y:^1'])
                 ->getCommand()
         );
+
+        $this->assertEquals(
+            $this->adjustQuotes("composer require a/b 'x/y:^1' --no-interaction --no-suggest --no-update"),
+            (new \Robo\Task\Composer\RequireDependency('composer'))
+                ->setConfig(new \Robo\Config())
+                ->dependency(['a/b', 'x/y:^1'])
+                ->noSuggest()
+                ->noUpdate()
+                ->getCommand()
+        );
     }
 
     public function testComposerCreateProjectCommand()


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [x] Adds or fixes documentation

### Summary

* Allow to add `--no-update` option to `composer require`.
* Fixes a bug: It wasn't possible to pass the package(s) to `composer remove`

### Description

New `\Robo\Task\Composer\RequireDependency::noUpdate()` method