### PR TITLE
Don't require exact event-dispatcher version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "league/container": "^3.3.1 || ^4.0",
         "phpowermove/docblock": "^4.0",
         "symfony/console": "^6 || ^7",
-        "symfony/event-dispatcher": "6 || ^7",
+        "symfony/event-dispatcher": "^6 || ^7",
         "symfony/filesystem": "^6 || ^7",
         "symfony/finder": "^6 || ^7",
         "symfony/process": "^6 || ^7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d6de22e8baac0dc45385d18b5f9af9b",
+    "content-hash": "356d965c2355967efaa4c71b48fe813e",
     "packages": [
         {
             "name": "consolidation/annotated-command",


### PR DESCRIPTION
I am assuming this is a typo.

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Allow installing any 6.x version of symfony/event-dispatcher.

### Description
Drupal 10.3 requires event-dispatcher 6.4 so we can't install Robo 5.
