### PR TITLE
Replace deprecated Application::add() and enhance ParallelExec

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -56,7 +56,7 @@ class Application extends SymfonyApplication
             );
             $output->writeln("<comment>  Edit this file to add your commands! </comment>");
         });
-        $this->add($createRoboFile);
+        $this->addCommand($createRoboFile);
     }
 
     /**
@@ -71,6 +71,6 @@ class Application extends SymfonyApplication
             return;
         }
         $selfUpdateCommand = new \SelfUpdate\SelfUpdateCommand($this->getName(), $this->getVersion(), $repository);
-        $this->add($selfUpdateCommand);
+        $this->addCommand($selfUpdateCommand);
     }
 }

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -547,7 +547,7 @@ class Robo
         // If the instance is a Symfony Command, register it with
         // the application
         if ($instance instanceof Command) {
-            $app->add($instance);
+            $app->addCommand($instance);
             return $instance;
         }
 
@@ -555,7 +555,7 @@ class Robo
         $commandFactory = $container->get('commandFactory');
         $commandList = $commandFactory->createCommandsFromClass($instance);
         foreach ($commandList as $command) {
-            $app->add($command);
+            $app->addCommand($command);
         }
         return $instance;
     }

--- a/src/Runtime/Runner.php
+++ b/src/Runtime/Runner.php
@@ -353,7 +353,7 @@ class Runner implements ContainerAwareInterface
         $commandFactory = $container->get('commandFactory');
         $commandList = $commandFactory->createCommandsFromClass($roboCommandFileInstance);
         foreach ($commandList as $command) {
-            $app->add($command);
+            $app->addCommand($command);
         }
         return $roboCommandFileInstance;
     }

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -84,12 +84,17 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
     }
 
     /**
-     * @param string|\Robo\Contract\CommandInterface $command
+     * @param string|\Robo\Contract\CommandInterface|Process $command
      *
      * @return $this
      */
     public function process($command)
     {
+        if ($command instanceof Process) {
+            $this->processes[] = $command;
+            return $this;
+        }
+
         // TODO: Symfony 4 requires that we supply the working directory.
         $this->processes[] = Process::fromShellCommandline($this->receiveCommand($command), getcwd());
         return $this;

--- a/tests/integration/RoboFileTest.php
+++ b/tests/integration/RoboFileTest.php
@@ -35,7 +35,7 @@ class RoboFileTest extends TestCase
         $this->roboCommandFileInstance->setBuilder($builder);
         $commandList = $this->commandFactory->createCommandsFromClass($this->roboCommandFileInstance);
         foreach ($commandList as $command) {
-            $this->app->add($command);
+            $this->app->addCommand($command);
         }
     }
 

--- a/tests/unit/ApplicationTest.php
+++ b/tests/unit/ApplicationTest.php
@@ -39,7 +39,7 @@ class ApplicationTest extends \Codeception\TestCase\Test
         $this->roboCommandFileInstance->setBuilder($builder);
         $commandList = $this->commandFactory->createCommandsFromClass($this->roboCommandFileInstance);
         foreach ($commandList as $command) {
-            $this->app->add($command);
+            $this->app->addCommand($command);
         }
     }
 


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [ ] Adds or fixes documentation

### Summary
Replace deprecated Symfony Console `add()` method with `addCommand()` across all source and test files, and allow passing `Process` instances directly to `ParallelExec::process()`.

### Description
**Commit 1: Allow passing Process instances directly to ParallelExec::process()**
- `ParallelExec::process()` now accepts a `Process` instance in addition to strings and `CommandInterface` objects, giving users more flexibility when configuring parallel tasks.

**Commit 2: Replace deprecated Application::add() with addCommand()**
- Symfony Console deprecated `Application::add()` in favor of `addCommand()`. All usages across `Application.php`, `Robo.php`, `Runner.php`, and test files have been updated accordingly.
