### PR TITLE
1st step: upgrade actions/cache to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         run: Add-Content -Path $ENV:GITHUB_ENV -Value "COMPOSER_CACHE_DIR=~\AppData\Local\Composer"
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
@@ -156,7 +156,7 @@ jobs:
 
       - name: Show composer dependencies
         run: composer info
-      
+
       - name: Run tests with phpunit
         run: composer unit
 


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary

All the automated tests are failing, and the reason is because github actions/cache v1 was deprecated earlier this year.

The solution: drop in v4, it should Just Work™.

### Description
Any additional information.
