### PR TITLE
Fix deprecation issue with Symfony Console

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "356d965c2355967efaa4c71b48fe813e",
+    "content-hash": "557cebdc403e62c68a828bc13114b10e",
     "packages": [
         {
             "name": "consolidation/annotated-command",

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -547,7 +547,11 @@ class Robo
         // If the instance is a Symfony Command, register it with
         // the application
         if ($instance instanceof Command) {
-            $app->add($instance);
+            if (method_exists($app, 'addCommand')) {
+                $app->addCommand($instance);
+            } else {
+                $app->add($instance);
+            }
             return $instance;
         }
 
@@ -555,7 +559,11 @@ class Robo
         $commandFactory = $container->get('commandFactory');
         $commandList = $commandFactory->createCommandsFromClass($instance);
         foreach ($commandList as $command) {
-            $app->add($command);
+            if (method_exists($app, 'addCommand')) {
+                $app->addCommand($command);
+            } else {
+                $app->add($command);
+            }
         }
         return $instance;
     }

--- a/src/Runtime/Runner.php
+++ b/src/Runtime/Runner.php
@@ -353,7 +353,11 @@ class Runner implements ContainerAwareInterface
         $commandFactory = $container->get('commandFactory');
         $commandList = $commandFactory->createCommandsFromClass($roboCommandFileInstance);
         foreach ($commandList as $command) {
-            $app->add($command);
+            if (method_exists($app, 'addCommand')) {
+                $app->addCommand($command);
+            } else {
+                $app->add($command);
+            }
         }
         return $roboCommandFileInstance;
     }


### PR DESCRIPTION
### Overview
This pull request make sure users don't get a deprecated message if they are using a newer version of Symfony Console:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary

Added a check to see if the new `addCommand` method exists, otherwise fallback to the `add` method

### Description
The `add` method will be removed in symfony/console 8.0
