### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/src/Collection/CompletionWrapper.php
+++ b/src/Collection/CompletionWrapper.php
@@ -54,7 +54,7 @@ class CompletionWrapper extends BaseTask implements WrappedTaskInterface
      * @param \Robo\Contract\TaskInterface $task
      * @param \Robo\Contract\TaskInterface|null $rollbackTask
      */
-    public function __construct(Collection $collection, TaskInterface $task, TaskInterface $rollbackTask = null)
+    public function __construct(Collection $collection, TaskInterface $task, ?TaskInterface $rollbackTask = null)
     {
         $this->collection = $collection;
         $this->task = ($task instanceof WrappedTaskInterface) ? $task->original() : $task;

--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -45,7 +45,7 @@ trait IO
     }
 
     // This should typically only be called by State::restore()
-    public function restoreState(InputInterface $input = null, OutputInterface $output = null, SymfonyStyle $io = null)
+    public function restoreState(?InputInterface $input = null, ?OutputInterface $output = null, ?SymfonyStyle $io = null)
     {
         $this->setInput($input);
         $this->setOutput($output);


### PR DESCRIPTION
ref https://github.com/drush-ops/drush/issues/6069

### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation
- [x] Deprecation

### Summary
Fixed all nullable type declarations found

###Description

Testing with official docker image `docker run --rm -v $(pwd):/mnt -w /mnt php:8.4.0alpha2-cli-alpine find src -type f -name '*.php' -exec php -l {} \;`

