### PR TITLE
fix: replace 4.0.7 with 5.0.0

### DIFF
--- a/src/Robo.php
+++ b/src/Robo.php
@@ -26,7 +26,7 @@ use Symfony\Component\Process\Process;
 class Robo
 {
     const APPLICATION_NAME = 'Robo';
-    private const VERSION = '4.0.7-dev';
+    private const VERSION = '5.0.0-dev';
 
     /**
      * The currently active container object, or NULL if not initialized yet.


### PR DESCRIPTION
Hello,

I wanted to update Robo in Nix ([link to commit](https://github.com/NixOS/nixpkgs/pull/312870/commits/4dcdfe98f6c0ce227a61a948583d3b2c96c7da57)) and noticed this issue, therefore, providing a PR to fix it so I can use the patch in the meantime.

