### PR TITLE
Allow upgrade to legaue/container 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "consolidation/config": "^3",
         "consolidation/log": "^3",
         "consolidation/output-formatters": "^4.1.2",
-        "league/container": "^3.3.1 || ^4.0",
+        "league/container": "^3.3.1 || ^4.0 || ^5.0",
         "phpowermove/docblock": "^4.0",
         "symfony/console": "^6 || ^7",
         "symfony/event-dispatcher": "^6 || ^7",


### PR DESCRIPTION
The package `consolidation/robo` has a dependency on `league/container` up to v4. Under PHP 8.4 this causes (in my case) a PHP error:

```txt
League\Container\Inflector\Inflector::__construct(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead 
```

This was fixed in version 5.x of `league/container`: https://github.com/thephpleague/container/issues/262 The major 5 version is mainly to drop compatibility for PHP 8.0 and older. I've tested this and it seems to upgrade to `league/container` 5 as a dependency.