### PR TITLE
Ssh should implement PrintedInterface

### DIFF
--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -3,6 +3,7 @@
 namespace Robo\Task\Remote;
 
 use Robo\Contract\CommandInterface;
+use Robo\Contract\PrintedInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
 use Robo\Contract\SimulatedInterface;
@@ -43,7 +44,7 @@ use Robo\Common\ExecOneCommand;
  * \Robo\Task\Remote\Ssh::configure('remoteDir', '/some-dir');
  * ```
  */
-class Ssh extends BaseTask implements CommandInterface, SimulatedInterface
+class Ssh extends BaseTask implements CommandInterface, SimulatedInterface, PrintedInterface
 {
     use CommandReceiver;
     use ExecOneCommand;


### PR DESCRIPTION

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
`Ssh` uses `ExecTrait` so it has the `getPrinted()` method. It would make sense for this class to implement `PrintedInterface`.


### Description
Fixes https://github.com/consolidation/Robo/issues/919.
The logic in `Result::printError()` does not work correctly because it does not known that `$task->getPrinted()` is available so it always reprints the error even if already printed.