### PR TITLE
Update Scss task

### DIFF
--- a/docs/tasks/Assets.md
+++ b/docs/tasks/Assets.md
@@ -2,7 +2,6 @@
 
 ## ImageMinify
 
-
 Minifies images.
 
 When the task is run without any specified minifier it will compress the
@@ -23,12 +22,12 @@ This will use the following minifiers based in the extension:
 
 When the required minifier is not installed on the system the task will try
 to download it from the [imagemin](https://github.com/imagemin) repository
-into a local directory.
-This directory is `vendor/bin/` by default and may be changed:
+into a local directory. This directory is `vendor/bin/` by default and may be
+changed:
 
 ```php
 $this->taskImageMinify('assets/images/*')
-    ->setExecutableDir('/tmp/imagemin/bin/)
+    ->setExecutableDir('/tmp/imagemin/bin/')
     ->to('dist/images/')
     ->run();
 ```
@@ -39,7 +38,7 @@ files. In that case it is useful to filter the files with the extension:
 ```php
 $this->taskImageMinify('assets/images/*.png')
     ->to('dist/images/')
-    ->minifier('pngcrush');
+    ->minifier('pngcrush')
     ->run();
 ```
 
@@ -70,20 +69,15 @@ This will execute as:
 `jpegtran -copy none -progressive -optimize -outfile "dist/images/test.jpg" "/var/www/test/assets/images/test.jpg"`
 
 * `setExecutableDir($directory)`
-
- * `param string` $directory
+  * `param string` $directory
 * `to($target)`
-
- * `param string` $target
+  * `param string` $target
 * `minifier($minifier, array $options = array ( ))`
-
- * `param string` $minifier
+  * `param string` $minifier
 * `setOutput($output)`
-
- * `param \Symfony\Component\Console\Output\OutputInterface` $output
+  * `param \Symfony\Component\Console\Output\OutputInterface` $output
 
 ## Less
-
 
 Compiles less files.
 
@@ -121,35 +115,29 @@ method named after them and overloading the lessCompilers() method to
 inject the name there.
 
 * `importDir($dirs)`
-
- * `see` CssPreprocessor::setImportPaths
+  * `see` CssPreprocessor::setImportPaths
 * `addImportPath($dir)`
-
- * `param string` $dir
+  * `param string` $dir
 * `setImportPaths($dirs)`
-
- * `param array|string` $dirs
+  * `param array|string` $dirs
 * `setFormatter($formatterName)`
-
- * `param string` $formatterName
+  * `param string` $formatterName
 * `compiler($compiler, array $options = array ( ))`
-
- * `param string` $compiler
+  * `param string` $compiler
 * `setOutput($output)`
-
- * `param \Symfony\Component\Console\Output\OutputInterface` $output
+  * `param \Symfony\Component\Console\Output\OutputInterface` $output
 
 ## Minify
 
-
 Minifies an asset file (CSS or JS).
 
-``` php
+```php
 <?php
 $this->taskMinify('web/assets/theme.css')
-     ->run()
+    ->run();
 ?>
 ```
+
 Please install additional packages to use this task:
 
 ```
@@ -158,29 +146,21 @@ composer require natxet/cssmin:^3.0
 ```
 
 * `to($dst)`
-
- * `param string` $dst
+  * `param string` $dst
 * `type($type)`
-
- * `param string` $type Allowed values: "css", "js".
+  * `param string` $type Allowed values: "css", "js".
 * `singleLine($singleLine)`
-
- * `param bool` $singleLine
+  * `param bool` $singleLine
 * `keepImportantComments($keepImportantComments)`
-
- * `param bool` $keepImportantComments
+  * `param bool` $keepImportantComments
 * `specialVarRx($specialVarRx)`
-
- * `param bool` $specialVarRx
+  * `param bool` $specialVarRx
 * `__toString()`
-
- * `return string`
+  * `return string`
 * `setOutput($output)`
-
- * `param \Symfony\Component\Console\Output\OutputInterface` $output
+  * `param \Symfony\Component\Console\Output\OutputInterface` $output
 
 ## Scss
-
 
 Compiles scss files.
 
@@ -194,10 +174,24 @@ $this->taskScss([
 ?>
 ```
 
-Use the following scss compiler in your project:
+Use one of both scss compilers in your project:
 
 ```
-"scssphp/scssphp ": "~1.0.0",
+"scssphp/scssphp": "^2.1",
+"bugo/scss-php": "^0.4"
+```
+
+Specify directory (string or array) for scss imports lookup:
+
+```php
+<?php
+$this->taskScss([
+    'scss/default.scss' => 'css/default.css'
+])
+->importDir('scss')
+->compiler('scss')
+->run();
+?>
 ```
 
 You can implement additional compilers by extending this task and adding a
@@ -205,22 +199,15 @@ method named after them and overloading the scssCompilers() method to
 inject the name there.
 
 * `setFormatter($formatterName)`
-
- * `link` https://scssphp.github.io/scssphp/docs/#output-formatting
+  * `link` https://scssphp.github.io/scssphp/docs/#output-formatting
+  * Accepts `expanded` and `compressed`; legacy formatter class names from scssphp 1.x are also supported.
 * `importDir($dirs)`
-
- * `see` CssPreprocessor::setImportPaths
+  * `see` CssPreprocessor::setImportPaths
 * `addImportPath($dir)`
-
- * `param string` $dir
+  * `param string` $dir
 * `setImportPaths($dirs)`
-
- * `param array|string` $dirs
+  * `param array|string` $dirs
 * `compiler($compiler, array $options = array ( ))`
-
- * `param string` $compiler
+  * `param string` $compiler
 * `setOutput($output)`
-
- * `param \Symfony\Component\Console\Output\OutputInterface` $output
-
-
+  * `param \Symfony\Component\Console\Output\OutputInterface` $output

--- a/docs/tasks/Assets.md
+++ b/docs/tasks/Assets.md
@@ -178,7 +178,7 @@ Use one of both scss compilers in your project:
 
 ```
 "scssphp/scssphp": "^2.1",
-"bugo/scss-php": "^0.4"
+"bugo/scss-php": "^0.7"
 ```
 
 Specify directory (string or array) for scss imports lookup:

--- a/src/Task/Assets/Scss.php
+++ b/src/Task/Assets/Scss.php
@@ -17,10 +17,24 @@ use Robo\Result;
  * ?>
  * ```
  *
- * Use the following scss compiler in your project:
+ * Use one of both scss compilers in your project:
  *
  * ```
- * "scssphp/scssphp ": "~1.0.0",
+ * "scssphp/scssphp": "^2.1",
+ * "bugo/scss-php": "^0.4"
+ * ```
+ *
+ * Specify directory (string or array) for scss imports lookup:
+ *
+ * ```php
+ * <?php
+ * $this->taskScss([
+ *     'scss/default.scss' => 'css/default.css'
+ * ])
+ * ->importDir('scss')
+ * ->compiler('scss')
+ * ->run();
+ * ?>
  * ```
  *
  * You can implement additional compilers by extending this task and adding a
@@ -36,6 +50,7 @@ class Scss extends CssPreprocessor
      */
     protected $compilers = [
         'scssphp', // https://github.com/scssphp/scssphp
+        'scss', // https://github.com/dragomano/scss-php
     ];
 
     /**
@@ -52,34 +67,105 @@ class Scss extends CssPreprocessor
             return Result::errorMissingPackage($this, 'scssphp', 'scssphp/scssphp');
         }
 
-        $scssCode = file_get_contents($file);
         $scss = new \ScssPhp\ScssPhp\Compiler();
 
-        // set options for the scssphp compiler
         if (isset($this->compilerOptions['importDirs'])) {
             $scss->setImportPaths($this->compilerOptions['importDirs']);
         }
 
         if (isset($this->compilerOptions['formatter'])) {
-            $scss->setFormatter($this->compilerOptions['formatter']);
+            $scss->setOutputStyle($this->normalizeScssPhpOutputStyle($this->compilerOptions['formatter']));
         }
 
-        return $scss->compile($scssCode);
+        return $scss->compileFile($file)->getCss();
     }
 
     /**
-     * Sets the formatter for scssphp
+     * bugo/scss-php compiler
+     * @link https://github.com/dragomano/scss-php
      *
-     * The method setFormatter($formatterName) sets the current formatter to $formatterName,
-     * the name of a class as a string that implements the formatting interface. See the source
-     * for ScssPhp\ScssPhp\Formatter\Expanded for an example.
+     * @param string $file
      *
-     * Five formatters are included with scssphp/scssphp:
-     * - ScssPhp\ScssPhp\Formatter\Expanded
-     * - ScssPhp\ScssPhp\Formatter\Nested (default)
-     * - ScssPhp\ScssPhp\Formatter\Compressed
-     * - ScssPhp\ScssPhp\Formatter\Compact
-     * - ScssPhp\ScssPhp\Formatter\Crunched
+     * @return string|\Robo\Result
+     */
+    protected function scss($file)
+    {
+        if (!class_exists('\Bugo\SCSS\Compiler')) {
+            return Result::errorMissingPackage($this, 'Bugo\\SCSS\\Compiler', 'bugo/scss-php');
+        }
+
+        $loader = isset($this->compilerOptions['importDirs'])
+            ? new \Bugo\SCSS\Loader($this->compilerOptions['importDirs'])
+            : new \Bugo\SCSS\Loader();
+
+        $compiler = new \Bugo\SCSS\Compiler(
+            new \Bugo\SCSS\CompilerOptions(
+                style: $this->normalizeBugoOutputStyle($this->compilerOptions['formatter'] ?? null)
+            ),
+            $loader
+        );
+
+        return $compiler->compileFile($file);
+    }
+
+    /**
+     * @param string|null $formatter
+     *
+     * @return \ScssPhp\ScssPhp\OutputStyle
+     */
+    protected function normalizeScssPhpOutputStyle($formatter)
+    {
+        return \ScssPhp\ScssPhp\OutputStyle::fromString($this->normalizeFormatter($formatter));
+    }
+
+    /**
+     * @param string|null $formatter
+     *
+     * @return \Bugo\SCSS\Style
+     */
+    protected function normalizeBugoOutputStyle($formatter)
+    {
+        return $this->normalizeFormatter($formatter) === 'compressed'
+            ? \Bugo\SCSS\Style::COMPRESSED
+            : \Bugo\SCSS\Style::EXPANDED;
+    }
+
+    /**
+     * Maps legacy formatter names from scssphp 1.x to the output styles
+     * supported by the modern compilers.
+     *
+     * @param string|null $formatter
+     *
+     * @return string
+     */
+    protected function normalizeFormatter($formatter)
+    {
+        $formatter = ltrim((string) $formatter, '\\');
+
+        $formatters = [
+            '' => 'expanded',
+            'expanded' => 'expanded',
+            'compressed' => 'compressed',
+            'ScssPhp\ScssPhp\Formatter\Expanded' => 'expanded',
+            'ScssPhp\ScssPhp\Formatter\Nested' => 'expanded',
+            'ScssPhp\ScssPhp\Formatter\Compact' => 'expanded',
+            'ScssPhp\ScssPhp\Formatter\Compressed' => 'compressed',
+            'ScssPhp\ScssPhp\Formatter\Crunched' => 'compressed',
+        ];
+
+        if (!isset($formatters[$formatter])) {
+            throw new \InvalidArgumentException(sprintf('Invalid scss formatter %s!', $formatter));
+        }
+
+        return $formatters[$formatter];
+    }
+
+    /**
+     * Sets the formatter for scss compilers.
+     *
+     * `scssphp/scssphp` 2.x and `bugo/scss-php` support `expanded` and `compressed`
+     * output styles. Legacy formatter class names from scssphp 1.x are also
+     * accepted and mapped to the closest supported output style.
      *
      * @link https://scssphp.github.io/scssphp/docs/#output-formatting
      *

--- a/src/Task/Assets/Scss.php
+++ b/src/Task/Assets/Scss.php
@@ -21,7 +21,7 @@ use Robo\Result;
  *
  * ```
  * "scssphp/scssphp": "^2.1",
- * "bugo/scss-php": "^0.4"
+ * "bugo/scss-php": "^0.7"
  * ```
  *
  * Specify directory (string or array) for scss imports lookup:

--- a/tests/integration/AssetsTest.php
+++ b/tests/integration/AssetsTest.php
@@ -80,4 +80,67 @@ class AssetsTest extends TestCase
         $this->assertLessThan($initialFileSize, $minifiedFileSize, 'Minified file is smaller than the source file');
         $this->assertGreaterThan(0, $minifiedFileSize, 'Minified file is not empty');
     }
+
+    public function testScssCompilationWithScssPhpCompiler()
+    {
+        if (! class_exists('\ScssPhp\ScssPhp\Compiler')) {
+            $this->markTestSkipped('scssphp/scssphp is not installed.');
+        }
+
+        $this->fixtures->createAndCdToSandbox();
+        mkdir('scss');
+
+        file_put_contents('scss/_variables.scss', '$primary: #fff;');
+        file_put_contents('scss/input.scss', <<<'SCSS'
+@import 'variables';
+
+body {
+  color: $primary;
+}
+SCSS
+        );
+
+        $result = $this->taskScss([
+            'scss/input.scss' => 'output.css',
+        ])
+            ->importDir('scss')
+            ->setFormatter('compressed')
+            ->run();
+
+        $this->assertTrue($result->wasSuccessful(), $result->getMessage());
+        $this->assertFileExists('output.css');
+        $this->assertSame('body{color:#fff}', trim(file_get_contents('output.css')));
+    }
+
+    public function testScssCompilationWithBugoCompiler()
+    {
+        if (! class_exists('\Bugo\SCSS\Compiler')) {
+            $this->markTestSkipped('bugo/scss-php is not installed.');
+        }
+
+        $this->fixtures->createAndCdToSandbox();
+        mkdir('scss');
+
+        file_put_contents('scss/_variables.scss', '$primary: #fff;');
+        file_put_contents('scss/input.scss', <<<'SCSS'
+@import 'variables';
+
+body {
+  color: $primary;
+}
+SCSS
+        );
+
+        $result = $this->taskScss([
+            'scss/input.scss' => 'output.css',
+        ])
+            ->importDir('scss')
+            ->compiler('scss')
+            ->setFormatter('compressed')
+            ->run();
+
+        $this->assertTrue($result->wasSuccessful(), $result->getMessage());
+        $this->assertFileExists('output.css');
+        $this->assertSame('body{color:#fff}', trim(file_get_contents('output.css')));
+    }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes
- [x] Adds or fixes documentation

### Summary
Updated the SCSS task for `scssphp/scssphp` 2.1 and added support for `bugo/scss-php` with backward-compatible formatter handling.

### Description
Added support for `scssphp/scssphp` 2.1 with the updated compiler API, plus a second SCSS backend via `bugo/scss-php`. The SCSS task now supports selecting either compiler, keeps import path handling for both, and preserves backward compatibility for legacy `setFormatter()` values by mapping old formatter class names to modern expanded and compressed output styles.
