### PR TITLE
Use error output as TaskExitException message

### DIFF
--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -146,7 +146,8 @@ trait ExecCommand
             $this,
             $result_data->getExitCode(),
             $result_data->getMessage(),
-            $result_data->getData()
+            $result_data->getData(),
+            $result_data->getErrorOutput()
         );
     }
 }

--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -398,7 +398,8 @@ trait ExecTrait
             return new ResultData(
                 $this->process->getExitCode(),
                 $this->process->getOutput(),
-                $this->getResultData()
+                $this->getResultData(),
+                $this->process->getErrorOutput(),
             );
         }
 
@@ -408,7 +409,8 @@ trait ExecTrait
             return new ResultData(
                 $this->process->getExitCode(),
                 $e->getMessage(),
-                $this->getResultData()
+                $this->getResultData(),
+                $this->process->getErrorOutput(),
             );
         }
         return new ResultData($this->process->getExitCode());

--- a/src/Result.php
+++ b/src/Result.php
@@ -31,10 +31,11 @@ class Result extends ResultData implements OutputAwareInterface, InflectionInter
      * @param int $exitCode
      * @param string $message
      * @param array $data
+     * @param string $errorOutput
      */
-    public function __construct(TaskInterface $task, $exitCode, $message = '', $data = [])
+    public function __construct(TaskInterface $task, $exitCode, $message = '', $data = [], $errorOutput = '')
     {
-        parent::__construct($exitCode, $message, $data);
+        parent::__construct($exitCode, $message, $data, $errorOutput);
         $this->task = $task;
         $this->inflect($task);
         $this->printResult();
@@ -292,6 +293,6 @@ class Result extends ResultData implements OutputAwareInterface, InflectionInter
      */
     private function exitEarly($status)
     {
-        throw new TaskExitException($this->getTask(), $this->getMessage(), $status);
+        throw new TaskExitException($this->getTask(), $this->getErrorOutput(), $status);
     }
 }

--- a/src/ResultData.php
+++ b/src/ResultData.php
@@ -13,6 +13,11 @@ class ResultData extends Data implements ExitCodeInterface, OutputDataInterface
      */
     protected $exitCode;
 
+    /**
+     * @var string
+     */
+    protected $errorOutput;
+
     const EXITCODE_OK = 0;
     const EXITCODE_ERROR = 1;
     /** Symfony Console handles these conditions; Robo returns the status
@@ -30,10 +35,12 @@ class ResultData extends Data implements ExitCodeInterface, OutputDataInterface
      * @param int $exitCode
      * @param string $message
      * @param array $data
+     * @param string $errorOutput
      */
-    public function __construct($exitCode = self::EXITCODE_OK, $message = '', $data = [])
+    public function __construct($exitCode = self::EXITCODE_OK, $message = '', $data = [], $errorOutput = '')
     {
         $this->exitCode = $exitCode;
+        $this->errorOutput = $errorOutput;
         parent::__construct($message, $data);
     }
 
@@ -107,5 +114,13 @@ class ResultData extends Data implements ExitCodeInterface, OutputDataInterface
     public function wasCancelled()
     {
         return $this->exitCode == self::EXITCODE_USER_CANCEL;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorOutput()
+    {
+        return $this->errorOutput;
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Fixes https://github.com/consolidation/robo/issues/1153.

### Description
`TaskExitException` contains STDOUT, which causes the stand output to be displayed twice and the actual error message to be buried between it.
Making the exception contain STDERR ensure the error message is the last thing printed, so the can find it easily. (It also makes more sense semantically that an exit exception contains the error output.)

#### With the patch
```
 [ExecStack] echo "this command output is very long" && echo "this command output is very long" && echo "this command output is very long" && echo "this command output is very long" && echo "this command output is very long" && echo "this command output is very long" && invalid_cmd
 [ExecStack] Running echo "this command output is very long" &&
 echo "this command output is very long" &&
 echo "this command output is very long" &&
 echo "this command output is very long" &&
 echo "this command output is very long" &&
 echo "this command output is very long" &&
 invalid_cmd
this command output is very long
this command output is very long
this command output is very long
this command output is very long
this command output is very long
this command output is very long
sh: 1: invalid_cmd: not found
 [ExecStack]  Exit code 127  Time 0.003s
 [notice] Stopping on fail. Exiting....
 [error]  Exit Code: 127 
 [error]    in task Robo\Task\Base\ExecStack 

  sh: 1: invalid_cmd: not found
 
```

#### Without the patch
```
 [ExecStack] echo "this command output is very long" && echo "this command output is very long" && echo "this command output is very long" && echo "this command output is very long" && echo "this command output is very long" && echo "this command output is very long" && invalid_cmd
 [ExecStack] Running echo "this command output is very long" &&
 echo "this command output is very long" &&
 echo "this command output is very long" &&
 echo "this command output is very long" &&
 echo "this command output is very long" &&
 echo "this command output is very long" &&
 invalid_cmd
this command output is very long
this command output is very long
this command output is very long
this command output is very long
this command output is very long
this command output is very long
sh: 1: invalid_cmd: not found
 [ExecStack]  Exit code 127  Time 0.003s
 [notice] Stopping on fail. Exiting....
 [error]  Exit Code: 127 
 [error]    in task Robo\Task\Base\ExecStack 

  this command output is very long
this command output is very long
this command output is very long
this command output is very long
this command output is very long
this command output is very long
 
```